### PR TITLE
ES|QL|DS: enable local type on BWC remotes

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -489,9 +489,6 @@ tests:
 - class: org.elasticsearch.reindex.ReindexFailureTests
   method: testResponseOnSearchFailure
   issue: https://github.com/elastic/elasticsearch/issues/151064
-- class: org.elasticsearch.xpack.esql.ccq.FederationOutgoingDatasetGateRestIT
-  method: testDisabledLocalResolvesRemoteDatasetAsMissingIndex
-  issue: https://github.com/elastic/elasticsearch/issues/155916
 - class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
   method: testCacheIsWarmedBeforeSearchShardRecoveryWhenVBCCGetsUploaded
   issue: https://github.com/elastic/elasticsearch/issues/153406

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.ccq;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
@@ -63,6 +64,10 @@ public class Clusters {
         if (remoteClusterVersion().onOrAfter(org.elasticsearch.Version.V_9_5_0)) {
             cluster.setting(localAllowedPathsSetting(remoteClusterVersion()), csvDataPath.toString());
         }
+        // The local data-source type is snapshot-on / release-off. A release BWC remote therefore rejects
+        // PUT type=local unless the flag is forced on; .feature() is a no-op on snapshots and on versions
+        // before the flag existed (9.5.0).
+        cluster.feature(FeatureFlag.ESQL_EXTERNAL_DATASOURCES_LOCAL);
         if (knowsFederationSetting(remoteClusterVersion())) {
             cluster.setting(Federation.FEDERATION_ENABLED.getKey(), federationEnabled == null ? () -> "true" : federationEnabled);
         }


### PR DESCRIPTION
## Summary
- `FederationOutgoingDatasetGateRestIT` PUTs a `local` data source on the remote cluster. That type exists in 9.5.0 but is gated by `ESQL_EXTERNAL_DATASOURCES_LOCAL`, which is snapshot-on and release-off.
- A 9.5.0 `newToOld` remote is a release build, so the PUT failed with `unknown data source type [local]`. Force-enable the flag on the multi-cluster remote via `cluster.feature(...)` (no-op on snapshots and on versions before 9.5.0).
- Unmutes `testDisabledLocalResolvesRemoteDatasetAsMissingIndex`.

Closes #155916
