### PR TITLE
[8.19] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,24 @@
 
+# claude
+.claude
+
+# cursor
+.cursorrules
+
+# JetBrainsAI/Junie
+.junie/
+
+# Cursor rules and commands, if we want to implement project level rules and commands we'll want to remove these
+# These are based on the cursor docs here: https://cursor.com/docs/cli/using#rules
+# Prefix slash ensures these are only ignored at the same level as this file
+/.cursor/
+
+# codex
+.agent
+
+# pi agent harness
+.pi
+
 # intellij files
 .idea/
 *.iml


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/158549, in that while I was there working on that backport PR, there were some uncommitted changes that I didn't intentionally make (due to the existence of various tools on my machine).

This is just me mechanically backporting the section of `main`'s `.gitignore` that seemed relevant.