### PR TITLE
Add doc-values fallback for unsigned_long queries

### DIFF
--- a/docs/changelog/158545.yaml
+++ b/docs/changelog/158545.yaml
@@ -1,0 +1,5 @@
+area: Columnar
+issues: []
+pr: 158545
+summary: Add doc-values fallback for `unsigned_long` queries
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -132,10 +132,6 @@ public class CsvColumnarIT extends CsvIT {
         // data contains deliberate duplicates in boolean MV fields (e.g. [false,true,true]).
         // SortedSetDocValues deduplicates those in standard mode while columnar may preserve them.
         "employees_incompatible",
-        // Contains an unsigned_long field that is not indexed in columnar mode; MV_INTERSECTS and
-        // MV_CONTAINS tests that use this field in a filter context fail with "Cannot search on
-        // field [unsigned_long] since it is not indexed".
-        "all_types_mv",
         // Contains semantic_text and dense_vector fields that are absent from columnar field_caps,
         // and has a short-typed field "short" that columnar normalises to long — both cause
         // expected column-type header mismatches vs csv-spec declared types.
@@ -158,10 +154,6 @@ public class CsvColumnarIT extends CsvIT {
         // cartesian_shape field with doc_values:false cannot be reconstructed from doc values
         // in columnar mode: "field [shape] cannot reconstruct _source from doc values".
         "cartesian_multipolygons_no_doc_values",
-        // Known columnar bug: STATS output aliases whose names conflict with existing index fields
-        // read from the wrong source, producing incorrect aggregate values.
-        // TODO: file an issue and reference it here.
-        "ul_logs",
         // index.mapping.index_disabled_by_default=true disables the inverted index for fields
         // without an explicit "index: true", so full-text (:) queries return different results
         // between standard and columnar modes.

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -337,17 +337,26 @@ public class UnsignedLongFieldMapper extends FieldMapper {
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            failIfNotIndexed();
+            failIfNotIndexedNorDocValuesFallback(context);
             Long longValue = parseTerm(value);
             if (longValue == null) {
                 return Queries.NO_DOCS_INSTANCE;
             }
-            return LongPoint.newExactQuery(name(), unsignedToSortableSignedLong(longValue));
+            long sortableValue = unsignedToSortableSignedLong(longValue);
+            if (indexType.hasPoints() == false) {
+                return SortedNumericDocValuesField.newSlowRangeQuery(name(), sortableValue, sortableValue);
+            }
+            return LongPoint.newExactQuery(name(), sortableValue);
         }
 
         @Override
         public Query termsQuery(Collection<?> values, SearchExecutionContext context) {
-            failIfNotIndexed();
+            failIfNotIndexedNorDocValuesFallback(context);
+            if (indexType.hasPoints() == false) {
+                // Without a point index the set has to be matched as a disjunction of per-value
+                // doc-values queries, which termQuery already builds.
+                return super.termsQuery(values, context);
+            }
             long[] lvalues = new long[values.size()];
             int upTo = 0;
             for (Object value : values) {
@@ -373,7 +382,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             boolean includeUpper,
             SearchExecutionContext context
         ) {
-            failIfNotIndexed();
+            failIfNotIndexedNorDocValuesFallback(context);
             long l = Long.MIN_VALUE;
             long u = Long.MAX_VALUE;
             if (lowerTerm != null) {
@@ -388,13 +397,18 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             }
             if (l > u) return Queries.NO_DOCS_INSTANCE;
 
-            Query query = LongPoint.newRangeQuery(name(), l, u);
-            if (hasDocValues()) {
-                Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
-                query = new IndexOrDocValuesQuery(query, dvQuery);
-                if (context.indexSortedOnField(name())) {
-                    query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
+            Query query;
+            if (indexType.hasPoints()) {
+                query = LongPoint.newRangeQuery(name(), l, u);
+                if (hasDocValues()) {
+                    Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+                    query = new IndexOrDocValuesQuery(query, dvQuery);
                 }
+            } else {
+                query = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+            }
+            if (hasDocValues() && context.indexSortedOnField(name())) {
+                query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
             }
             return query;
         }

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
@@ -7,7 +7,17 @@
 
 package org.elasticsearch.xpack.unsignedlong;
 
+import org.apache.lucene.document.Document;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.IndexType;
@@ -18,26 +28,29 @@ import org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.UnsignedLong
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.BIGINTEGER_2_64_MINUS_ONE;
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.UnsignedLongFieldType.parseLowerRangeTerm;
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.UnsignedLongFieldType.parseTerm;
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.UnsignedLongFieldType.parseUpperRangeTerm;
+import static org.hamcrest.Matchers.hasSize;
 
 public class UnsignedLongFieldTypeTests extends FieldTypeTestCase {
 
     public void testTermQuery() {
         UnsignedLongFieldType ft = new UnsignedLongFieldType("my_unsigned_long");
 
-        assertEquals(LongPoint.newExactQuery("my_unsigned_long", -9223372036854775808L), ft.termQuery(0, null));
-        assertEquals(LongPoint.newExactQuery("my_unsigned_long", 0L), ft.termQuery("9223372036854775808", null));
-        assertEquals(LongPoint.newExactQuery("my_unsigned_long", 9223372036854775807L), ft.termQuery("18446744073709551615", null));
+        assertEquals(LongPoint.newExactQuery("my_unsigned_long", -9223372036854775808L), ft.termQuery(0, MOCK_CONTEXT));
+        assertEquals(LongPoint.newExactQuery("my_unsigned_long", 0L), ft.termQuery("9223372036854775808", MOCK_CONTEXT));
+        assertEquals(LongPoint.newExactQuery("my_unsigned_long", 9223372036854775807L), ft.termQuery("18446744073709551615", MOCK_CONTEXT));
 
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termQuery(-1L, null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termQuery(10.5, null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termQuery("18446744073709551616", null));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termQuery(-1L, MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termQuery(10.5, MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termQuery("18446744073709551616", MOCK_CONTEXT));
 
-        expectThrows(NumberFormatException.class, () -> ft.termQuery("18incorrectnumber", null));
+        expectThrows(NumberFormatException.class, () -> ft.termQuery("18incorrectnumber", MOCK_CONTEXT));
     }
 
     public void testTermsQuery() {
@@ -45,13 +58,13 @@ public class UnsignedLongFieldTypeTests extends FieldTypeTestCase {
 
         assertEquals(
             LongPoint.newSetQuery("my_unsigned_long", -9223372036854775808L, 0L, 9223372036854775807L),
-            ft.termsQuery(List.of("0", "9223372036854775808", "18446744073709551615"), null)
+            ft.termsQuery(List.of("0", "9223372036854775808", "18446744073709551615"), MOCK_CONTEXT)
         );
 
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termsQuery(List.of(-9223372036854775808L, -1L), null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termsQuery(List.of("-0.5", "3.14", "18446744073709551616"), null));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termsQuery(List.of(-9223372036854775808L, -1L), MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.termsQuery(List.of("-0.5", "3.14", "18446744073709551616"), MOCK_CONTEXT));
 
-        expectThrows(NumberFormatException.class, () -> ft.termsQuery(List.of("18incorrectnumber"), null));
+        expectThrows(NumberFormatException.class, () -> ft.termsQuery(List.of("18incorrectnumber"), MOCK_CONTEXT));
     }
 
     public void testRangeQuery() {
@@ -69,33 +82,134 @@ public class UnsignedLongFieldTypeTests extends FieldTypeTestCase {
 
         assertEquals(
             LongPoint.newRangeQuery("my_unsigned_long", -9223372036854775808L, -9223372036854775808L),
-            ft.rangeQuery(-1L, 0L, true, true, null)
+            ft.rangeQuery(-1L, 0L, true, true, MOCK_CONTEXT)
         );
         assertEquals(
             LongPoint.newRangeQuery("my_unsigned_long", -9223372036854775808L, -9223372036854775808L),
-            ft.rangeQuery(0.0, 0.5, true, true, null)
+            ft.rangeQuery(0.0, 0.5, true, true, MOCK_CONTEXT)
         );
         assertEquals(
             LongPoint.newRangeQuery("my_unsigned_long", 0, 0),
-            ft.rangeQuery("9223372036854775807", "9223372036854775808", false, true, null)
+            ft.rangeQuery("9223372036854775807", "9223372036854775808", false, true, MOCK_CONTEXT)
         );
         assertEquals(
             LongPoint.newRangeQuery("my_unsigned_long", -9223372036854775808L, 9223372036854775806L),
-            ft.rangeQuery(null, "18446744073709551614.5", true, true, null)
+            ft.rangeQuery(null, "18446744073709551614.5", true, true, MOCK_CONTEXT)
         );
         assertEquals(
             LongPoint.newRangeQuery("my_unsigned_long", 9223372036854775807L, 9223372036854775807L),
-            ft.rangeQuery("18446744073709551615", "18446744073709551616", true, true, null)
+            ft.rangeQuery("18446744073709551615", "18446744073709551616", true, true, MOCK_CONTEXT)
         );
 
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(-1f, -0.5f, true, true, null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(-1L, 0L, true, false, null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(9223372036854775807L, 9223372036854775806L, true, true, null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery("18446744073709551616", "18446744073709551616", true, true, null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery("18446744073709551615", "18446744073709551616", false, true, null));
-        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(9223372036854775807L, 9223372036854775806L, true, true, null));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(-1f, -0.5f, true, true, MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(-1L, 0L, true, false, MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(9223372036854775807L, 9223372036854775806L, true, true, MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery("18446744073709551616", "18446744073709551616", true, true, MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery("18446744073709551615", "18446744073709551616", false, true, MOCK_CONTEXT));
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(9223372036854775807L, 9223372036854775806L, true, true, MOCK_CONTEXT));
 
-        expectThrows(NumberFormatException.class, () -> ft.rangeQuery("18incorrectnumber", "18incorrectnumber", true, true, null));
+        expectThrows(NumberFormatException.class, () -> ft.rangeQuery("18incorrectnumber", "18incorrectnumber", true, true, MOCK_CONTEXT));
+    }
+
+    /**
+     * Columnar index mode stores unsigned_long via doc values only, with no point index. Queries
+     * must fall back to doc values rather than failing as "not indexed".
+     */
+    private static UnsignedLongFieldType docValuesOnlyFieldType() {
+        return new UnsignedLongFieldType(
+            "my_unsigned_long",
+            IndexType.docValuesOnly(),
+            false,
+            null,
+            Collections.emptyMap(),
+            false,
+            null,
+            null,
+            false
+        );
+    }
+
+    public void testTermQueryOnDocValuesOnlyFieldUsesDocValues() {
+        UnsignedLongFieldType ft = docValuesOnlyFieldType();
+
+        assertEquals(
+            SortedNumericDocValuesField.newSlowRangeQuery("my_unsigned_long", -9223372036854775808L, -9223372036854775808L),
+            ft.termQuery(0, MOCK_CONTEXT)
+        );
+        assertEquals(
+            SortedNumericDocValuesField.newSlowRangeQuery("my_unsigned_long", 9223372036854775807L, 9223372036854775807L),
+            ft.termQuery("18446744073709551615", MOCK_CONTEXT)
+        );
+    }
+
+    public void testTermsQueryOnDocValuesOnlyFieldUsesDocValues() {
+        UnsignedLongFieldType ft = docValuesOnlyFieldType();
+
+        Query query = ft.termsQuery(List.of("0", "18446744073709551615"), MOCK_CONTEXT);
+
+        // Without a point index the set becomes a constant-score disjunction of per-value
+        // doc-values queries. Clause order is unspecified, so compare them as a set.
+        ConstantScoreQuery constantScoreQuery = asInstanceOf(ConstantScoreQuery.class, query);
+        BooleanQuery booleanQuery = asInstanceOf(BooleanQuery.class, constantScoreQuery.getQuery());
+        assertThat(booleanQuery.clauses(), hasSize(2));
+        Set<Query> clauses = booleanQuery.clauses().stream().map(BooleanClause::query).collect(Collectors.toSet());
+        assertEquals(
+            Set.of(
+                SortedNumericDocValuesField.newSlowRangeQuery("my_unsigned_long", -9223372036854775808L, -9223372036854775808L),
+                SortedNumericDocValuesField.newSlowRangeQuery("my_unsigned_long", 9223372036854775807L, 9223372036854775807L)
+            ),
+            clauses
+        );
+    }
+
+    public void testRangeQueryOnDocValuesOnlyFieldUsesDocValues() {
+        UnsignedLongFieldType ft = docValuesOnlyFieldType();
+
+        assertEquals(
+            SortedNumericDocValuesField.newSlowRangeQuery("my_unsigned_long", -9223372036854775808L, 9223372036854775807L),
+            ft.rangeQuery("0", "18446744073709551615", true, true, MOCK_CONTEXT)
+        );
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.rangeQuery(-1L, 0L, true, false, MOCK_CONTEXT));
+    }
+
+    public void testDocValuesOnlyQueriesMatchTheSameDocsAsPointQueries() throws IOException {
+        UnsignedLongFieldType docValuesOnly = docValuesOnlyFieldType();
+        UnsignedLongFieldType pointIndexed = new UnsignedLongFieldType("my_unsigned_long");
+
+        // Values chosen to span the signed-long wrap-around that unsigned_long encoding relies on.
+        List<String> values = List.of("0", "1", "9223372036854775807", "9223372036854775808", "18446744073709551615");
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+                for (String value : values) {
+                    // unsigned_long is stored shifted by 2^63, which is a flip of the sign bit.
+                    long sortable = Long.parseUnsignedLong(value) ^ Long.MIN_VALUE;
+                    Document document = new Document();
+                    document.add(new SortedNumericDocValuesField("my_unsigned_long", sortable));
+                    document.add(new LongPoint("my_unsigned_long", sortable));
+                    writer.addDocument(document);
+                }
+            }
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                IndexSearcher searcher = newSearcher(reader);
+                for (String value : values) {
+                    assertEquals(
+                        "termQuery for [" + value + "]",
+                        searcher.count(pointIndexed.termQuery(value, MOCK_CONTEXT)),
+                        searcher.count(docValuesOnly.termQuery(value, MOCK_CONTEXT))
+                    );
+                }
+                assertEquals(
+                    "termsQuery",
+                    searcher.count(pointIndexed.termsQuery(values, MOCK_CONTEXT)),
+                    searcher.count(docValuesOnly.termsQuery(values, MOCK_CONTEXT))
+                );
+                assertEquals(
+                    "rangeQuery over the full unsigned range",
+                    searcher.count(pointIndexed.rangeQuery("1", "18446744073709551615", true, true, MOCK_CONTEXT)),
+                    searcher.count(docValuesOnly.rangeQuery("1", "18446744073709551615", true, true, MOCK_CONTEXT))
+                );
+            }
+        }
     }
 
     public void testParseTermForTermQuery() {


### PR DESCRIPTION
`UnsignedLongFieldType` called `failIfNotIndexed()` in `termQuery`,
`termsQuery` and `rangeQuery`, so an `unsigned_long` field with doc
values but no point index rejected every query with "Cannot search on
field [x] since it is not indexed". Other numeric types fall back to
doc-values queries in that configuration.

This mirrors `NumberFieldMapper`: the guard becomes
`failIfNotIndexedNorDocValuesFallback(context)` and, when
`indexType().hasPoints()` is false, the query is built from
`SortedNumericDocValuesField` instead of `LongPoint`. Doc-values-only
queries are gated by `search.allow_expensive_queries`, as elsewhere.

This is the gap behind the `all_types_mv` and `ul_logs` exclusions in
`CsvColumnarIT`, which columnar mode hits because it disables point
indexing. Both datasets are un-excluded here. `ul_logs` had been
attributed to a STATS alias-shadowing bug, but no such bug reproduces.

Note this also affects standard indices: a field mapped
`index: false, doc_values: true` previously threw on term, terms and
range queries and now answers them from doc values.
