### PR TITLE
Make 9.4.4 and 9.3.8 security advisories durable

### DIFF
--- a/docs/release-notes/changelog-bundles/9.3.8.yml
+++ b/docs/release-notes/changelog-bundles/9.3.8.yml
@@ -95,6 +95,12 @@ changelogs:
     area: Infra/Core
     type: upgrade
     issues: []
+    highlight:
+      notable: true
+      title: Security advisory
+      body: |-
+        The 9.3.8 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
+      pr: 152163
   - pr: 152385
     summary: Add defensive protections when parsing `query_string`
     area: Search

--- a/docs/release-notes/changelog-bundles/9.4.4.yml
+++ b/docs/release-notes/changelog-bundles/9.4.4.yml
@@ -150,6 +150,12 @@ changelogs:
     area: Infra/Core
     type: upgrade
     issues: []
+    highlight:
+      notable: true
+      title: Security advisory
+      body: |-
+        The 9.4.4 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
+      pr: 152163
   - pr: 152385
     summary: Add more defensive protections when parsing `query_string`
     area: Search

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1100,8 +1100,10 @@ Vector Search:
 
 ## 9.4.4 [elasticsearch-9.4.4-release-notes]
 
-::::{important}
-The 9.4.4 release contains fixes for potential security vulnerabilities. For details, go to [security announcements](https://discuss.elastic.co/c/announcements/security-announcements/31).
+### Highlights [elasticsearch-9.4.4-highlights]
+
+::::{dropdown} Security advisory
+The 9.4.4 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
 ::::
 
 ### Features and enhancements [elasticsearch-9.4.4-features-enhancements]
@@ -1198,8 +1200,10 @@ Transform:
 
 ## 9.3.8 [elasticsearch-9.3.8-release-notes]
 
-::::{important}
-The 9.3.8 release contains fixes for potential security vulnerabilities. For details, go to [security announcements](https://discuss.elastic.co/c/announcements/security-announcements/31).
+### Highlights [elasticsearch-9.3.8-highlights]
+
+::::{dropdown} Security advisory
+The 9.3.8 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
 ::::
 
 ### Features and enhancements [elasticsearch-9.3.8-features-enhancements]


### PR DESCRIPTION
The 9.4.4 and 9.3.8 security advisories were typed directly into `docs/release-notes/index.md`, which `generateReleaseNotes` rewrites in full from the changelog bundles. Every release regenerated the page and silently dropped them, so they had to be re-added by hand each time (most recently on #158021). This moves both advisories into a `highlight` block on the corresponding changelog entry in `9.4.4.yml` and `9.3.8.yml`, matching how 9.0.6, 9.0.8, 9.1.3 and 9.1.5 already do it. They now render as `::::{dropdown} Security advisory` and are reproduced on every run.