### PR TITLE
ESQL:DS: Avoid federated scans on index nodes

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AbstractExternalDistributedIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/AbstractExternalDistributedIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.qa.multi_node;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.esql.AssertWarnings;
@@ -22,12 +23,15 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.ACCESS_KEY;
 import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.BUCKET;
 import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.SECRET_KEY;
+import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.WAREHOUSE;
+import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.addBlobToFixture;
 
 /**
  * Base class for external source distributed integration tests that use the in-memory
@@ -43,12 +47,19 @@ public abstract class AbstractExternalDistributedIT extends ESRestTestCase {
 
     protected static final List<String> DISTRIBUTION_MODES = List.of("coordinator_only", "round_robin", "adaptive");
 
+    /** Warehouse prefix used by the in-memory S3 fixture. */
+    protected static final String S3_WAREHOUSE = WAREHOUSE;
+
     /** The single {@code s3} data source every dataset binds to; registered lazily on first {@link #fromS3}. */
     private static final String S3_DATA_SOURCE = "distributed_s3_ds";
 
     public static DataSourcesS3HttpFixture s3Fixture = new DataSourcesS3HttpFixture();
 
     private static ElasticsearchCluster clusterInstance = ExternalDistributedClusters.testCluster(() -> s3Fixture.getAddress());
+
+    protected static ElasticsearchCluster cluster() {
+        return clusterInstance;
+    }
 
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule((base, description) -> new org.junit.runners.model.Statement() {
@@ -119,5 +130,13 @@ public abstract class AbstractExternalDistributedIT extends ESRestTestCase {
             .build();
         var request = new RestEsqlTestCase.RequestObjectBuilder().query(query).pragmasOk().pragmas(pragmas);
         return RestEsqlTestCase.runEsqlSync(request, new AssertWarnings.NoWarnings(), null);
+    }
+
+    /**
+     * Puts a CSV object into the in-memory S3 fixture so a {@link #fromS3} glob can discover it.
+     */
+    @SuppressForbidden(reason = "writes directly to the in-memory S3 fixture blob map")
+    protected void addS3Csv(String key, String csv) {
+        addBlobToFixture(s3Fixture.getHandler(), key, csv.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
@@ -21,7 +21,9 @@ import java.util.List;
  * <p>
  * Distributes when the plan contains pipeline breakers (aggregations, TopN)
  * and there are multiple splits, or when the split count exceeds the number
- * of eligible nodes. Stays on the coordinator for single splits or LIMIT-only plans.
+ * of eligible remote workers. Stays on the coordinator for single splits or LIMIT-only plans.
+ * An empty eligible-worker set -- including an index-only cluster -- returns {@code LOCAL}
+ * so the coordinator runs the scan itself.
  */
 public final class AdaptiveStrategy implements ExternalDistributionStrategy {
 
@@ -35,7 +37,7 @@ public final class AdaptiveStrategy implements ExternalDistributionStrategy {
     }
 
     public AdaptiveStrategy() {
-        this(NodeEligibilityStrategy.DATA_NODES_ONLY);
+        this(NodeEligibilityStrategy.EXTERNAL_WORKER_NODES);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -13,6 +13,9 @@ import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.RemoteException;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.BigArrays;
@@ -378,27 +381,35 @@ public class ComputeService {
         // in which case there is no pool size to cap against and the pragma value stands on its own.
         ThreadPool.Info computePoolInfo = threadPool.info(EsqlPlugin.computePool());
         int effectiveConcurrency = computePoolInfo == null ? taskConcurrency : Math.min(taskConcurrency, computePoolInfo.getMax());
-        int eligibleNodes = Math.max(1, NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(clusterService.state().nodes()).size());
-        return externalCoalesceFloor(effectiveConcurrency, eligibleNodes);
+        return externalCoalesceFloor(effectiveConcurrency, clusterService.state().nodes());
     }
 
     /**
      * The minimum number of coalesced groups to keep for an external scan, so read parallelism is not collapsed
      * to a single unit. It is the per-node driver cap ({@code task_concurrency}) times the number of eligible
-     * data nodes: after distribution each node receives about {@code task_concurrency} groups and runs that many
-     * scan drivers. {@link SplitCoalescer} clamps the result to the input split count. The value is held at or
-     * above one (a degenerate {@code task_concurrency} of zero or below still leaves the scan coalescible) and at
-     * or below {@link Integer#MAX_VALUE} on an implausibly wide cluster.
+     * remote workers: after distribution each worker receives about {@code task_concurrency} groups and runs that
+     * many scan drivers. Index nodes contribute no remote external-scan capacity, so they are omitted. On an
+     * index-only cluster the eligible-worker count is zero and is normalised to one, which holds the floor at
+     * {@code task_concurrency}: the scan is about to run on the coordinator alone, and that one node still fills
+     * {@code task_concurrency} scan drivers. Normalising the product instead would drop the floor to one and leave
+     * the coordinator with fewer groups than it has drivers. {@link SplitCoalescer} clamps the result to the input
+     * split count. The value is held at or above one (a degenerate {@code task_concurrency} of zero or below still
+     * leaves the scan coalescible) and at or below {@link Integer#MAX_VALUE} on an implausibly wide cluster.
      *
-     * <p>Deliberately counts the whole cluster even for a scan that ends up staying local: coalescing runs before
-     * the distribution decision, and the group count is itself an input to that decision
-     * ({@code AdaptiveStrategy} weighs splits against nodes). A local scan therefore gets more groups than its one
-     * node can occupy. That overshoot is harmless — the groups become slices in a shared queue and the driver count
-     * is still capped at {@code min(groupCount, task_concurrency)} — whereas undershooting would leave a
-     * distributable scan unable to fill the cluster.
+     * <p>Deliberately counts the whole eligible cluster even for a scan that ends up staying local: coalescing
+     * runs before the distribution decision, and the group count is itself an input to that decision
+     * ({@code AdaptiveStrategy} weighs splits against nodes). When eligible remote workers exist, a local scan
+     * therefore gets more groups than its one node can occupy. That overshoot is harmless — the groups become slices
+     * in a shared queue and the driver count is still capped at {@code min(groupCount, task_concurrency)} — whereas
+     * undershooting would leave a distributable scan unable to fill the cluster.
      */
+    static int externalCoalesceFloor(int taskConcurrency, DiscoveryNodes availableNodes) {
+        int eligibleNodeCount = NodeEligibilityStrategy.EXTERNAL_WORKER_NODES.eligibleNodes(availableNodes).size();
+        return externalCoalesceFloor(taskConcurrency, eligibleNodeCount);
+    }
+
     static int externalCoalesceFloor(int taskConcurrency, int eligibleNodeCount) {
-        long floor = (long) taskConcurrency * eligibleNodeCount;
+        long floor = (long) taskConcurrency * Math.max(1, eligibleNodeCount);
         return (int) Math.max(1, Math.min(floor, Integer.MAX_VALUE));
     }
 
@@ -457,6 +468,20 @@ public class ComputeService {
             return new ExternalDistributionResult(resolvedPlan, distributionPlan, List.of());
         }
 
+        return localExternalScanResult(resolvedPlan, externalSplits, clusterService.localNode().getId());
+    }
+
+    /**
+     * Coordinator-local placement after a strategy returned {@code LOCAL}. A gather-boundary plan
+     * with more than one split is self-assigned on the coordinator so the exchange stays in place;
+     * everything else is collapsed onto local drivers. The coordinator is not added to the worker
+     * list to reach this path -- {@code LOCAL} already means "run here".
+     */
+    static ExternalDistributionResult localExternalScanResult(
+        PhysicalPlan resolvedPlan,
+        List<ExternalSplit> externalSplits,
+        String localNodeId
+    ) {
         // Staying local but a gather is required: preserve the exchange and run the partial-aggregation stage on the local
         // (coordinator) node via the same path the distributed modes use, so the parallel per-group drivers are gathered into a
         // single final aggregation. Collapsing here instead would drop the gather boundary and emit one row per split group.
@@ -466,14 +491,54 @@ public class ComputeService {
         if (externalSplits.size() > 1
             && ExternalDistributionStrategy.needsGatherBoundary(resolvedPlan)
             && hasCollapsibleExternalExchange(resolvedPlan)) {
-            ExternalDistributionPlan localNodePlan = new ExternalDistributionPlan(
-                Map.of(clusterService.localNode().getId(), externalSplits),
-                true
-            );
+            ExternalDistributionPlan localNodePlan = new ExternalDistributionPlan(Map.of(localNodeId, externalSplits), true);
             return new ExternalDistributionResult(resolvedPlan, localNodePlan, List.of());
         }
 
         return new ExternalDistributionResult(collapseExternalSourceExchanges(resolvedPlan), null, externalSplits);
+    }
+
+    static boolean hasNonEmptyExternalSplits(ExternalDistributionResult result) {
+        return result.coordinatorSplits().isEmpty() == false || result.distributionPlan() != null;
+    }
+
+    /**
+     * Whether a non-empty external scan reads on the coordinator rather than on remote workers. Both
+     * coordinator-local shapes count: splits collapsed onto local drivers, and the gather-boundary
+     * self-assignment that keeps the exchange in place but still reads here.
+     */
+    static boolean runsExternalScanLocally(ExternalDistributionResult result, String localNodeId) {
+        if (result.coordinatorSplits().isEmpty() == false) {
+            return true;
+        }
+        ExternalDistributionPlan plan = result.distributionPlan();
+        return plan != null && plan.nodeAssignments().keySet().equals(Set.of(localNodeId));
+    }
+
+    /**
+     * Logs at most once per top-level request when an index node reads an external scan itself. An index node
+     * that coordinates and hands the scan to eligible workers is the normal split-role path and is not logged;
+     * this fires whenever the selected placement keeps the read on the coordinator, including an explicit or
+     * adaptive local placement and the fallback when no worker is eligible. Such execution is allowed -- this is
+     * visibility for a transition-state routing choice, not a placement violation.
+     */
+    static void warnIndexCoordinatorOnce(DiscoveryNode localNode, AtomicBoolean alreadyWarned) {
+        if (localNode.hasRole(DiscoveryNodeRole.INDEX_ROLE.roleName()) && alreadyWarned.compareAndSet(false, true)) {
+            LOGGER.warn(
+                "index node [{}] is running an external ES|QL scan locally; this is expected only as a transition state",
+                localNode.getId()
+            );
+        }
+    }
+
+    static Runnable newIndexCoordinatorWarningCallback(DiscoveryNode localNode) {
+        // Only an index node can ever warn, and the role set is fixed for the lifetime of the node. Skipping the
+        // per-request state for every other node keeps the callback off the allocation path of the common query.
+        if (localNode.hasRole(DiscoveryNodeRole.INDEX_ROLE.roleName()) == false) {
+            return () -> {};
+        }
+        AtomicBoolean alreadyWarned = new AtomicBoolean();
+        return () -> warnIndexCoordinatorOnce(localNode, alreadyWarned);
     }
 
     /** Bundles the (possibly rewritten) plan produced by split discovery with the splits collected from it. */
@@ -922,6 +987,8 @@ public class ComputeService {
             initialClusterStatuses.put(entry.getKey(), entry.getValue().getStatus());
         }
 
+        Runnable warnIndexCoordinatorOnce = newIndexCoordinatorWarningCallback(clusterService.localNode());
+
         // we have no sub plans, so we can just execute the given plan
         if (subplans == null || subplans.isEmpty()) {
             executePlan(
@@ -936,7 +1003,8 @@ public class ComputeService {
                 listener,
                 null,
                 initialClusterStatuses,
-                planTimeProfile
+                planTimeProfile,
+                warnIndexCoordinatorOnce
             );
             return;
         }
@@ -1004,7 +1072,8 @@ public class ComputeService {
                 execInfo,
                 queryPragmas,
                 mainExchangeSource,
-                initialClusterStatuses
+                initialClusterStatuses,
+                warnIndexCoordinatorOnce
             );
             subPlansExecutor.execute(branchParallelDegree);
         }
@@ -1027,6 +1096,7 @@ public class ComputeService {
         final QueryPragmas queryPragmas;
         final ExchangeSourceHandler mainExchangeSource;
         final Map<String, EsqlExecutionInfo.Cluster.Status> initialClusterStatuses;
+        final Runnable warnIndexCoordinatorOnce;
         final AtomicInteger nextId = new AtomicInteger();
         final AtomicInteger completedSubPlanCount = new AtomicInteger();
         final Releasable emptySinkRef;
@@ -1042,7 +1112,8 @@ public class ComputeService {
             EsqlExecutionInfo execInfo,
             QueryPragmas queryPragmas,
             ExchangeSourceHandler mainExchangeSource,
-            Map<String, EsqlExecutionInfo.Cluster.Status> initialClusterStatuses
+            Map<String, EsqlExecutionInfo.Cluster.Status> initialClusterStatuses,
+            Runnable warnIndexCoordinatorOnce
         ) {
             this.subplans = subplans;
             // Pre-acquire all subplan listeners upfront so that the ComputeListener's ref count
@@ -1061,6 +1132,7 @@ public class ComputeService {
             this.queryPragmas = queryPragmas;
             this.mainExchangeSource = mainExchangeSource;
             this.initialClusterStatuses = initialClusterStatuses;
+            this.warnIndexCoordinatorOnce = warnIndexCoordinatorOnce;
             this.emptySinkRef = Releasables.releaseOnce(mainExchangeSource.addEmptySink());
         }
 
@@ -1111,7 +1183,8 @@ public class ComputeService {
                 }),
                 () -> exchangeSink.createExchangeSink(() -> {}),
                 initialClusterStatuses,
-                configuration.profile() ? new PlanTimeProfile() : null
+                configuration.profile() ? new PlanTimeProfile() : null,
+                warnIndexCoordinatorOnce
             );
         }
 
@@ -1138,7 +1211,8 @@ public class ComputeService {
         ActionListener<Result> listener,
         Supplier<ExchangeSink> exchangeSinkSupplier,
         Map<String, EsqlExecutionInfo.Cluster.Status> initialClusterStatuses,
-        PlanTimeProfile planTimeProfile
+        PlanTimeProfile planTimeProfile,
+        Runnable warnIndexCoordinatorOnce
     ) {
         final long splitDiscoveryStart = System.nanoTime();
         ActionListener<CollectedSplits> afterDiscovery = ActionListener.wrap(
@@ -1156,6 +1230,7 @@ public class ComputeService {
                     exchangeSinkSupplier,
                     initialClusterStatuses,
                     planTimeProfile,
+                    warnIndexCoordinatorOnce,
                     splitDiscoveryStart
                 ),
                 listener
@@ -1223,6 +1298,7 @@ public class ComputeService {
         Supplier<ExchangeSink> exchangeSinkSupplier,
         Map<String, EsqlExecutionInfo.Cluster.Status> initialClusterStatuses,
         PlanTimeProfile planTimeProfile,
+        Runnable warnIndexCoordinatorOnce,
         long splitDiscoveryStart
     ) {
         final ExternalDistributionResult distributionResult;
@@ -1232,8 +1308,10 @@ public class ComputeService {
             // this timer before the hop: start and completion would be different threads.
             long splitDiscoveryCpuStart = ThreadCpuTimer.currentNanos();
             distributionResult = applyExternalDistributionStrategy(collected, configuration);
-            if (execInfo != null
-                && (distributionResult.coordinatorSplits.isEmpty() == false || distributionResult.distributionPlan() != null)) {
+            if (runsExternalScanLocally(distributionResult, clusterService.localNode().getId())) {
+                warnIndexCoordinatorOnce.run();
+            }
+            if (execInfo != null && hasNonEmptyExternalSplits(distributionResult)) {
                 if (splitDiscoveryCpuStart >= 0) {
                     execInfo.queryProfile().addSplitDiscoveryCpuNanos(ThreadCpuTimer.elapsedNanos(splitDiscoveryCpuStart));
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.SplitShardCountSummary;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -917,12 +918,35 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         listener.onFailure(failure);
     }
 
+    /**
+     * Diagnoses an old coordinator placing external scan work on an index node during a rolling
+     * upgrade. Deliberately does not reject: rejecting without reassignment would fail the query
+     * or return partial results, and rolling-upgrade tests run with assertions enabled.
+     * A coordinator's own self-assignment is suppressed so it does not duplicate the coordinator warning.
+     */
+    static void warnIfRemoteIndexWorker(DiscoveryNode localNode, String parentNodeId) {
+        if (localNode.hasRole(DiscoveryNodeRole.INDEX_ROLE.roleName()) == false) {
+            return;
+        }
+        // An unset parent task carries the empty node id of TaskId.EMPTY_TASK_ID, which names no coordinator
+        // and so cannot be attributed to an old one.
+        if (parentNodeId.isEmpty() || parentNodeId.equals(localNode.getId())) {
+            return;
+        }
+        LOGGER.warn(
+            "index node [{}] received external ES|QL scan work from coordinator [{}]; expected only during a mixed-version transition",
+            localNode.getId(),
+            parentNodeId
+        );
+    }
+
     private void handleExternalSourceRequest(
         DataNodeRequest request,
         CancellableTask task,
         ActionListener<DataNodeComputeResponse> listener,
         PlanTimeProfile planTimeProfile
     ) {
+        warnIfRemoteIndexWorker(clusterService.localNode(), task.getParentTaskId().getNodeId());
         // Federation gate for the whole external request, not just the operators it ends up building. The backstop in
         // LocalExecutionPlanner.planExternalSource only fires for a plan that still contains an ExternalSourceExec, and
         // localPlan() below can consume it: PushStatsToExternalSource answers an ungrouped COUNT/MIN/MAX from the split

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionStrategy.java
@@ -12,8 +12,10 @@ import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 
 /**
- * Decides whether an external source query should be distributed across data nodes
- * or executed locally on the coordinator.
+ * Decides whether an external source query should be distributed across eligible
+ * remote workers or executed locally on the coordinator. Index-role nodes are never
+ * selected as remote workers; an empty eligible-worker set is a {@code LOCAL} fallback,
+ * not a failure.
  */
 public interface ExternalDistributionStrategy {
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategy.java
@@ -8,30 +8,43 @@
 package org.elasticsearch.xpack.esql.plugin;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Determines which nodes are eligible to execute external-source splits.
+ * Determines which nodes are eligible to execute external-source splits as remote workers.
  */
 public interface NodeEligibilityStrategy {
 
     List<DiscoveryNode> eligibleNodes(DiscoveryNodes allNodes);
 
-    NodeEligibilityStrategy ALL_NODES = allNodes -> {
+    /**
+     * Data-capable nodes that do not carry {@link DiscoveryNodeRole#INDEX_ROLE}.
+     * <p>
+     * An index node is never a valid remote scan worker: sending external scan work there risks
+     * OOM-ing the indexing tier, and an OOM-ed index node affects ingest for everything on that
+     * node. Coordinator-local execution remains allowed -- this predicate is only consulted when
+     * a strategy is choosing remote workers.
+     * <p>
+     * An empty result is a normal outcome, not an error. On an index-only cluster the strategies
+     * fall back to {@code LOCAL} and the coordinator runs the scan itself, which is what keeps a
+     * query alive when the controller routes it to an index node with no search capacity left.
+     * <p>
+     * The test is data-capability minus {@code INDEX_ROLE} rather than "has {@code SEARCH_ROLE}":
+     * both {@code INDEX_ROLE} and {@code SEARCH_ROLE} are declared with {@code canContainData == true},
+     * and requiring {@code SEARCH_ROLE} would silently disable distribution on every stateful
+     * cluster. Stateful nodes do not carry {@code INDEX_ROLE}, so they remain eligible.
+     * <p>
+     * {@link DiscoveryNode#hasRole(String)} directly expresses role-name membership;
+     * {@code DiscoveryNode} already canonicalizes roles known to the receiving version.
+     */
+    NodeEligibilityStrategy EXTERNAL_WORKER_NODES = allNodes -> {
         List<DiscoveryNode> nodes = new ArrayList<>();
         for (DiscoveryNode node : allNodes) {
-            nodes.add(node);
-        }
-        return nodes;
-    };
-
-    NodeEligibilityStrategy DATA_NODES_ONLY = allNodes -> {
-        List<DiscoveryNode> nodes = new ArrayList<>();
-        for (DiscoveryNode node : allNodes) {
-            if (node.canContainData()) {
+            if (node.canContainData() && node.hasRole(DiscoveryNodeRole.INDEX_ROLE.roleName()) == false) {
                 nodes.add(node);
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategy.java
@@ -16,8 +16,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Distributes external splits evenly across eligible data nodes in round-robin order.
- * Falls back to coordinator-only when there are no splits or no eligible nodes.
+ * Distributes external splits evenly across eligible remote workers in round-robin order.
+ * Falls back to coordinator-only when there are no splits or no eligible workers,
+ * including an index-only cluster where the coordinator then runs the scan itself.
  */
 public final class RoundRobinStrategy implements ExternalDistributionStrategy {
 
@@ -31,7 +32,7 @@ public final class RoundRobinStrategy implements ExternalDistributionStrategy {
     }
 
     public RoundRobinStrategy() {
-        this(NodeEligibilityStrategy.DATA_NODES_ONLY);
+        this(NodeEligibilityStrategy.EXTERNAL_WORKER_NODES);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategy.java
@@ -17,10 +17,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Distributes external splits across data nodes using a Longest Processing Time (LPT)
+ * Distributes external splits across eligible remote workers using a Longest Processing Time (LPT)
  * algorithm that considers {@link ExternalSplit#estimatedSizeInBytes()} for load balancing.
  * When all splits report size information, larger splits are assigned first to the node
  * with the least accumulated load. Falls back to plain round-robin when size info is absent.
+ * An empty eligible-worker set returns {@code LOCAL} so the coordinator runs the scan itself.
  */
 public final class WeightedRoundRobinStrategy implements ExternalDistributionStrategy {
 
@@ -34,7 +35,7 @@ public final class WeightedRoundRobinStrategy implements ExternalDistributionStr
     }
 
     public WeightedRoundRobinStrategy() {
-        this(NodeEligibilityStrategy.DATA_NODES_ONLY);
+        this(NodeEligibilityStrategy.EXTERNAL_WORKER_NODES);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategyTests.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 public class AdaptiveStrategyTests extends ESTestCase {
 
@@ -174,6 +176,130 @@ public class AdaptiveStrategyTests extends ESTestCase {
         for (List<ExternalSplit> assigned : plan.nodeAssignments().values()) {
             assertEquals(2, assigned.size());
         }
+    }
+
+    public void testIndexCoordinatorAssignsDistributableScanToSearchWorker() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+        PhysicalPlan planWithAgg = new AggregateExec(
+            Source.EMPTY,
+            createExternalSourceExec(),
+            List.of(),
+            List.of(),
+            AggregatorMode.SINGLE,
+            List.of(),
+            null
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(planWithAgg, createSplits(4), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertTrue(plan.distributed());
+        assertEquals(Set.of("search-1"), plan.nodeAssignments().keySet());
+        assertEquals(4, plan.nodeAssignments().get("search-1").size());
+    }
+
+    public void testIndexOnlyClusterReturnsLocal() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .build();
+        PhysicalPlan planWithAgg = new AggregateExec(
+            Source.EMPTY,
+            createExternalSourceExec(),
+            List.of(),
+            List.of(),
+            AggregatorMode.SINGLE,
+            List.of(),
+            null
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(planWithAgg, createSplits(5), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertFalse(plan.distributed());
+        assertTrue(plan.nodeAssignments().isEmpty());
+    }
+
+    public void testLocalShapesStayLocalEvenWhenSearchWorkerExists() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan singleSplit = strategy.planDistribution(
+            new ExternalDistributionContext(createExternalSourceExec(), createSplits(1), nodes, QueryPragmas.EMPTY)
+        );
+        assertFalse(singleSplit.distributed());
+
+        PhysicalPlan limitOnly = new LimitExec(
+            Source.EMPTY,
+            createExternalSourceExec(),
+            new Literal(Source.EMPTY, 10, DataType.INTEGER),
+            null
+        );
+        ExternalDistributionPlan limitPlan = strategy.planDistribution(
+            new ExternalDistributionContext(limitOnly, createSplits(5), nodes, QueryPragmas.EMPTY)
+        );
+        assertFalse(limitPlan.distributed());
+
+        // One search worker: few splits with no pipeline breaker stay local (2 <= 1 is false, so
+        // manySplits is true only when splits > eligible workers). With 1 search worker, 2 splits
+        // would distribute; use more search workers so the few-split path stays LOCAL.
+        DiscoveryNodes manySearch = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-2").roles(Set.of(SEARCH_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-3").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+        ExternalDistributionPlan fewSplits = strategy.planDistribution(
+            new ExternalDistributionContext(createExternalSourceExec(), createSplits(2), manySearch, QueryPragmas.EMPTY)
+        );
+        assertFalse(fewSplits.distributed());
+    }
+
+    public void testAdaptiveThresholdUsesEligibleWorkersOnly() {
+        // 2 index + 1 search: eligible count is 1, so 2 splits with no breaker is manySplits and distributes.
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("index-2").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(createExternalSourceExec(), createSplits(2), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertTrue(plan.distributed());
+        assertEquals(Set.of("search-1"), plan.nodeAssignments().keySet());
+    }
+
+    public void testAssignmentsNeverReferenceIndexNode() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build())
+            .build();
+        PhysicalPlan planWithAgg = new AggregateExec(
+            Source.EMPTY,
+            createExternalSourceExec(),
+            List.of(),
+            List.of(),
+            AggregatorMode.SINGLE,
+            List.of(),
+            null
+        );
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(planWithAgg, createSplits(6), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertTrue(plan.distributed());
+        assertFalse(plan.nodeAssignments().containsKey("index-1"));
+        assertEquals(Set.of("search-1", "data-1"), plan.nodeAssignments().keySet());
     }
 
     private static ExternalSourceExec createExternalSourceExec() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/CoordinatorOnlyStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/CoordinatorOnlyStrategyTests.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 public class CoordinatorOnlyStrategyTests extends ESTestCase {
 
@@ -47,6 +49,32 @@ public class CoordinatorOnlyStrategyTests extends ESTestCase {
         ExternalDistributionContext context = new ExternalDistributionContext(createPlan(), List.of(), createNodes(3), QueryPragmas.EMPTY);
 
         ExternalDistributionPlan plan = CoordinatorOnlyStrategy.INSTANCE.planDistribution(context);
+
+        assertFalse(plan.distributed());
+    }
+
+    public void testAlwaysReturnsLocalOnIndexSearchTopology() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = CoordinatorOnlyStrategy.INSTANCE.planDistribution(
+            new ExternalDistributionContext(createPlan(), createSplits(8), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertFalse(plan.distributed());
+        assertTrue(plan.nodeAssignments().isEmpty());
+    }
+
+    public void testAlwaysReturnsLocalOnIndexOnlyTopology() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = CoordinatorOnlyStrategy.INSTANCE.planDistribution(
+            new ExternalDistributionContext(createPlan(), createSplits(8), nodes, QueryPragmas.EMPTY)
+        );
 
         assertFalse(plan.distributed());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExtendedDistributionPropertyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExtendedDistributionPropertyTests.java
@@ -9,12 +9,20 @@ package org.elasticsearch.xpack.esql.plugin;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.CoalescedSplit;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.SplitCoalescer;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -23,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 /**
  * Extended property tests for weighted round-robin distribution, split coalescing,
@@ -203,6 +213,35 @@ public class ExtendedDistributionPropertyTests extends ESTestCase {
         assertEquals("Both strategies must assign all splits", splitCount, wrTotal);
     }
 
+    public void testWeightedPlanDistributionNeverAssignsIndexRoleNodes() {
+        DiscoveryNodes mixed = mixedRoleNodes();
+        List<ExternalSplit> splits = createSizedSplits(between(4, 40));
+        ExternalSourceExec source = new ExternalSourceExec(
+            Source.EMPTY,
+            "s3://bucket/data/*.parquet",
+            "parquet",
+            List.of(
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "name",
+                    new EsField("name", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+                )
+            ),
+            Map.of(),
+            Map.of(),
+            null
+        ).withSplits(splits);
+        AggregateExec plan = new AggregateExec(Source.EMPTY, source, List.of(), List.of(), AggregatorMode.INITIAL, source.output(), null);
+
+        ExternalDistributionPlan distribution = new WeightedRoundRobinStrategy().planDistribution(
+            new ExternalDistributionContext(plan, splits, mixed, QueryPragmas.EMPTY)
+        );
+        assertTrue(distribution.distributed());
+        for (String nodeId : distribution.nodeAssignments().keySet()) {
+            assertFalse("weighted strategy assigned work to an index node: " + nodeId, nodeId.startsWith("index-"));
+        }
+    }
+
     // --- Helpers ---
 
     private static List<ExternalSplit> expandCoalesced(List<ExternalSplit> splits) {
@@ -243,6 +282,19 @@ public class ExtendedDistributionPropertyTests extends ESTestCase {
             Map.of(),
             Map.of()
         );
+    }
+
+    private static DiscoveryNodes mixedRoleNodes() {
+        int indexCount = between(1, 3);
+        int searchCount = between(1, 4);
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        for (int i = 0; i < indexCount; i++) {
+            builder.add(DiscoveryNodeUtils.builder("index-" + i).roles(Set.of(INDEX_ROLE)).build());
+        }
+        for (int i = 0; i < searchCount; i++) {
+            builder.add(DiscoveryNodeUtils.builder("search-" + i).roles(Set.of(SEARCH_ROLE)).build());
+        }
+        return builder.build();
     }
 
     private static List<DiscoveryNode> createNodeList(int count) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionPropertyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionPropertyTests.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 /**
  * Randomized property tests for external source distribution strategies.
@@ -217,6 +219,20 @@ public class ExternalDistributionPropertyTests extends ESTestCase {
         assertFalse("CoordinatorOnly must never distribute", plan.distributed());
     }
 
+    public void testDefaultStrategiesNeverAssignIndexRoleNodes() {
+        DiscoveryNodes mixed = mixedRoleNodes();
+        List<ExternalSplit> splits = createSplits(between(4, 40));
+        ExternalDistributionContext context = new ExternalDistributionContext(createAggPlan(splits), splits, mixed, QueryPragmas.EMPTY);
+
+        for (ExternalDistributionStrategy strategy : List.of(new AdaptiveStrategy(), new RoundRobinStrategy())) {
+            ExternalDistributionPlan plan = strategy.planDistribution(context);
+            assertTrue(plan.distributed());
+            for (String nodeId : plan.nodeAssignments().keySet()) {
+                assertFalse("strategy assigned work to an index node: " + nodeId, nodeId.startsWith("index-"));
+            }
+        }
+    }
+
     public void testStrategyResolutionFromPragma() {
         assertTrue(resolveStrategy("adaptive") instanceof AdaptiveStrategy);
         assertTrue(resolveStrategy("coordinator_only") instanceof CoordinatorOnlyStrategy);
@@ -275,6 +291,20 @@ public class ExternalDistributionPropertyTests extends ESTestCase {
             nodes.add(DiscoveryNodeUtils.builder("node-" + i).roles(Set.of(DATA_HOT_NODE_ROLE)).build());
         }
         return nodes;
+    }
+
+    private static DiscoveryNodes mixedRoleNodes() {
+        int indexCount = between(1, 3);
+        int searchCount = between(1, 4);
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        for (int i = 0; i < indexCount; i++) {
+            builder.add(DiscoveryNodeUtils.builder("index-" + i).roles(Set.of(INDEX_ROLE)).build());
+        }
+        for (int i = 0; i < searchCount; i++) {
+            builder.add(DiscoveryNodeUtils.builder("search-" + i).roles(Set.of(SEARCH_ROLE)).build());
+        }
+        builder.add(DiscoveryNodeUtils.builder("data-0").roles(Set.of(DATA_HOT_NODE_ROLE)).build());
+        return builder.build();
     }
 
     private static DiscoveryNodes createNodes(int count) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.esql.plugin;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.operator.topn.TopNOperator.InputOrdering;
@@ -58,8 +60,12 @@ import org.elasticsearch.xpack.esql.stats.SearchStats;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 public class ExternalDistributionTests extends ESTestCase {
 
@@ -548,6 +554,95 @@ public class ExternalDistributionTests extends ESTestCase {
         assertEquals(1, ComputeService.externalCoalesceFloor(-3, 4));
         // An implausibly wide cluster must clamp rather than overflow.
         assertEquals(Integer.MAX_VALUE, ComputeService.externalCoalesceFloor(Integer.MAX_VALUE, 4));
+        // An index-only cluster has zero eligible remote workers, but the coordinator that ends up running the
+        // scan still fills task_concurrency drivers, so the count -- not the product -- is normalised to one.
+        assertEquals(14, ComputeService.externalCoalesceFloor(14, 0));
+    }
+
+    public void testExternalCoalesceFloorUsesEligibleWorkers() {
+        DiscoveryNodes indexOnly = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .build();
+        assertEquals(14, ComputeService.externalCoalesceFloor(14, indexOnly));
+
+        DiscoveryNodes mixed = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-2").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+        assertEquals(28, ComputeService.externalCoalesceFloor(14, mixed));
+    }
+
+    public void testLocalExternalScanResultCollapsesWhenNoGatherBoundary() {
+        List<ExternalSplit> splits = List.of(
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file1.parquet"), 0, 1024, ".parquet", Map.of(), Map.of()),
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file2.parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+        );
+        ExternalSourceExec source = createExternalSourceExec().withSplits(splits);
+        LimitExec limit = new LimitExec(SRC, source, new Literal(SRC, 10, DataType.INTEGER), null);
+
+        var result = ComputeService.localExternalScanResult(limit, splits, "index-1");
+
+        assertFalse(result.isDistributed());
+        assertNull(result.distributionPlan());
+        assertEquals(2, result.coordinatorSplits().size());
+        assertFalse(ComputeService.hasCollapsibleExternalExchange(result.plan()));
+    }
+
+    public void testLocalExternalScanResultSelfAssignsWhenGatherNeeded() {
+        ExternalRelation external = createExternalRelation();
+        Aggregate aggregate = new Aggregate(SRC, external, List.of(), List.of());
+        Mapper mapper = new Mapper();
+        PhysicalPlan physicalPlan = mapper.map(new Versioned<>(aggregate, TransportVersion.current()));
+        List<ExternalSplit> splits = List.of(
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file1.parquet"), 0, 1024, ".parquet", Map.of(), Map.of()),
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file2.parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+        );
+
+        var result = ComputeService.localExternalScanResult(physicalPlan, splits, "index-1");
+
+        assertTrue(result.isDistributed());
+        assertEquals(Set.of("index-1"), result.distributionPlan().nodeAssignments().keySet());
+        assertEquals(2, result.distributionPlan().nodeAssignments().get("index-1").size());
+        assertTrue(result.coordinatorSplits().isEmpty());
+    }
+
+    public void testHasNonEmptyExternalSplits() {
+        ExternalSourceExec source = createExternalSourceExec();
+        assertFalse(ComputeService.hasNonEmptyExternalSplits(new ComputeService.ExternalDistributionResult(source, null, List.of())));
+
+        List<ExternalSplit> splits = List.of(
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file1.parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+        );
+        assertTrue(ComputeService.hasNonEmptyExternalSplits(new ComputeService.ExternalDistributionResult(source, null, splits)));
+        ExternalDistributionPlan distributed = new ExternalDistributionPlan(Map.of("search-1", splits), true);
+        assertTrue(ComputeService.hasNonEmptyExternalSplits(new ComputeService.ExternalDistributionResult(source, distributed, List.of())));
+    }
+
+    public void testRunsExternalScanLocally() {
+        ExternalSourceExec source = createExternalSourceExec();
+        List<ExternalSplit> splits = List.of(
+            new FileSplit("parquet", StoragePath.of("s3://bucket/file1.parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+        );
+
+        // No external scan at all.
+        assertFalse(runsLocally(source, null, List.of()));
+        // Collapsed onto local drivers.
+        assertTrue(runsLocally(source, null, splits));
+        // Gather-boundary self-assignment: distributed() is true, but the read still happens here.
+        assertTrue(runsLocally(source, new ExternalDistributionPlan(Map.of("index-1", splits), true), List.of()));
+        // Handed to a remote worker, which is the normal split-role path and not local.
+        assertFalse(runsLocally(source, new ExternalDistributionPlan(Map.of("search-1", splits), true), List.of()));
+        // A plan that keeps some splits here but sends others away is not local either.
+        Map<String, List<ExternalSplit>> partlyRemote = Map.of("index-1", splits, "search-1", splits);
+        assertFalse(runsLocally(source, new ExternalDistributionPlan(partlyRemote, true), List.of()));
+    }
+
+    private static boolean runsLocally(PhysicalPlan plan, ExternalDistributionPlan distribution, List<ExternalSplit> coordinatorSplits) {
+        return ComputeService.runsExternalScanLocally(
+            new ComputeService.ExternalDistributionResult(plan, distribution, coordinatorSplits),
+            "index-1"
+        );
     }
 
     // --- Field retention through local optimization tests ---

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/IndexNodeExternalScanWarningTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/IndexNodeExternalScanWarningTests.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexNodeExternalScanWarningTests extends ESTestCase {
+
+    public void testCoordinatorWarningAbsentWithoutIndexRole() {
+        DiscoveryNode search = DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build();
+        DiscoveryNode data = DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build();
+        AtomicBoolean warned = new AtomicBoolean();
+
+        MockLog.assertThatLogger(() -> {
+            ComputeService.warnIndexCoordinatorOnce(search, warned);
+            ComputeService.warnIndexCoordinatorOnce(data, warned);
+        },
+            ComputeService.class,
+            new MockLog.UnseenEventExpectation(
+                "no coordinator warning on non-index nodes",
+                ComputeService.class.getCanonicalName(),
+                Level.WARN,
+                "index node"
+            )
+        );
+        assertFalse(warned.get());
+    }
+
+    public void testCoordinatorWarningOnceForRepeatedCalls() {
+        DiscoveryNode index = DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build();
+        Runnable warning = ComputeService.newIndexCoordinatorWarningCallback(index);
+
+        MockLog.assertThatLogger(() -> {
+            warning.run();
+            warning.run();
+        },
+            ComputeService.class,
+            new ExactEventCountExpectation(
+                "coordinator warning",
+                ComputeService.class.getCanonicalName(),
+                Level.WARN,
+                "index node [index-1] is running an external ES|QL scan locally",
+                1
+            )
+        );
+    }
+
+    public void testRequestScopedCoordinatorWarningOnceAcrossConcurrentCalls() throws Exception {
+        DiscoveryNode index = DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build();
+        Runnable warning = ComputeService.newIndexCoordinatorWarningCallback(index);
+        int threads = between(4, 8);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        AtomicInteger invocations = new AtomicInteger();
+
+        MockLog.assertThatLogger(() -> {
+            List<Thread> workers = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                Thread t = new Thread(() -> {
+                    try {
+                        start.await();
+                        warning.run();
+                        invocations.incrementAndGet();
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                workers.add(t);
+                t.start();
+            }
+            start.countDown();
+            try {
+                done.await();
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+            for (Thread t : workers) {
+                try {
+                    t.join();
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+            }
+        },
+            ComputeService.class,
+            new ExactEventCountExpectation(
+                "single coordinator warning",
+                ComputeService.class.getCanonicalName(),
+                Level.WARN,
+                "index node [index-1] is running an external ES|QL scan locally",
+                1
+            )
+        );
+
+        assertEquals(threads, invocations.get());
+    }
+
+    public void testCoordinatorWarningCallbackIsNoOpWithoutIndexRole() {
+        DiscoveryNode search = DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build();
+        Runnable warning = ComputeService.newIndexCoordinatorWarningCallback(search);
+
+        MockLog.assertThatLogger(
+            warning::run,
+            ComputeService.class,
+            new MockLog.UnseenEventExpectation(
+                "no coordinator warning on a search node",
+                ComputeService.class.getCanonicalName(),
+                Level.WARN,
+                "index node"
+            )
+        );
+    }
+
+    public void testReceiverWarningFiresForRemoteParentOnIndexNode() {
+        DiscoveryNode index = DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build();
+
+        MockLog.assertThatLogger(
+            () -> DataNodeComputeHandler.warnIfRemoteIndexWorker(index, "old-coordinator"),
+            DataNodeComputeHandler.class,
+            new MockLog.SeenEventExpectation(
+                "receiver warning",
+                DataNodeComputeHandler.class.getCanonicalName(),
+                Level.WARN,
+                "index node [index-1] received external ES|QL scan work from coordinator [old-coordinator]"
+            )
+        );
+    }
+
+    public void testReceiverWarningSuppressedForSelfAssignment() {
+        DiscoveryNode index = DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build();
+
+        MockLog.assertThatLogger(
+            () -> DataNodeComputeHandler.warnIfRemoteIndexWorker(index, "index-1"),
+            DataNodeComputeHandler.class,
+            new MockLog.UnseenEventExpectation(
+                "no receiver warning for self-assignment",
+                DataNodeComputeHandler.class.getCanonicalName(),
+                Level.WARN,
+                "received external ES|QL scan work"
+            )
+        );
+    }
+
+    public void testReceiverWarningSuppressedForUnsetParentTask() {
+        DiscoveryNode index = DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build();
+
+        MockLog.assertThatLogger(
+            () -> DataNodeComputeHandler.warnIfRemoteIndexWorker(index, TaskId.EMPTY_TASK_ID.getNodeId()),
+            DataNodeComputeHandler.class,
+            new MockLog.UnseenEventExpectation(
+                "no receiver warning when no coordinator can be named",
+                DataNodeComputeHandler.class.getCanonicalName(),
+                Level.WARN,
+                "received external ES|QL scan work"
+            )
+        );
+    }
+
+    private static final class ExactEventCountExpectation implements MockLog.LoggingExpectation {
+        private final String name;
+        private final String logger;
+        private final Level level;
+        private final String message;
+        private final int expectedCount;
+        private final AtomicInteger count = new AtomicInteger();
+
+        private ExactEventCountExpectation(String name, String logger, Level level, String message, int expectedCount) {
+            this.name = name;
+            this.logger = logger;
+            this.level = level;
+            this.message = message;
+            this.expectedCount = expectedCount;
+        }
+
+        @Override
+        public void match(LogEvent event) {
+            if (event.getLevel().equals(level)
+                && event.getLoggerName().equals(logger)
+                && event.getMessage().getFormattedMessage().contains(message)) {
+                count.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void assertMatched() {
+            assertThat("unexpected number of " + name + " events", count.get(), equalTo(expectedCount));
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/NodeEligibilityStrategyTests.java
@@ -14,49 +14,80 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.MASTER_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 public class NodeEligibilityStrategyTests extends ESTestCase {
 
-    public void testAllNodesReturnsEveryNode() {
+    public void testSearchAndStatefulDataNodesIncluded() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
             .add(DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build())
-            .add(DiscoveryNodeUtils.builder("master-1").roles(Set.of(MASTER_ROLE)).build())
             .build();
 
-        List<DiscoveryNode> eligible = NodeEligibilityStrategy.ALL_NODES.eligibleNodes(nodes);
+        List<DiscoveryNode> eligible = NodeEligibilityStrategy.EXTERNAL_WORKER_NODES.eligibleNodes(nodes);
 
-        assertEquals(2, eligible.size());
+        assertEquals(Set.of("search-1", "data-1"), ids(eligible));
     }
 
-    public void testDataNodesOnlyExcludesMasterOnly() {
+    public void testIndexMasterAndCoordinatingExcluded() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("index-search-1").roles(Set.of(INDEX_ROLE, SEARCH_ROLE)).build())
             .add(DiscoveryNodeUtils.builder("master-1").roles(Set.of(MASTER_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("coord-1").roles(Set.of()).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
             .build();
 
-        List<DiscoveryNode> eligible = NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(nodes);
+        List<DiscoveryNode> eligible = NodeEligibilityStrategy.EXTERNAL_WORKER_NODES.eligibleNodes(nodes);
 
-        assertEquals(1, eligible.size());
-        assertEquals("data-1", eligible.get(0).getId());
+        assertEquals(List.of("search-1"), eligible.stream().map(DiscoveryNode::getId).toList());
     }
 
-    public void testDataNodesOnlyIncludesMultiRoleNode() {
+    public void testMixedIndexAndSearchYieldsOnlySearch() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(DiscoveryNodeUtils.builder("multi-1").roles(Set.of(DATA_HOT_NODE_ROLE, MASTER_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("index-2").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-2").roles(Set.of(SEARCH_ROLE)).build())
             .build();
 
-        List<DiscoveryNode> eligible = NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(nodes);
+        List<DiscoveryNode> eligible = NodeEligibilityStrategy.EXTERNAL_WORKER_NODES.eligibleNodes(nodes);
 
-        assertEquals(1, eligible.size());
+        assertEquals(Set.of("search-1", "search-2"), ids(eligible));
+    }
+
+    public void testIndexOnlyClusterYieldsEmptyList() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("index-2").roles(Set.of(INDEX_ROLE)).build())
+            .build();
+
+        assertTrue(NodeEligibilityStrategy.EXTERNAL_WORKER_NODES.eligibleNodes(nodes).isEmpty());
     }
 
     public void testEmptyNodesReturnsEmpty() {
         DiscoveryNodes nodes = DiscoveryNodes.builder().build();
 
-        assertTrue(NodeEligibilityStrategy.ALL_NODES.eligibleNodes(nodes).isEmpty());
-        assertTrue(NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(nodes).isEmpty());
+        assertTrue(NodeEligibilityStrategy.EXTERNAL_WORKER_NODES.eligibleNodes(nodes).isEmpty());
+    }
+
+    public void testStatefulMultiRoleNodeIncluded() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("multi-1").roles(Set.of(DATA_HOT_NODE_ROLE, MASTER_ROLE)).build())
+            .build();
+
+        List<DiscoveryNode> eligible = NodeEligibilityStrategy.EXTERNAL_WORKER_NODES.eligibleNodes(nodes);
+
+        assertEquals(1, eligible.size());
+        assertEquals("multi-1", eligible.get(0).getId());
+    }
+
+    private static Set<String> ids(List<DiscoveryNode> nodes) {
+        return nodes.stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RoundRobinStrategyTests.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 public class RoundRobinStrategyTests extends ESTestCase {
 
@@ -101,6 +103,50 @@ public class RoundRobinStrategyTests extends ESTestCase {
         ExternalDistributionPlan plan = strategy.planDistribution(context);
 
         assertFalse(plan.distributed());
+    }
+
+    public void testAssignmentsNeverReferenceIndexNode() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(createPlan(), createSplits(6), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertTrue(plan.distributed());
+        assertFalse(plan.nodeAssignments().containsKey("index-1"));
+        assertEquals(Set.of("search-1", "data-1"), plan.nodeAssignments().keySet());
+    }
+
+    public void testIndexCoordinatorAssignsEverySplitToSearchWorker() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(createPlan(), createSplits(5), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertTrue(plan.distributed());
+        assertEquals(Set.of("search-1"), plan.nodeAssignments().keySet());
+        assertEquals(5, plan.nodeAssignments().get("search-1").size());
+    }
+
+    public void testIndexOnlyClusterReturnsLocal() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(createPlan(), createSplits(3), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertFalse(plan.distributed());
+        assertTrue(plan.nodeAssignments().isEmpty());
     }
 
     private static PhysicalPlan createPlan() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/WeightedRoundRobinStrategyTests.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.SEARCH_ROLE;
 
 public class WeightedRoundRobinStrategyTests extends ESTestCase {
 
@@ -135,6 +137,60 @@ public class WeightedRoundRobinStrategyTests extends ESTestCase {
         ExternalDistributionPlan plan2 = strategy.planDistribution(context);
 
         assertEquals(plan1.nodeAssignments(), plan2.nodeAssignments());
+    }
+
+    public void testAssignmentsNeverReferenceIndexNode() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("data-1").roles(Set.of(DATA_HOT_NODE_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(
+                createPlan(),
+                List.of(createSplit("a.parquet", 500), createSplit("b.parquet", 300), createSplit("c.parquet", 200)),
+                nodes,
+                QueryPragmas.EMPTY
+            )
+        );
+
+        assertTrue(plan.distributed());
+        assertFalse(plan.nodeAssignments().containsKey("index-1"));
+        assertEquals(Set.of("search-1", "data-1"), plan.nodeAssignments().keySet());
+    }
+
+    public void testIndexCoordinatorAssignsEverySplitToSearchWorker() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .add(DiscoveryNodeUtils.builder("search-1").roles(Set.of(SEARCH_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(
+                createPlan(),
+                List.of(createSplit("a.parquet", 500), createSplit("b.parquet", 300)),
+                nodes,
+                QueryPragmas.EMPTY
+            )
+        );
+
+        assertTrue(plan.distributed());
+        assertEquals(Set.of("search-1"), plan.nodeAssignments().keySet());
+        assertEquals(2, plan.nodeAssignments().get("search-1").size());
+    }
+
+    public void testIndexOnlyClusterReturnsLocal() {
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(DiscoveryNodeUtils.builder("index-1").roles(Set.of(INDEX_ROLE)).build())
+            .build();
+
+        ExternalDistributionPlan plan = strategy.planDistribution(
+            new ExternalDistributionContext(createPlan(), List.of(createSplit("a.parquet", 1024)), nodes, QueryPragmas.EMPTY)
+        );
+
+        assertFalse(plan.distributed());
+        assertTrue(plan.nodeAssignments().isEmpty());
     }
 
     private static ExternalSplit createSplit(String name, long sizeBytes) {


### PR DESCRIPTION
Exclude index-role nodes from external-source remote workers while preserving coordinator-local execution when required. Add transition warnings, correct split coalescing without eligible workers, and expand distribution test coverage.

Closes https://github.com/elastic/esql-planning/issues/1873
Related https://github.com/elastic/esql-planning/issues/1852 