### PR TITLE
PromQL(refactor): rename `PromqlAttributesTranslationContext` to `TranslationContext`

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -145,9 +145,9 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ApplyWindowFilter;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.SubstituteSurrogateExpressions;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesWithout;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslatePromqlToEsqlPlan;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslateTimeSeriesCollapse;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
@@ -1114,18 +1114,12 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 if (node instanceof Selector) {
                     return node.transformExpressionsOnly(UnresolvedAttribute.class, storedScope);
                 }
-                List<Attribute> scope = PromqlAttributesTranslationContext.shadowedResolutionScope(
-                    childrenOutput,
-                    activeDestinations(node)
-                );
+                List<Attribute> scope = TranslationContext.shadowedResolutionScope(childrenOutput, activeDestinations(node));
                 return node.transformExpressionsOnly(UnresolvedAttribute.class, ua -> ResolveRefs.maybeResolveAttribute(ua, scope, log));
             });
 
             // The command's own output contract sees the full derived label set: every destination, same nearest-wins collapse.
-            List<Attribute> outputScope = PromqlAttributesTranslationContext.shadowedResolutionScope(
-                childrenOutput,
-                collapseByName(relabels)
-            );
+            List<Attribute> outputScope = TranslationContext.shadowedResolutionScope(childrenOutput, collapseByName(relabels));
             return promql.withPromqlPlan(resolvedPlan)
                 .transformExpressionsOnly(UnresolvedAttribute.class, ua -> ResolveRefs.maybeResolveAttribute(ua, outputScope, log));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -63,9 +63,9 @@ import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionReg
 import org.elasticsearch.xpack.esql.expression.promql.function.RegexExpand;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TemporaryNameGenerator;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesAggregate;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.Header;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.NamedColumn;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.TimeSeriesColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.Header;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.NamedColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.TimeSeriesColumn;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlLogicalPlanBuilder;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
@@ -115,11 +115,11 @@ import java.util.Set;
 import static org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction.withFilter;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.combineAnd;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.combineAndNullable;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.findById;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.findByIdOrName;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.findByName;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.resolveColumn;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.toCanonicalName;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.findById;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.findByIdOrName;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.findByName;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.resolveColumn;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.toCanonicalName;
 import static org.elasticsearch.xpack.esql.plan.logical.promql.AcrossSeriesAggregate.Grouping.WITHOUT;
 
 /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContext.java
@@ -23,9 +23,9 @@ import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlLabels.PROM
 /**
  * The required and actual header of a PromQL translation attempt.
  */
-public final class PromqlAttributesTranslationContext {
+public final class TranslationContext {
 
-    private PromqlAttributesTranslationContext() {}
+    private TranslationContext() {}
 
     /**
      * A column exposed by a translated subtree. A column carries the expression currently denoting it; whether that
@@ -204,7 +204,7 @@ public final class PromqlAttributesTranslationContext {
             List<Attribute> removed = distinctByCanonicalName(labels);
             TimeSeriesColumn timeSeries = groupByTimeSeries();
             if (timeSeries != null) {
-                TimeSeriesColumn desired = TimeSeriesColumn.of(PromqlAttributesTranslationContext.union(timeSeries.exclusions(), removed));
+                TimeSeriesColumn desired = TimeSeriesColumn.of(TranslationContext.union(timeSeries.exclusions(), removed));
                 TimeSeriesColumn exposed = timeSeries(desired.exclusions());
                 desired = exposed == null ? desired : exposed;
                 return new Header(List.of(desired), List.of(desired));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContextTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContextTests.java
@@ -13,10 +13,10 @@ import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.Column;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.Header;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.NamedColumn;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.TimeSeriesColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.Column;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.Header;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.NamedColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.TimeSeriesColumn;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class PromqlAttributesTranslationContextTests extends ESTestCase {
+public class TranslationContextTests extends ESTestCase {
 
     private static final Attribute CLUSTER = attr("cluster");
     private static final Attribute POD = attr("pod");
@@ -113,7 +113,7 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
 
         assertThat(
             outer.transformExpressions(
-                (column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(regionIdentity, podRegionIdentity))
+                (column, grouping) -> TranslationContext.resolveColumn(column, List.of(regionIdentity, podRegionIdentity))
             ).groupingExpressions().stream().map(expression -> expression.toAttribute()).toList(),
             equalTo(List.of(podRegionIdentity))
         );
@@ -122,9 +122,7 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
     public void testByKeepsConcreteKeysAndReportsMissingLabels() {
         Header by = concreteHeader(CLUSTER).groupedBy(List.of(CLUSTER, REGION));
 
-        Header bound = by.transformExpressions(
-            (column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(CLUSTER))
-        );
+        Header bound = by.transformExpressions((column, grouping) -> TranslationContext.resolveColumn(column, List.of(CLUSTER)));
         assertThat(
             bound.groupingExpressions().stream().map(expression -> expression.toAttribute()).toList(),
             equalTo(List.of(CLUSTER, REGION))
@@ -137,9 +135,8 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
 
         assertThat(by.labels(), hasSize(1));
         assertThat(
-            by.transformExpressions(
-                (column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(CLUSTER, duplicate))
-            ).groupingExpressions(),
+            by.transformExpressions((column, grouping) -> TranslationContext.resolveColumn(column, List.of(CLUSTER, duplicate)))
+                .groupingExpressions(),
             hasSize(1)
         );
     }
@@ -169,7 +166,7 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
         Header bound = new Header(
             List.of(new TimeSeriesColumn(identity, List.of(REGION))),
             List.of(new TimeSeriesColumn(identity, List.of(REGION)), new NamedColumn(CLUSTER))
-        ).transformExpressions((column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(identity, CLUSTER)));
+        ).transformExpressions((column, grouping) -> TranslationContext.resolveColumn(column, List.of(identity, CLUSTER)));
         int[] resolvedKinds = new int[2];
 
         bound.transformExpressions((column, grouping) -> switch (column) {


### PR DESCRIPTION
## What

A pure rename of `PromqlAttributesTranslationContext` to `TranslationContext`, with its test. The class is the translation's shared context - the label header the translator pushes down and lifts up, and the name mapping between PromQL labels and ES|QL attributes - not a bag of attribute helpers. The PRs stacked on top build the header model on it under that name. No behavior change.

Bottom of the stack: base of #158492 (fuse fix), then #158430 (context refactor), then #155634 (vector matching).
