### PR TITLE
Update implicit privilege provider to use dot-prefixed SML index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -769,7 +769,7 @@ class KibanaOwnedReservedRoleDescriptors {
                 // Context Engine's SML storage. A regular (non-system) index that Kibana
                 // creates and manages itself at startup, including its alias.
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("ai-index-idx-sml-data", "ai-index-idx-sml-data-*")
+                    .indices(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-*")
                     .privileges("all")
                     .build(),
                 // Context Engine feedback-loop signals. Per-space, regular (non-system)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1280,7 +1280,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         // Context Engine's SML storage: a regular (non-system) index that Kibana
         // creates and manages itself, including its alias.
-        Arrays.asList("ai-index-idx-sml-data", "ai-index-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
+        Arrays.asList(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
             .forEach(index -> assertReadWriteAndManage(kibanaRole, index));
 
         // Context Engine feedback-loop signals: per-space, regular (non-system)

--- a/x-pack/plugin/kibana/src/javaRestTest/java/org/elasticsearch/xpack/kibana/ElasticAiIndexImplicitPrivilegesIT.java
+++ b/x-pack/plugin/kibana/src/javaRestTest/java/org/elasticsearch/xpack/kibana/ElasticAiIndexImplicitPrivilegesIT.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -38,7 +39,7 @@ import static org.hamcrest.Matchers.not;
  * <p>
  * The happy path verifies that a role holding {@code ai_index:<kiType>/read} Kibana application privileges,
  * granted in different spaces (with no explicit index privileges), can read the Elastic AI Index
- * {@code ai-index-idx-sml-data}, and that the implicit document-level-security filter restricts results
+ * {@code .ai-index-idx-sml-data}, and that the implicit document-level-security filter restricts results
  * to the following rule: a document is visible only when the user holds <em>all</em> the
  * actions it requires <em>within a single space</em>. Actions accumulated across different spaces
  * must not grant access, and a document scoped to every space via {@code "*"} must still be visible
@@ -61,10 +62,10 @@ public class ElasticAiIndexImplicitPrivilegesIT extends ESRestTestCase {
     private static final String ELASTIC_AI_INDEX_WORKFLOW_READ_ACTION = "ai_index:workflow/read";
     // Registered alongside the ai_index: action to prove non-ai_index: actions are filtered out of the DLS query.
     private static final String SAVED_OBJECT_GET_ACTION = "saved_object:dashboard/get";
-    private static final String ELASTIC_AI_INDEX = "ai-index-idx-sml-data";
+    private static final String ELASTIC_AI_INDEX = ".ai-index-idx-sml-data";
 
     // The SML storage adapter creates a CONCRETE index "<name>-000001" and fronts it with an ALIAS
-    // named exactly ELASTIC_AI_INDEX. So "ai-index-idx-sml-data" is never a concrete index in production.
+    // named exactly ELASTIC_AI_INDEX. So ".ai-index-idx-sml-data" is never a concrete index in production.
     private static final String ELASTIC_AI_INDEX_BACKING = ELASTIC_AI_INDEX + "-000001";
 
     // Shared between the _search and ES|QL assertions: both engines must resolve each role's DLS
@@ -164,6 +165,8 @@ public class ElasticAiIndexImplicitPrivilegesIT extends ESRestTestCase {
         create.setJsonEntity(Strings.format("""
             { "aliases": { "%s": { "is_write_index": true } } }
             """, ELASTIC_AI_INDEX));
+        // Creating a dot-prefixed index emits a deprecation warning that is irrelevant to this test.
+        create.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
         assertOK(client().performRequest(create));
         indexDoc("marketing-dashboard", """
             {
@@ -304,6 +307,8 @@ public class ElasticAiIndexImplicitPrivilegesIT extends ESRestTestCase {
               }
             }
             """, ELASTIC_AI_INDEX));
+        // Creating a dot-prefixed index emits a deprecation warning that is irrelevant to this test.
+        create.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
         assertOK(client().performRequest(create));
 
         // Documents deliberately carry no title/description/content: the template maps a semantic_text
@@ -480,7 +485,7 @@ public class ElasticAiIndexImplicitPrivilegesIT extends ESRestTestCase {
 
         final List<Map<String, Object>> implicitEntries = indices.stream()
             .filter(entry -> Boolean.TRUE.equals(entry.get("implicitly_granted")))
-            .filter(entry -> ((List<String>) entry.get("names")).stream().anyMatch(n -> n.startsWith("ai-index-")))
+            .filter(entry -> ((List<String>) entry.get("names")).stream().anyMatch(n -> n.startsWith(".ai-index-")))
             .toList();
         assertThat("expected exactly one implicit Elastic AI Index grant, got " + indices, implicitEntries, hasSize(1));
 

--- a/x-pack/plugin/kibana/src/main/java/org/elasticsearch/xpack/kibana/ElasticAiIndexImplicitPrivilegesProvider.java
+++ b/x-pack/plugin/kibana/src/main/java/org/elasticsearch/xpack/kibana/ElasticAiIndexImplicitPrivilegesProvider.java
@@ -31,7 +31,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
- * Implicitly grants read access to the Elastic AI Index ({@code ai-index-idx-sml-data}) for
+ * Implicitly grants read access to the Elastic AI Index ({@code .ai-index-idx-sml-data}) for
  * users whose roles include a Kibana application privilege grant carrying at least one
  * {@code ai_index:} action.
  * <p>
@@ -52,7 +52,7 @@ public class ElasticAiIndexImplicitPrivilegesProvider implements ImplicitPrivile
 
     static final String KIBANA_APPLICATION = "kibana-.kibana";
     // Index pattern mirrors the Kibana-side definition; keep in sync if it changes.
-    static final String ELASTIC_AI_INDEX = "ai-index-idx-sml-data";
+    static final String ELASTIC_AI_INDEX = ".ai-index-idx-sml-data";
     static final String RESOURCE_PREFIX = "space:";
     // Action namespace owned by Elastic AI Index; mirrors the Kibana-side AiIndexActions definition, keep in sync if it changes.
     static final String AI_INDEX_ACTION_PREFIX = "ai_index:";


### PR DESCRIPTION
Followup to https://github.com/elastic/elasticsearch/pull/156990

The Elastic AI index will now be dot-prefixed, this PR renames it accordingly. 