### PR TITLE
ESQL: remove stale columnar test masks

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
@@ -146,10 +146,6 @@ public abstract class CrossIndexModeGenerativeRestRunner extends GenerativeRestT
         // search string is not a valid IP literal (e.g. "ring"). Standard mode silently returns
         // no results. Same root cause as "For input string:" for numeric fields.
         "is not an IP string literal",
-        // Columnar mode FORK execution has a known array-bounds bug (Index N out of bounds for
-        // length N) that surfaces as HTTP 500 on the candidate side while the reference succeeds.
-        // TODO: remove once the columnar FORK array-bounds bug is fixed.
-        "out of bounds for length",
         // DateExtract.resolveType incorrectly handles null field types (server-side bug). Produces
         // a 500 error on any shard that encounters a null-typed unmapped field in a date_extract()
         // expression. Affects both modes equally but can surface as partial results on one side

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
@@ -522,18 +522,8 @@ public abstract class CrossIndexModeGenerativeRestRunner extends GenerativeRestT
         if (cmdText.contains("FIRST(") || cmdText.contains("LAST(")) {
             return false;
         }
-        // Commands whose output order or aggregate semantics depend on per-segment or per-shard
-        // execution order, or whose aggregation behaviour differs between standard and columnar mode.
-        // INLINE STATS without BY has a mode-specific COUNT discrepancy on multi-index wildcard
-        // queries (standard returns a different global count than columnar); gated until root-caused.
-        // STATS without BY (global aggregate): when a STATS alias reuses an original field name,
-        // a subsequent EVAL can cause the optimizer to incorrectly re-resolve the alias to the
-        // original field, silently corrupting the aggregated value (returns 0 instead of N). Close
-        // the gate for global STATS to prevent these false positives; gated until root-caused.
-        if ("sample".equals(cmdName)
-            || "fork".equals(cmdName)
-            || "change_point".equals(cmdName)
-            || (("inline_stats".equals(cmdName) || "stats".equals(cmdName)) && cmdText.contains(" BY ") == false)) {
+        // Commands whose output order depends on per-segment or per-shard execution order.
+        if ("sample".equals(cmdName) || "fork".equals(cmdName) || "change_point".equals(cmdName)) {
             return false;
         }
         // DEDUP deduplicates rows by all column values. Columnar mode preserves MV fields in

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
@@ -24,7 +24,6 @@ emp_no:integer | _fork:keyword
 simpleForkWithStats
 required_capability: fork_v9
 required_capability: routing_function_update
-skip_columnar: FORK branch stats differ in columnar mode when MV field ordering affects aggregation order
 
 // tag::simpleForkWithStats[]
 FROM books METADATA _score

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1890,7 +1890,6 @@ c:l
 ;
 
 countMV
-skip_columnar: COUNT of a multi-value numeric field returns the document count (79) instead of the value count (183). Columnar disables point indexing, so SearchContextStats#detectSingleValue mis-detects numeric/date fields as single-valued and PushStatsToSource pushes COUNT down to a Lucene document count. The keyword branch has an indexType().hasTerms() guard for this; the numeric/date branch needs the hasPoints() equivalent.
 FROM employees
 | STATS vals = COUNT(salary_change.int)
 ;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
@@ -19,6 +19,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -615,6 +616,79 @@ public class SearchContextStatsTests extends MapperServiceTestCase {
             );
         } finally {
             IOUtils.close(toClose);
+        }
+    }
+
+    /**
+     * A single-valued numeric field with a point index must be reported as single-valued via the
+     * {@code PointValues.size() == PointValues.getDocCount()} check. Covers the points branch of
+     * {@code detectSingleValue}, as opposed to the doc-values-skipper branch.
+     */
+    public void testPointIndexedSingleValuedNumericIsDetectedAsSingleValued() throws IOException {
+        final MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
+        final MapperService mapperService = mapperHelper.createMapperService("""
+            { "doc": { "properties": { "lng": { "type": "long" } } } }""");
+
+        final Directory dir = newDirectory();
+        final DirectoryReader reader;
+        try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+            writer.addDocument(List.of(new LongField("lng", 1, Field.Store.NO)));
+            writer.addDocument(List.of(new LongField("lng", 2, Field.Store.NO)));
+            writer.forceMerge(1);
+            reader = writer.getReader();
+        }
+
+        try {
+            LeafReader leafReader = reader.leaves().get(0).reader();
+            PointValues points = leafReader.getPointValues("lng");
+            assertNotNull(points);
+            assertEquals(2, points.size());
+            assertEquals(2, points.getDocCount());
+
+            SearchExecutionContext ctx = mapperHelper.createSearchExecutionContext(mapperService, newSearcher(reader));
+            SearchStats stats = SearchContextStats.from(List.of(ctx));
+            assertTrue(
+                "single-valued numeric field with a point index must be reported as single-valued",
+                stats.isSingleValue(new FieldAttribute.FieldName("lng"))
+            );
+        } finally {
+            IOUtils.close(reader, mapperService, dir);
+        }
+    }
+
+    /**
+     * A multi-valued numeric field with a point index must be reported as multi-valued via the
+     * {@code PointValues.size() == PointValues.getDocCount()} check.
+     */
+    public void testPointIndexedMultiValuedNumericIsDetectedAsMultiValued() throws IOException {
+        final MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
+        final MapperService mapperService = mapperHelper.createMapperService("""
+            { "doc": { "properties": { "lng": { "type": "long" } } } }""");
+
+        final Directory dir = newDirectory();
+        final DirectoryReader reader;
+        try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+            writer.addDocument(List.of(new LongField("lng", 1, Field.Store.NO), new LongField("lng", 2, Field.Store.NO)));
+            writer.addDocument(List.of(new LongField("lng", 3, Field.Store.NO)));
+            writer.forceMerge(1);
+            reader = writer.getReader();
+        }
+
+        try {
+            LeafReader leafReader = reader.leaves().get(0).reader();
+            PointValues points = leafReader.getPointValues("lng");
+            assertNotNull(points);
+            assertEquals(3, points.size());
+            assertEquals(2, points.getDocCount());
+
+            SearchExecutionContext ctx = mapperHelper.createSearchExecutionContext(mapperService, newSearcher(reader));
+            SearchStats stats = SearchContextStats.from(List.of(ctx));
+            assertFalse(
+                "multi-valued numeric field must not be reported as single-valued",
+                stats.isSingleValue(new FieldAttribute.FieldName("lng"))
+            );
+        } finally {
+            IOUtils.close(reader, mapperService, dir);
         }
     }
 


### PR DESCRIPTION
`COUNT(field)` returned the **document** count instead of the **value** count for multi-value numeric and date fields when the field has no point index. Columnar mode disables point indexing for these types, so every numeric and date field there looked single-valued and `COUNT` was silently pushed down to a Lucene document count. The fix adds the missing points guard, mirroring one the keyword branch already had.

## Reproduction

Two indices with identical data, one `standard` and one `columnar`, each holding 2 documents with 5 values per field:

| query | expected | standard | columnar (before) | columnar (after) |
|---|---|---|---|---|
| `COUNT(lng)` (long)   | 5 | 5 | **2** | 5 |
| `COUNT(dbl)` (double) | 5 | 5 | **2** | 5 |
| `COUNT(dt)` (date)    | 5 | 5 | **2** | 5 |
| `COUNT(kwd)` (keyword)| 5 | 5 | 5     | 5 |

Keyword was already correct, which is the tell: its branch has the guard, the numeric/date branch did not.

## Root cause

`SearchContextStats#detectSingleValue` proves value cardinality for `NumberFieldType` and `DateFieldType` with:

```java
PointValues values = lr.getPointValues(name);
return values == null || values.size() == values.getDocCount();
```

values == null was read as "single valued". But an absent PointValues carries no cardinality information at all — it only means there is no point index to ask. Columnar mode (index.mapping.index_disabled_by_default) disables point indexing for numeric and date fields, so this returned true for every such field.

PushStatsToSource consumes that answer to decide whether COUNT(field) can be rewritten into an EsStatsQueryExec document count:

```java
if (fa.isPotentiallyUnmapped() == false && context.searchStats().isSingleValue(fName)) {
    fieldName = fName.string();
    query = QueryBuilders.existsQuery(fieldName);
}
```

For a genuinely multi-valued field that rewrite counts documents rather than values, producing the wrong answer.

This also affects standard indices that set "index": false on a numeric or date field, since IndexType.points(false, true) likewise reports hasPoints() == false.