### PR TITLE
Unmute IndexPropertiesTests.testDeserializationFromPreShardCountsVersionDefaultsToZero

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -752,9 +752,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
   method: testFetchTooManyBigFields
   issue: https://github.com/elastic/elasticsearch/issues/158349
-- class: org.elasticsearch.xpack.esql.index.IndexPropertiesTests
-  method: testDeserializationFromPreShardCountsVersionDefaultsToZero
-  issue: https://github.com/elastic/elasticsearch/issues/158380
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681


### PR DESCRIPTION
Root-cause fix already landed in #158323: `testDeserializationFromPreShardCountsVersionDefaultsToZero` now filters out `IndexMode` values that cannot be serialized at the pre-`SHARD_COUNTS` transport version, so `vectordb_columnar` is skipped instead of causing an `IllegalStateException`.

Closes #158380