### PR TITLE
ESQL: pin ExternalSourceProfileIT to one coordinator

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -231,9 +231,6 @@ tests:
 - class: org.elasticsearch.upgrades.MlMappingsUpgradeIT
   method: testMappingsUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/152115
-- class: org.elasticsearch.xpack.esql.action.ExternalSourceProfileIT
-  method: testCsvCountStarScansColdThenSkipsWarm
-  issue: https://github.com/elastic/elasticsearch/issues/152132
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlCurrentCoordinatorSpecDateRangeIT
   method: test {csv-spec:date_range.rangeWithinPointMultiValueSomeMatch}
   issue: https://github.com/elastic/elasticsearch/issues/152267

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceProfileIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceProfileIT.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.nullValue;
  * and {@code EsqlQueryProfile.dataset_resolution} are populated when {@code FROM <dataset>}
  * queries execute against a local Parquet fixture.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 public class ExternalSourceProfileIT extends AbstractExternalDataSourceIT {
 
     @Override


### PR DESCRIPTION
# Pin ExternalSourceProfileIT to one coordinator

## Problem
`ExternalSourceCacheService` is per-node. This suite allowed dedicated masters and client nodes, so a cold CSV `COUNT(*)` could harvest into one coordinator's cache and the warm query could land on another node with an empty cache. The warm pass then scanned the file (`filesScanned == 1`) even though the count was correct. The mute for `testCsvCountStarScansColdThenSkipsWarm` does not match the renamed test and never applied.

## Fix
- Restrict the suite cluster to one data node: no client nodes, no dedicated masters.
- Drop the stale mute. `run()` already pins queries to the master.

## Tests
`ExternalSourceProfileIT.testCsvCountStarColdHarvestThenWarmServedFromStripes` (and the rest of the class) now always share one coordinator cache.

Closes https://github.com/elastic/elasticsearch/issues/152132
