### PR TITLE
Enable real indexing throttling in UploadQueueControllerService

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/UploadQueueControllerService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/UploadQueueControllerService.java
@@ -51,7 +51,7 @@ public class UploadQueueControllerService extends AbstractLifecycleComponent {
     // This is not dynamic to simplify the implementation.
     public static final Setting<Boolean> STATELESS_UPLOAD_QUEUE_CONTROLLER_INDEXING_THROTTLING_ENABLED = Setting.boolSetting(
         "stateless.upload.queue_controller.indexing_throttling.enabled",
-        false,
+        true,
         Setting.Property.NodeScope
     );
 


### PR DESCRIPTION
We have confirmed that we see expected behavior while running in metrics-only mode so now we can enable real throttling. 