### PR TITLE
ESQL: Retry HTTP keep-alive disconnects on external resolve

### DIFF
--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObject.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObject.java
@@ -30,6 +30,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 
 /**
@@ -307,10 +308,7 @@ public final class HttpStorageObject extends AbstractMeteredStorageObject {
             (response, throwable) -> {
                 if (throwable != null) {
                     counters.addRequest(System.nanoTime() - startNanos, 0L);
-                    // Wrap with path context so stack-trace-only triage names the offending URL.
-                    // The original cause (CompletionException, body subscriber's IOException,
-                    // transport error, etc.) is preserved in the cause chain.
-                    listener.onFailure(new IOException("HTTP read failed for " + path, throwable));
+                    listener.onFailure(mapAsyncSendFailure(throwable));
                     return;
                 }
 
@@ -414,14 +412,7 @@ public final class HttpStorageObject extends AbstractMeteredStorageObject {
         HttpResponse.BodyHandler<T> bodyHandler,
         CheckedFunction<HttpResponse<T>, R, IOException> responseHandler
     ) throws IOException {
-        HttpRequest request = requestSupplier.apply(null);
-        try {
-            HttpResponse<T> response = client.send(request, bodyHandler);
-            return responseHandler.apply(response);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("HTTP request interrupted for " + path, e);
-        }
+        return responseHandler.apply(sendChecked(requestSupplier.apply(null), bodyHandler));
     }
 
     /**
@@ -437,14 +428,50 @@ public final class HttpStorageObject extends AbstractMeteredStorageObject {
         HttpResponse.BodyHandler<T> bodyHandler,
         CheckedFunction<HttpResponse<T>, R, IOException> responseHandler
     ) throws IOException {
-        HttpRequest request = requestSupplier.get();
+        return responseHandler.apply(sendChecked(requestSupplier.get(), bodyHandler));
+    }
+
+    /**
+     * Sends {@code request} and types a transport fault the same way
+     * {@link HttpTransientTypingInputStream} types a mid-body drop. The JDK {@code HttpClient}
+     * reuses HTTP/1.1 keep-alive connections; when the peer has already closed one, {@code send()}
+     * throws a plain {@link IOException} or {@link IllegalStateException} with message {@code closed}
+     * before any response body exists. Those are retryable transport drops (a fresh connection
+     * succeeds), not client errors, so they become {@link ExternalUnavailableException}.
+     * Interrupt stays an {@link IOException} so it is not retried. Status-bearing failures are
+     * handled by the caller after a successful send.
+     */
+    private <T> HttpResponse<T> sendChecked(HttpRequest request, HttpResponse.BodyHandler<T> bodyHandler) throws IOException {
         try {
-            HttpResponse<T> response = client.send(request, bodyHandler);
-            return responseHandler.apply(response);
+            return client.send(request, bodyHandler);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("HTTP request interrupted for " + path, e);
+        } catch (IOException e) {
+            throw typeTransportFailure(e);
+        } catch (IllegalStateException e) {
+            throw typeTransportFailure(e);
         }
+    }
+
+    /**
+     * Types an async {@code sendAsync} failure. Unwraps {@link CompletionException} so the same
+     * closed-keep-alive {@link IOException} / {@link IllegalStateException} that {@link #sendChecked}
+     * sees is classified here too; other faults keep the path-prefixed {@link IOException} wrapper.
+     */
+    private Exception mapAsyncSendFailure(Throwable throwable) {
+        Throwable cause = throwable instanceof CompletionException && throwable.getCause() != null ? throwable.getCause() : throwable;
+        if (cause instanceof ExternalUnavailableException eue) {
+            return eue;
+        }
+        if (cause instanceof IOException || cause instanceof IllegalStateException) {
+            return typeTransportFailure((Exception) cause);
+        }
+        return new IOException("HTTP read failed for " + path, throwable);
+    }
+
+    private ExternalUnavailableException typeTransportFailure(Exception e) {
+        return new ExternalUnavailableException(false, e, "transient read failure for [{}]", path);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObjectTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObjectMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -25,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
@@ -129,6 +131,66 @@ public class HttpStorageObjectTests extends ESTestCase {
     public void testExistsOnNotFoundReturnsFalse() throws Exception {
         HttpStorageObject object = objectWithNotFoundResponse();
         assertFalse(object.exists());
+    }
+
+    /**
+     * The JDK {@code HttpClient} surfaces a reused keep-alive connection that the peer already closed as a
+     * plain {@link IOException}{@code ("closed")} from {@code send()}, before any response body exists.
+     * That open-phase fault must be typed like the mid-read wrapper so the retry layer re-opens a fresh
+     * connection instead of failing resolve as a 500.
+     */
+    public void testSendClosedIOExceptionIsTypedTransient() throws Exception {
+        HttpClient mockClient = mock(HttpClient.class);
+        when(mockClient.send(any(), any())).thenThrow(new IOException("closed"));
+        HttpStorageObject object = new HttpStorageObject(
+            mockClient,
+            StoragePath.of("https://example.com/file.parquet"),
+            HttpConfiguration.defaults()
+        );
+
+        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, object::length);
+        assertFalse("a closed keep-alive is a transport drop, not a throttle", eue.throttling());
+        assertThat(eue.getCause(), instanceOf(IOException.class));
+        assertThat(eue.getCause().getMessage(), containsString("closed"));
+    }
+
+    public void testSendClosedIllegalStateExceptionIsTypedTransient() throws Exception {
+        HttpClient mockClient = mock(HttpClient.class);
+        when(mockClient.send(any(), any())).thenThrow(new IllegalStateException("closed"));
+        HttpStorageObject object = new HttpStorageObject(
+            mockClient,
+            StoragePath.of("https://example.com/file.parquet"),
+            HttpConfiguration.defaults()
+        );
+
+        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, object::newStream);
+        assertFalse(eue.throttling());
+        assertThat(eue.getCause(), instanceOf(IllegalStateException.class));
+        assertThat(eue.getCause().getMessage(), containsString("closed"));
+    }
+
+    public void testAsyncSendClosedIOExceptionIsTypedTransient() throws Exception {
+        HttpClient mockClient = mock(HttpClient.class);
+        doReturn(CompletableFuture.failedFuture(new CompletionException(new IOException("closed")))).when(mockClient)
+            .sendAsync(any(), any());
+        HttpStorageObject object = new HttpStorageObject(
+            mockClient,
+            StoragePath.of("https://example.com/file.parquet"),
+            HttpConfiguration.defaults()
+        );
+
+        AtomicReference<Exception> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        object.readBytesAsync(0, 100, FACTORY, Runnable::run, ActionListener.wrap(result -> latch.countDown(), e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertThat(error.get(), instanceOf(ExternalUnavailableException.class));
+        ExternalUnavailableException eue = (ExternalUnavailableException) error.get();
+        assertFalse(eue.throttling());
+        assertThat(eue.getCause(), instanceOf(IOException.class));
     }
 
     public void testReadBytesAsync206UsesBodyHandler() throws Exception {


### PR DESCRIPTION
# ESQL: Retry HTTP keep-alive disconnects on external resolve

## Problem
HTTP external source resolve can fail with `500` `Failed to resolve external source [...]: closed` when the JDK `HttpClient` reuses a keep-alive connection the peer already dropped. That open-phase `send()` / `sendAsync()` fault arrived as a bare `IOException` or `IllegalStateException`, so `RetryPolicy` never retried and the query failed.

## Fix
- Type those transport failures as non-throttling `ExternalUnavailableException`, matching the existing mid-read HTTP wrapper.
- Interrupt stays an `IOException` so it is not retried. HTTP status errors are unchanged.

## Tests
Unit tests cover `IOException("closed")` and `IllegalStateException("closed")` on sync HEAD/GET and async range reads. The six previously muted `ExternalDistributedSpecIT` HTTP methods pass against this branch.

Closes https://github.com/elastic/elasticsearch-serverless/issues/7217
Closes https://github.com/elastic/elasticsearch-serverless/issues/7305
Closes https://github.com/elastic/elasticsearch-serverless/issues/7357
Closes https://github.com/elastic/elasticsearch-serverless/issues/7412
Closes https://github.com/elastic/elasticsearch-serverless/issues/7466
Closes https://github.com/elastic/elasticsearch-serverless/issues/7475
