### PR TITLE
Fix NPE setting similarity on an nvidia text_embedding endpoint

### DIFF
--- a/docs/changelog/158470.yaml
+++ b/docs/changelog/158470.yaml
@@ -1,0 +1,6 @@
+area: Machine Learning
+issues:
+ - 157288
+pr: 158470
+summary: Fix a null pointer exception setting similarity on an nvidia text_embedding endpoint
+type: bug

--- a/docs/changelog/158503.yaml
+++ b/docs/changelog/158503.yaml
@@ -1,6 +1,6 @@
 area: Machine Learning
 issues:
  - 157288
-pr: 158470
+pr: 158503
 summary: Fix a null pointer exception setting similarity on an nvidia text_embedding endpoint
 type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaService.java
@@ -175,10 +175,6 @@ public class NvidiaService extends SenderService<NvidiaModel> implements Reranki
             var similarityFromModel = serviceSettings.similarity();
             var similarityToUse = similarityFromModel == null ? SimilarityMeasure.DOT_PRODUCT : similarityFromModel;
 
-            if (similarityToUse.equals(similarityFromModel) && embeddingSize == serviceSettings.dimensions()) {
-                // Avoid creating a new model if similarity and embedding size are unchanged
-                return model;
-            }
             var updatedServiceSettings = new NvidiaEmbeddingsServiceSettings(
                 serviceSettings.modelId(),
                 serviceSettings.uri(),
@@ -187,6 +183,12 @@ public class NvidiaService extends SenderService<NvidiaModel> implements Reranki
                 serviceSettings.maxInputTokens(),
                 serviceSettings.rateLimitSettings()
             );
+
+            // Avoid creating a new model if nothing changed. Comparing the settings is safe when
+            // dimensions is still null, which it is until the first embedding response arrives.
+            if (updatedServiceSettings.equals(serviceSettings)) {
+                return model;
+            }
 
             return new NvidiaEmbeddingsModel(embeddingsModel, updatedServiceSettings);
         } else {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaServiceTests.java
@@ -676,6 +676,19 @@ public class NvidiaServiceTests extends InferenceServiceTestCase {
         );
     }
 
+    public void testUpdateModelWithEmbeddingDetails_DimensionsNotSetYet() throws Exception {
+        var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
+        try (var service = new NvidiaService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
+            // nvidia does not take dimensions in the config, so it stays null until the first
+            // embedding response comes back
+            var model = NvidiaEmbeddingsModelTests.createEmbeddingsModel("url", "secret", "model", null, null, null, null, null);
+
+            var updated = service.updateModelWithEmbeddingDetails(model, 1024);
+
+            assertThat(((NvidiaEmbeddingsModel) updated).getServiceSettings().dimensions(), is(1024));
+        }
+    }
+
     @Override
     protected void assertRerankerWindowSize(RerankingInferenceService rerankingInferenceService) {
         assertThat(rerankingInferenceService.rerankerWindowSize("any model"), is(300));


### PR DESCRIPTION
Closes #157288

`dimensions()` is an `Integer` and stays null until the first embedding response comes back, and nvidia does not accept `dimensions` in the endpoint config. The guard compared it to an `int` with `==`, which unboxes it, so setting `similarity` on an nvidia `text_embedding` endpoint always threw a 500.

Builds the updated settings first and compares them with `equals` instead, which is what `JinaAIService` already does in the same package.

The test creates a model with no dimensions and calls `updateModelWithEmbeddingDetails`. Without the change it fails with `Cannot invoke "java.lang.Integer.intValue()" because the return value of NvidiaEmbeddingsServiceSettings.dimensions() is null`.

The nvidia tests pass, 224 in 21 classes.
