### PR TITLE
[9.5] ESQL: Unmute stats_sample spatial tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -376,12 +376,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:ip.conditional}
   issue: https://github.com/elastic/elasticsearch/issues/155566
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample cartesian_point}
-  issue: https://github.com/elastic/elasticsearch/issues/155625
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample geo_point}
-  issue: https://github.com/elastic/elasticsearch/issues/155626
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/155532


### PR DESCRIPTION
Closes #155625
Closes #155626

8.19 ([#155604](https://github.com/elastic/elasticsearch/pull/155604)) and 9.4 ([#155603](https://github.com/elastic/elasticsearch/pull/155603)) got the `MV_SORT` restriction backport before 9.5 ([#155536](https://github.com/elastic/elasticsearch/pull/155536)), so 9.5 BWC against those versions failed until that last backport landed.

These SAMPLE spatial cases pass again, so they're being unmuted.