### PR TITLE
Allow .ai-index-* in dot-prefix validation

### DIFF
--- a/docs/changelog/158497.yaml
+++ b/docs/changelog/158497.yaml
@@ -1,0 +1,5 @@
+area: Indices APIs
+issues: []
+pr: 158497
+summary: Allow .ai-index-* in dot-prefix validation
+type: enhancement

--- a/modules/dot-prefix-validation/src/main/java/org/elasticsearch/validation/DotPrefixValidator.java
+++ b/modules/dot-prefix-validation/src/main/java/org/elasticsearch/validation/DotPrefixValidator.java
@@ -82,6 +82,8 @@ public abstract class DotPrefixValidator<RequestType> implements MappedActionFil
             "\\.evaluation-.*",
             // Security index:
             "\\.entities\\.v\\d+\\..*",
+            // AI indices (Context Engine):
+            "\\.ai-index-.*",
             // indices or data streams defined in files in x-pack/plugin/core/template-resources/src/main/resources/monitoring-*:
             "\\.monitoring-es-8-.*",
             "\\.monitoring-logstash-8-.*",

--- a/modules/dot-prefix-validation/src/test/java/org/elasticsearch/validation/DotPrefixValidatorTests.java
+++ b/modules/dot-prefix-validation/src/test/java/org/elasticsearch/validation/DotPrefixValidatorTests.java
@@ -128,6 +128,12 @@ public class DotPrefixValidatorTests extends ESTestCase {
         assertIgnored(Set.of(".entities.v1.latest.noop"));
         assertIgnored(Set.of(".entities.v92.latest.eggplant.potato"));
         assertIgnored(Set.of("<.entities.v12.latest.eggplant-{M{yyyy-MM-dd|UTC}}>"));
+        assertIgnored(Set.of(".ai-index-idx-puggles"));
+        assertIgnored(Set.of(".ai-index-ds-puggles"));
+        assertIgnored(Set.of(".ai-index-puggles.pugs-000001"));
+        assertIgnored(Set.of("<.ai-index-foo-{M{yyyy-MM-dd|UTC}}>"));
+        assertFails(Set.of(".ai-index"));
+        assertFails(Set.of(".ai-indexes"));
         assertIgnored(Set.of(".monitoring-es-8-thing"));
         assertIgnored(Set.of("<.monitoring-es-8-thing>"));
         assertIgnored(Set.of(".monitoring-logstash-8-thing"));


### PR DESCRIPTION
Adds the `.ai-index-` prefix to the default ignored dot-prefix patterns so that internally managed AI indices (Context Engine) can be created in Serverless.