### PR TITLE
[9.5] ESQL: Return 400 for unresolved MMR query vector (#158301)

### DIFF
--- a/docs/changelog/158301.yaml
+++ b/docs/changelog/158301.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 157876
+pr: 158301
+summary: Return 400 for unresolved MMR query vector
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2408,7 +2408,9 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
 
             Expression queryVector = resolved.queryVector();
 
-            if (queryVector != null && (queryVector.dataType().isNumeric() || queryVector.dataType() == KEYWORD)) {
+            if (queryVector != null
+                && queryVector.resolved()
+                && (queryVector.dataType().isNumeric() || queryVector.dataType() == KEYWORD)) {
                 return new MMR(
                     resolved.source(),
                     resolved.child(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MMR.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MMR.java
@@ -91,7 +91,7 @@ public class MMR extends UnaryPlan
 
     @Override
     public boolean expressionsResolved() {
-        return diversifyField.resolved();
+        return diversifyField.resolved() && (queryVector == null || queryVector.resolved());
     }
 
     @Override
@@ -137,7 +137,7 @@ public class MMR extends UnaryPlan
             failures.add(fail(this, "MMR diversify field must be a dense vector field"));
         }
 
-        if (queryVector != null && queryVector.dataType() != DENSE_VECTOR) {
+        if (queryVector != null && queryVector.resolved() && queryVector.dataType() != DENSE_VECTOR) {
             failures.add(
                 fail(
                     this,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -4490,10 +4490,10 @@ public class VerifierTests extends ESTestCase {
         defaultAnalyzer().query(
             "row dense_embedding=[0.5, 0.4, 0.3, 0.2]::dense_vector | mmr [0.5, 0.4, 0.3, 0.2] on dense_embedding limit 10"
         );
-        defaultAnalyzer().query("""
+        defaultAnalyzer().addAnalysisTestsInferenceResolution().query(Strings.format("""
             row dense_embedding=[0.5, 0.4, 0.3, 0.2]::dense_vector
-            | mmr TEXT_EMBEDDING("some text", "some model") on dense_embedding limit 10
-            """);
+            | mmr TEXT_EMBEDDING("some text", "%s") on dense_embedding limit 10
+            """, TEXT_EMBEDDING_INFERENCE_ID));
 
         defaultAnalyzer().query("row dense_embedding=[0.5, 0.4, 0.3, 0.2]::dense_vector | mmr \"7e7e\" on dense_embedding limit 10");
         defaultAnalyzer().query("row dense_embedding=[0.5, 0.4, 0.3, 0.2]::dense_vector | mmr [15, 16, 20] on dense_embedding limit 10");
@@ -4501,6 +4501,13 @@ public class VerifierTests extends ESTestCase {
         fullText().error(
             "FROM test | LIMIT 100 | MMR published_date ON vector LIMIT 10",
             equalTo("1:25: MMR query vector must be a DENSE_VECTOR, found [published_date] of type [DATETIME]")
+        );
+    }
+
+    public void testMMRUnresolvedQueryVector() {
+        defaultAnalyzer().error(
+            "row dense_embedding=[0.5, 0.4, 0.3, 0.2]::dense_vector | mmr _score on dense_embedding limit 10",
+            containsString("Unknown column [_score]")
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL: Return 400 for unresolved MMR query vector (#158301)