### PR TITLE
PromQL(bugfix): preserve original grouping names when fusing operands

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-passthrough-binary-operators.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-passthrough-binary-operators.csv-spec
@@ -1,0 +1,37 @@
+// PromQL binary operators over a labels.* passthrough index (prom-metrics-name).
+//
+// Two aggregates with the same grouping keys fuse into one aggregate over a shared frame. Under a passthrough mapping the
+// analyzer binds the declared output label (`pod`) to the bare attribute while the plan carries the concrete field
+// (`labels.pod`), so the command projection must find the grouping column by its canonical name. The fuse used to rename
+// grouping columns along with the value aggregates, which broke that lookup with "missing references [pod]".
+
+// sum by (K) / sum by (K) over a passthrough label: the grouping column keeps its name through the fused aggregate.
+fused_binary_op_keeps_passthrough_grouping_label
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: fix_ts_block_loader_passthrough_aliasing
+required_capability: fix_promql_fused_binary_op_labels
+PROMQL index=prom-metrics-name step=1h result=(sum by (pod) (metrics.requests{pod=~"pod[AB]"}) / sum by (pod) (metrics.requests{pod=~"pod[AB]"}))
+| KEEP result, pod
+| SORT pod;
+
+result:double | pod:keyword
+1.0           | podA
+1.0           | podB
+;
+
+
+// Two grouping keys, arithmetic on the fused frame: both passthrough labels survive as output columns.
+fused_binary_op_keeps_two_passthrough_grouping_labels
+required_capability: promql_command_v0
+required_capability: fix_promql_time_bucket_v2
+required_capability: fix_ts_block_loader_passthrough_aliasing
+required_capability: fix_promql_fused_binary_op_labels
+PROMQL index=prom-metrics-name step=1h result=(sum by (pod, zone) (metrics.requests{pod=~"pod[AB]"}) - sum by (pod, zone) (metrics.requests{pod=~"pod[AB]"}) / 2)
+| KEEP result, pod, zone
+| SORT pod;
+
+result:double | pod:keyword | zone:keyword
+5.0           | podA        | eu
+10.0          | podB        | us
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3586,6 +3586,14 @@ public class EsqlCapabilities {
         FIX_PROMQL_QUANTILE_SCALE,
 
         /**
+         * PromQL binary operators between aggregates with the same grouping keys fuse into one aggregate. The fuse renamed
+         * the grouping columns along with the value aggregates, so over a {@code labels.*} passthrough index the command
+         * projection could no longer find the declared label by its canonical name and the plan failed verification with
+         * "missing references". Grouping columns now keep their names through the fuse.
+         */
+        FIX_PROMQL_FUSED_BINARY_OP_LABELS,
+
+        /**
          * Bugfix in query approximation to not rewrite non-approximable FORK branches:
          * <a href="https://github.com/elastic/elasticsearch/issues/149501">#149501</a>
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -145,9 +145,9 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ApplyWindowFilter;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.SubstituteSurrogateExpressions;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesWithout;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslatePromqlToEsqlPlan;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslateTimeSeriesCollapse;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
@@ -1114,18 +1114,12 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 if (node instanceof Selector) {
                     return node.transformExpressionsOnly(UnresolvedAttribute.class, storedScope);
                 }
-                List<Attribute> scope = PromqlAttributesTranslationContext.shadowedResolutionScope(
-                    childrenOutput,
-                    activeDestinations(node)
-                );
+                List<Attribute> scope = TranslationContext.shadowedResolutionScope(childrenOutput, activeDestinations(node));
                 return node.transformExpressionsOnly(UnresolvedAttribute.class, ua -> ResolveRefs.maybeResolveAttribute(ua, scope, log));
             });
 
             // The command's own output contract sees the full derived label set: every destination, same nearest-wins collapse.
-            List<Attribute> outputScope = PromqlAttributesTranslationContext.shadowedResolutionScope(
-                childrenOutput,
-                collapseByName(relabels)
-            );
+            List<Attribute> outputScope = TranslationContext.shadowedResolutionScope(childrenOutput, collapseByName(relabels));
             return promql.withPromqlPlan(resolvedPlan)
                 .transformExpressionsOnly(UnresolvedAttribute.class, ua -> ResolveRefs.maybeResolveAttribute(ua, outputScope, log));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -783,12 +783,14 @@ public final class TranslatePromqlToEsqlPlan extends AnalyzerRules.Parameterized
                 uniqueAggregates.addAll(withFilter(leftAgg.aggregates(), left.pendingFilter()));
                 uniqueAggregates.addAll(withFilter(rightAgg.aggregates(), right.pendingFilter()));
 
+                // Only the aggregate functions need fresh names: both operands define `value`. Grouping columns keep their
+                // own names - the command projection finds a passthrough label (`labels.pod`) by its canonical name when the
+                // analyzer bound the declared output to the bare attribute instead, and a renamed column would not map.
                 var newAggregates = uniqueAggregates.stream().map(e -> (NamedExpression) e).map(e -> {
-                    Expression inner = e;
                     if (e instanceof Alias a) {
-                        inner = a.child();
+                        return (NamedExpression) new Alias(a.source(), names.next(a.name()), a.child(), a.id());
                     }
-                    return new Alias(e.source(), names.next(e.name()), inner, e.id());
+                    return e;
                 }).toList();
 
                 return leftAgg.with(leftAgg.child(), leftAgg.groupings(), newAggregates);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -63,9 +63,9 @@ import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionReg
 import org.elasticsearch.xpack.esql.expression.promql.function.RegexExpand;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TemporaryNameGenerator;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesAggregate;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.Header;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.NamedColumn;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.TimeSeriesColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.Header;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.NamedColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.TimeSeriesColumn;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlLogicalPlanBuilder;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
@@ -115,11 +115,11 @@ import java.util.Set;
 import static org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction.withFilter;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.combineAnd;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.combineAndNullable;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.findById;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.findByIdOrName;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.findByName;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.resolveColumn;
-import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.toCanonicalName;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.findById;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.findByIdOrName;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.findByName;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.resolveColumn;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.toCanonicalName;
 import static org.elasticsearch.xpack.esql.plan.logical.promql.AcrossSeriesAggregate.Grouping.WITHOUT;
 
 /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContext.java
@@ -23,9 +23,9 @@ import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlLabels.PROM
 /**
  * The required and actual header of a PromQL translation attempt.
  */
-public final class PromqlAttributesTranslationContext {
+public final class TranslationContext {
 
-    private PromqlAttributesTranslationContext() {}
+    private TranslationContext() {}
 
     /**
      * A column exposed by a translated subtree. A column carries the expression currently denoting it; whether that
@@ -204,7 +204,7 @@ public final class PromqlAttributesTranslationContext {
             List<Attribute> removed = distinctByCanonicalName(labels);
             TimeSeriesColumn timeSeries = groupByTimeSeries();
             if (timeSeries != null) {
-                TimeSeriesColumn desired = TimeSeriesColumn.of(PromqlAttributesTranslationContext.union(timeSeries.exclusions(), removed));
+                TimeSeriesColumn desired = TimeSeriesColumn.of(TranslationContext.union(timeSeries.exclusions(), removed));
                 TimeSeriesColumn exposed = timeSeries(desired.exclusions());
                 desired = exposed == null ? desired : exposed;
                 return new Header(List.of(desired), List.of(desired));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContextTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslationContextTests.java
@@ -13,10 +13,10 @@ import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.Column;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.Header;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.NamedColumn;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.PromqlAttributesTranslationContext.TimeSeriesColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.Column;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.Header;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.NamedColumn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslationContext.TimeSeriesColumn;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class PromqlAttributesTranslationContextTests extends ESTestCase {
+public class TranslationContextTests extends ESTestCase {
 
     private static final Attribute CLUSTER = attr("cluster");
     private static final Attribute POD = attr("pod");
@@ -113,7 +113,7 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
 
         assertThat(
             outer.transformExpressions(
-                (column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(regionIdentity, podRegionIdentity))
+                (column, grouping) -> TranslationContext.resolveColumn(column, List.of(regionIdentity, podRegionIdentity))
             ).groupingExpressions().stream().map(expression -> expression.toAttribute()).toList(),
             equalTo(List.of(podRegionIdentity))
         );
@@ -122,9 +122,7 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
     public void testByKeepsConcreteKeysAndReportsMissingLabels() {
         Header by = concreteHeader(CLUSTER).groupedBy(List.of(CLUSTER, REGION));
 
-        Header bound = by.transformExpressions(
-            (column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(CLUSTER))
-        );
+        Header bound = by.transformExpressions((column, grouping) -> TranslationContext.resolveColumn(column, List.of(CLUSTER)));
         assertThat(
             bound.groupingExpressions().stream().map(expression -> expression.toAttribute()).toList(),
             equalTo(List.of(CLUSTER, REGION))
@@ -137,9 +135,8 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
 
         assertThat(by.labels(), hasSize(1));
         assertThat(
-            by.transformExpressions(
-                (column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(CLUSTER, duplicate))
-            ).groupingExpressions(),
+            by.transformExpressions((column, grouping) -> TranslationContext.resolveColumn(column, List.of(CLUSTER, duplicate)))
+                .groupingExpressions(),
             hasSize(1)
         );
     }
@@ -169,7 +166,7 @@ public class PromqlAttributesTranslationContextTests extends ESTestCase {
         Header bound = new Header(
             List.of(new TimeSeriesColumn(identity, List.of(REGION))),
             List.of(new TimeSeriesColumn(identity, List.of(REGION)), new NamedColumn(CLUSTER))
-        ).transformExpressions((column, grouping) -> PromqlAttributesTranslationContext.resolveColumn(column, List.of(identity, CLUSTER)));
+        ).transformExpressions((column, grouping) -> TranslationContext.resolveColumn(column, List.of(identity, CLUSTER)));
         int[] resolvedKinds = new int[2];
 
         bound.transformExpressions((column, grouping) -> switch (column) {


### PR DESCRIPTION
## What

Two aggregates with the same grouping keys (`sum by (k) (a) / sum by (k) (b)`) fuse into one aggregate over a shared frame. The fuse renamed the grouping columns along with the value aggregates, so over a `labels.*` passthrough index the command projection could not find the declared label by its canonical name and the plan failed verification: `Plan [Project[[value, step, pod]]] optimized incorrectly due to missing references [pod]` - 92 queries of the Grafana compliance suite (promcheck) on #158430. Flat-dimension indices do not show it because there both sides share one attribute id.

## Fix

- Rename only the value aggregates, since both operands define `value`; grouping columns pass through under their own names.
- Gated by `FIX_PROMQL_FUSED_BINARY_OP_LABELS`.
- `promql-passthrough-binary-operators.csv-spec`: two tests over the `prom-metrics-name` passthrough fixture, red before the fix with the same signature and green after; the full promql csv suite is 538/538.

Stacked on #158491 (the rename); base of #158430, which resolves label carriers by name in the plan and would otherwise expose the fuse to this, and of #155634 above it. Replaces #158484, which GitHub auto-closed as merged when its base branch was rebased to contain it.
