### PR TITLE
Use non-volatile version of feature flag (isOfflineWarmingEnabled)

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingService.java
@@ -938,7 +938,7 @@ public class SharedBlobCacheWarmingService {
                             l1.onResponse(endTargetsToWarm);
                         }
                     }).<Void>andThen((l2, targetsToWarmFinal) -> {
-                        if (searchOfflineWarmingEnabled) {
+                        if (isOfflineWarmingEnabled) {
                             warmBlobOffsets(indexShard, directory, targetsToWarmFinal, l2);
                         } else {
                             l2.onResponse(null);


### PR DESCRIPTION
There was an improper use of a volatile feature flag variable (that may change during the offline warming). It was used instead of a local variable that was created just above - line 897 (and used in other places).

Although probably unlikely to cause issues, we do want to have a consistent behaviour for one offline warming run.