### PR TITLE
[8.19] msearch/template parity with msearch: memory bounds, cancellation, metrics (#157642)

### DIFF
--- a/docs/changelog/157642.yaml
+++ b/docs/changelog/157642.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 157642
+summary: "Msearch/template parity with msearch: memory bounds, cancellation, metrics"
+type: enhancement

--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -10,26 +10,39 @@
 package org.elasticsearch.script.mustache;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.mustache.MultiSearchTemplateResponse.Item;
 import org.elasticsearch.search.DummyQueryParserPlugin;
 import org.elasticsearch.search.FailBeforeCurrentVersionQueryBuilder;
 import org.elasticsearch.search.SearchService;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.test.AbstractSearchCancellationTestCase;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
@@ -38,6 +51,7 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
@@ -45,7 +59,12 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(MustachePlugin.class, DummyQueryParserPlugin.class);
+        return List.of(MustachePlugin.class, DummyQueryParserPlugin.class, AbstractSearchCancellationTestCase.ScriptedBlockPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false; // enable real HTTP for REST-level header and channel-close tests
     }
 
     @Override
@@ -180,6 +199,160 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
             assertNull(response5.getResponse());
             assertThat(response5.getFailure(), instanceOf(XContentParseException.class));
         });
+    }
+
+    /**
+     * Regression test: a large msearch/template request must not cause OOM on the coordinator.
+     * <p>
+     * The action charges the REQUEST circuit breaker for each rendered template source held in
+     * memory before the inner searches execute. With a tight breaker, the first large render
+     * trips it and all remaining slots receive {@link CircuitBreakingException} item failures
+     * rather than silently accumulating until the node runs out of heap.
+     * <p>
+     * Render estimate = {@code 512 + source.length() + 2 × serialised(SearchSourceBuilder)}.
+     * The ~16 KB template body produces a serialised builder of comparable size, so the total
+     * estimate is well above the 10 KB breaker limit. The first render therefore trips; every
+     * subsequent slot is filled via the {@code renderCbe} fast-path without issuing any searches.
+     */
+    public void testLargeMsearchTemplateDoesNotOom() throws Exception {
+        createIndex("large-msearch");
+
+        // Build a ~16 KB rendered source (2 000 stored_fields entries, no template variables).
+        // stored_fields is a plain string array that SearchSourceBuilder accepts without any
+        // named-XContent extensions, so it round-trips cleanly through render → parse → execute.
+        StringBuilder sb = new StringBuilder("{\"size\":0,\"stored_fields\":[");
+        for (int j = 0; j < 2_000; j++) {
+            if (j > 0) sb.append(",");
+            sb.append("\"f").append(j).append("\"");
+        }
+        sb.append("]}");
+        String largeTemplate = sb.toString();
+
+        // Tighten the REQUEST breaker to 1 byte so that any positive charge trips it immediately,
+        // regardless of any pre-existing state in the breaker. The render estimate for the first
+        // item alone is 512 B (RENDER_BASE_OVERHEAD), which already exceeds this limit. Using
+        // "1b" instead of a KB-range value avoids races where the breaker's accumulated bytes
+        // from concurrent or preceding operations happen to leave just enough room under a larger
+        // limit for the charge to succeed.
+        updateClusterSettings(Settings.builder().put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "1b"));
+        try {
+            int numRequests = 20;
+            MultiSearchTemplateRequest multiRequest = new MultiSearchTemplateRequest();
+            for (int i = 0; i < numRequests; i++) {
+                SearchTemplateRequest req = new SearchTemplateRequest();
+                req.setRequest(new SearchRequest("large-msearch"));
+                req.setScriptType(ScriptType.INLINE);
+                req.setScript(largeTemplate);
+                multiRequest.add(req);
+            }
+
+            assertResponse(client().execute(MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION, multiRequest), response -> {
+                assertThat(response.getResponses().length, equalTo(numRequests));
+                // Once the first render trips the breaker, fillRemainingWithCbe fills every
+                // subsequent slot via the renderCbe fast-path. All slots must be CBE failures —
+                // a weaker "cbeCount > 0" check would miss a regression where only the first
+                // slot is a CBE and the rest execute as real searches.
+                for (Item item : response.getResponses()) {
+                    assertNotNull("every slot must be populated", item);
+                    assertTrue("every slot must be a CBE failure", item.isFailure());
+                    assertThat(item.getFailure(), instanceOf(CircuitBreakingException.class));
+                }
+            });
+        } finally {
+            updateClusterSettings(
+                Settings.builder().putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey())
+            );
+        }
+    }
+
+    /**
+     * Verifies end-to-end wiring of {@link MultiSearchTemplateResponse#mergeDirectoryMetrics()} through
+     * {@code wrapWithSearchMetricsHeader} in the REST action: when directory metrics are enabled (via
+     * {@link Store#DIRECTORY_METRICS_FEATURE_FLAG}), a real {@code _msearch/template} search emits exactly
+     * one {@code X-Elasticsearch-Search-Metrics} response header.
+     */
+    public void testSearchMetricsResponseHeader() throws Exception {
+        assumeTrue("directory metrics feature flag must be enabled", Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled());
+
+        createIndex("hdr-test");
+        prepareIndex("hdr-test").setId("1").setSource("field", "value").get();
+        refresh("hdr-test");
+
+        Request req = new Request("POST", "/_msearch/template");
+        req.setJsonEntity("{\"index\":\"hdr-test\"}\n" + "{\"source\":\"{\\\"query\\\":{\\\"match_all\\\":{}}}\",\"params\":{}}\n");
+        Response resp = getRestClient().performRequest(req);
+        long headerCount = Arrays.stream(resp.getHeaders())
+            .filter(h -> h.getName().equalsIgnoreCase(RestActions.SEARCH_METRICS_RESPONSE_HEADER))
+            .count();
+        assertThat("msearch/template must emit exactly one consolidated search-metrics header", headerCount, equalTo(1L));
+    }
+
+    /**
+     * Verifies that cancelling the outer {@code _msearch/template} task does not leave the outer
+     * listener hanging indefinitely. The outer response must be delivered (no deadlock) after
+     * cancellation regardless of whether the shard-level scripts complete before or after the
+     * cancel is processed.
+     *
+     * <p>Note: whether individual items come back as failures or successes depends on the race
+     * between task-cancellation propagation and the shard completing its script. The
+     * parent-task linkage itself is verified by {@code testParentTaskSetOnInnerMultiSearch}.
+     */
+    public void testCancellationPropagatesFromParentToInnerSearches() throws Exception {
+        createIndex("cancel-test");
+        for (int i = 0; i < 5; i++) {
+            prepareIndex("cancel-test").setId(Integer.toString(i)).setSource("field", "value").get();
+        }
+        refresh("cancel-test");
+
+        List<AbstractSearchCancellationTestCase.ScriptedBlockPlugin> plugins = new ArrayList<>();
+        for (PluginsService ps : internalCluster().getInstances(PluginsService.class)) {
+            ps.filterPlugins(AbstractSearchCancellationTestCase.ScriptedBlockPlugin.class).forEach(p -> {
+                p.reset();
+                p.enableBlock();
+                plugins.add(p);
+            });
+        }
+
+        // Arm the latch before submitting so there is no race on setBeforeExecution.
+        java.util.concurrent.CountDownLatch hitLatch = new java.util.concurrent.CountDownLatch(1);
+        for (AbstractSearchCancellationTestCase.ScriptedBlockPlugin plugin : plugins) {
+            plugin.setBeforeExecution(hitLatch::countDown);
+        }
+
+        String blockingTemplate = "{\"query\":{\"script\":{\"script\":{\"source\":\""
+            + AbstractSearchCancellationTestCase.ScriptedBlockPlugin.SEARCH_BLOCK_SCRIPT_NAME
+            + "\",\"lang\":\"mockscript\"}}}}";
+
+        MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+        SearchTemplateRequest str = new SearchTemplateRequest();
+        str.setRequest(new SearchRequest("cancel-test"));
+        str.setScriptType(ScriptType.INLINE);
+        str.setScript(blockingTemplate);
+        request.add(str);
+
+        ActionFuture<MultiSearchTemplateResponse> future = client().execute(MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION, request);
+
+        // Wait until at least one shard has entered the blocking script.
+        assertTrue("timed out waiting for shard to be blocked", hitLatch.await(10, TimeUnit.SECONDS));
+
+        // Cancel the outer _msearch/template task — propagates to inner searches via parent-task linkage.
+        ListTasksResponse listResp = clusterAdmin().prepareListTasks().setActions(MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION.name()).get();
+        assertThat("outer msearch/template task must be present", listResp.getTasks(), hasSize(1));
+        TaskInfo outerTask = listResp.getTasks().get(0);
+        clusterAdmin().prepareCancelTasks().setTargetTaskId(outerTask.taskId()).get();
+
+        // Unblock the shard-level scripts so the search threads can complete.
+        for (AbstractSearchCancellationTestCase.ScriptedBlockPlugin plugin : plugins) {
+            plugin.disableBlock();
+        }
+
+        // The outer response must be delivered — cancellation must not leave the listener unreachable.
+        MultiSearchTemplateResponse response = future.actionGet(30, TimeUnit.SECONDS);
+        try {
+            assertThat(response.getResponses().length, equalTo(1));
+        } finally {
+            response.decRef();
+        }
     }
 
     /**

--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -230,7 +230,7 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
         // can be negative from prior estimation releases, allowing a small render charge to
         // slip under a 1b limit (used + charge ≤ 0 + charge, which may still be ≤ 1).
         final long preCharge = 1_000_000_000L;
-        Collection<CircuitBreakerService> breakerServices = internalCluster().getInstances(CircuitBreakerService.class);
+        Iterable<CircuitBreakerService> breakerServices = internalCluster().getInstances(CircuitBreakerService.class);
         for (CircuitBreakerService bs : breakerServices) {
             bs.getBreaker(org.elasticsearch.common.breaker.CircuitBreaker.REQUEST).addWithoutBreaking(preCharge);
         }

--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -14,17 +14,14 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.store.Store;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
-import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.mustache.MultiSearchTemplateResponse.Item;
 import org.elasticsearch.search.DummyQueryParserPlugin;
@@ -228,12 +225,15 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
         sb.append("]}");
         String largeTemplate = sb.toString();
 
-        // Tighten the REQUEST breaker to 1 byte so that any positive charge trips it immediately,
-        // regardless of any pre-existing state in the breaker. The render estimate for the first
-        // item alone is 512 B (RENDER_BASE_OVERHEAD), which already exceeds this limit. Using
-        // "1b" instead of a KB-range value avoids races where the breaker's accumulated bytes
-        // from concurrent or preceding operations happen to leave just enough room under a larger
-        // limit for the charge to succeed.
+        // Pre-charge every node's REQUEST breaker with 1 GB so that the used counter is well
+        // above zero before we set the limit to 1b. Without this, the breaker's used counter
+        // can be negative from prior estimation releases, allowing a small render charge to
+        // slip under a 1b limit (used + charge ≤ 0 + charge, which may still be ≤ 1).
+        final long preCharge = 1_000_000_000L;
+        Collection<CircuitBreakerService> breakerServices = internalCluster().getInstances(CircuitBreakerService.class);
+        for (CircuitBreakerService bs : breakerServices) {
+            bs.getBreaker(org.elasticsearch.common.breaker.CircuitBreaker.REQUEST).addWithoutBreaking(preCharge);
+        }
         updateClusterSettings(Settings.builder().put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "1b"));
         try {
             int numRequests = 20;
@@ -262,29 +262,10 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
             updateClusterSettings(
                 Settings.builder().putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey())
             );
+            for (CircuitBreakerService bs : breakerServices) {
+                bs.getBreaker(org.elasticsearch.common.breaker.CircuitBreaker.REQUEST).addWithoutBreaking(-preCharge);
+            }
         }
-    }
-
-    /**
-     * Verifies end-to-end wiring of {@link MultiSearchTemplateResponse#mergeDirectoryMetrics()} through
-     * {@code wrapWithSearchMetricsHeader} in the REST action: when directory metrics are enabled (via
-     * {@link Store#DIRECTORY_METRICS_FEATURE_FLAG}), a real {@code _msearch/template} search emits exactly
-     * one {@code X-Elasticsearch-Search-Metrics} response header.
-     */
-    public void testSearchMetricsResponseHeader() throws Exception {
-        assumeTrue("directory metrics feature flag must be enabled", Store.DIRECTORY_METRICS_FEATURE_FLAG.isEnabled());
-
-        createIndex("hdr-test");
-        prepareIndex("hdr-test").setId("1").setSource("field", "value").get();
-        refresh("hdr-test");
-
-        Request req = new Request("POST", "/_msearch/template");
-        req.setJsonEntity("{\"index\":\"hdr-test\"}\n" + "{\"source\":\"{\\\"query\\\":{\\\"match_all\\\":{}}}\",\"params\":{}}\n");
-        Response resp = getRestClient().performRequest(req);
-        long headerCount = Arrays.stream(resp.getHeaders())
-            .filter(h -> h.getName().equalsIgnoreCase(RestActions.SEARCH_METRICS_RESPONSE_HEADER))
-            .count();
-        assertThat("msearch/template must emit exactly one consolidated search-metrics header", headerCount, equalTo(1L));
     }
 
     /**

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
@@ -18,6 +18,9 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -26,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
@@ -38,6 +42,16 @@ public class MultiSearchTemplateRequest extends UntypedActionRequest implements 
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosedIgnoreThrottled();
 
     public MultiSearchTemplateRequest() {}
+
+    @Override
+    public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+        return new CancellableTask(id, type, action, "requests[" + requests().size() + "]", parentTaskId, headers) {
+            @Override
+            public boolean shouldCancelChildrenOnCancellation() {
+                return true;
+            }
+        };
+    }
 
     MultiSearchTemplateRequest(StreamInput in) throws IOException {
         super(in);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -13,7 +13,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -17,7 +17,8 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
+import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 
@@ -63,9 +64,19 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (client.threadPool() != null && client.threadPool().getThreadContext() != null) {
+            client.threadPool().getThreadContext().setErrorTraceTransportHeader(request);
+        }
         MultiSearchTemplateRequest multiRequest = parseRequest(request, allowExplicitIndex);
-        return channel -> client.execute(MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION, multiRequest, new RestToXContentListener<>(channel));
+        return channel -> {
+            final RestCancellableNodeClient cancellableClient = new RestCancellableNodeClient(client, request.getHttpChannel());
+            cancellableClient.execute(
+                MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION,
+                multiRequest,
+                new RestRefCountedChunkedToXContentListener<>(channel)
+            );
+        };
     }
 
     /**

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -71,11 +71,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
         MultiSearchTemplateRequest multiRequest = parseRequest(request, allowExplicitIndex);
         return channel -> {
             final RestCancellableNodeClient cancellableClient = new RestCancellableNodeClient(client, request.getHttpChannel());
-            cancellableClient.execute(
-                MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION,
-                multiRequest,
-                new RestToXContentListener<>(channel)
-            );
+            cancellableClient.execute(MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION, multiRequest, new RestToXContentListener<>(channel));
         };
     }
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -18,7 +18,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
-import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
+import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 
@@ -74,7 +74,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
             cancellableClient.execute(
                 MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION,
                 multiRequest,
-                new RestRefCountedChunkedToXContentListener<>(channel)
+                new RestToXContentListener<>(channel)
             );
         };
     }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -16,17 +16,28 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.CountingStreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.usage.UsageService;
@@ -34,22 +45,50 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.action.search.MultiSearchRequest.MAX_CONCURRENT_SEARCH_REQUESTS_DEFAULT;
 import static org.elasticsearch.script.mustache.TransportSearchTemplateAction.convert;
 
 public class TransportMultiSearchTemplateAction extends HandledTransportAction<MultiSearchTemplateRequest, MultiSearchTemplateResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportMultiSearchTemplateAction.class);
 
+    private static final String MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL = ChildMemoryCircuitBreaker.CATEGORY_MSEARCH + "[render]";
+    private static final String MSEARCH_TEMPLATE_RESPONSE_BREAKER_LABEL = ChildMemoryCircuitBreaker.CATEGORY_MSEARCH + "[response]";
+    private static final String MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL = ChildMemoryCircuitBreaker.CATEGORY_MSEARCH + "[failure]";
+
+    /**
+     * Heap-overhead factor applied to serialised byte counts.
+     * Mirrors {@code TransportMultiSearchAction.SERIALISED_BYTES_HEAP_OVERHEAD_FACTOR}.
+     */
+    private static final long RENDER_HEAP_OVERHEAD_FACTOR = 2L;
+
+    /**
+     * Fixed per-render overhead for the {@link SearchTemplateResponse} wrapper object.
+     * Mirrors {@code TransportMultiSearchAction.BASE_RESPONSE_OVERHEAD}.
+     */
+    private static final long RENDER_BASE_OVERHEAD = 512L;
+
+    /**
+     * Wire-byte fallback used when {@link SearchSourceBuilder} serialisation raises an exception.
+     * Mirrors {@code TransportMultiSearchAction.SERIALISED_BYTES_FAILURE_FALLBACK}.
+     */
+    private static final long SERIALISED_BYTES_FAILURE_FALLBACK = 1024L;
+
     private final ScriptService scriptService;
     private final NamedXContentRegistry xContentRegistry;
     private final Predicate<NodeFeature> clusterSupportsFeature;
     private final NodeClient client;
     private final SearchUsageHolder searchUsageHolder;
+    private final int allocatedProcessors;
+    private final ClusterService clusterService;
+    private final CircuitBreaker circuitBreaker;
 
     @Inject
     public TransportMultiSearchTemplateAction(
+        Settings settings,
         TransportService transportService,
         ActionFilters actionFilters,
         ScriptService scriptService,
@@ -57,7 +96,8 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
         NodeClient client,
         UsageService usageService,
         ClusterService clusterService,
-        FeatureService featureService
+        FeatureService featureService,
+        CircuitBreakerService circuitBreakerService
     ) {
         super(
             MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION.name(),
@@ -74,19 +114,79 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
         };
         this.client = client;
         this.searchUsageHolder = usageService.getSearchUsageHolder();
+        this.allocatedProcessors = EsExecutors.allocatedProcessors(settings);
+        this.clusterService = clusterService;
+        this.circuitBreaker = circuitBreakerService.getBreaker(CircuitBreaker.REQUEST);
     }
 
     @Override
     protected void doExecute(Task task, MultiSearchTemplateRequest request, ActionListener<MultiSearchTemplateResponse> listener) {
-        List<Integer> originalSlots = new ArrayList<>();
+        int maxConcurrent = request.maxConcurrentSearchRequests() != MAX_CONCURRENT_SEARCH_REQUESTS_DEFAULT
+            ? request.maxConcurrentSearchRequests()
+            : TransportMultiSearchAction.defaultMaxConcurrentSearches(allocatedProcessors, clusterService.state());
+
+        int n = request.requests().size();
+        MultiSearchTemplateResponse.Item[] items = new MultiSearchTemplateResponse.Item[n];
+        // Three separate accumulators — each released under the same label it was charged with so
+        // that ChildMemoryCircuitBreaker's per-category gauge stays balanced.
+        long[] renderBytesPerItem = new long[n]; // per-slot render charge; released when the slot is finalized
+        long[] renderBytesCharged = { 0L };    // running total released by runAfter (remainder after early releases)
+        long[] responseBytesCharged = { 0L };  // charged/released under [response] (success hits only)
+        long[] failureBytesCharged = { 0L };   // charged/released under [failure] (errors and substitutes)
+        long startTimeNanos = System.nanoTime();
+
+        ActionListener<MultiSearchTemplateResponse> breakerReleasingListener = ActionListener.runAfter(listener, () -> {
+            if (renderBytesCharged[0] > 0) {
+                circuitBreaker.addWithoutBreaking(-renderBytesCharged[0], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+            }
+            if (responseBytesCharged[0] > 0) {
+                circuitBreaker.addWithoutBreaking(-responseBytesCharged[0], MSEARCH_TEMPLATE_RESPONSE_BREAKER_LABEL);
+            }
+            if (failureBytesCharged[0] > 0) {
+                circuitBreaker.addWithoutBreaking(-failureBytesCharged[0], MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
+            }
+        });
+        ActionListener<MultiSearchTemplateResponse> safeListener = new ActionListener<>() {
+            @Override
+            public void onResponse(MultiSearchTemplateResponse r) {
+                breakerReleasingListener.onResponse(r);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                for (int i = 0; i < items.length; i++) {
+                    if (items[i] != null && items[i].getResponse() != null) {
+                        items[i].getResponse().decRef();
+                        items[i] = null;
+                    }
+                }
+                breakerReleasingListener.onFailure(e);
+            }
+        };
+
+        // Render all templates. Simulate-only and render-error slots are filled here;
+        // searchable slots collect their SearchRequest for the single multiSearch call below.
+        List<Integer> searchSlots = new ArrayList<>(n);
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         multiSearchRequest.indicesOptions(request.indicesOptions());
-        if (request.maxConcurrentSearchRequests() != 0) {
-            multiSearchRequest.maxConcurrentSearchRequests(request.maxConcurrentSearchRequests());
-        }
+        multiSearchRequest.maxConcurrentSearchRequests(maxConcurrent);
 
-        MultiSearchTemplateResponse.Item[] items = new MultiSearchTemplateResponse.Item[request.requests().size()];
-        for (int i = 0; i < items.length; i++) {
+        // One CountingStreamOutput reused across all renders — no per-item buffer allocation.
+        CountingStreamOutput counter = new CountingStreamOutput();
+
+        CircuitBreakingException renderCbe = null; // set on first render-phase CBE; fills subsequent slots
+        for (int i = 0; i < n; i++) {
+            // Cooperative cancellation check: MultiSearchTemplateRequest always creates a CancellableTask.
+            if (((CancellableTask) task).isCancelled()) {
+                safeListener.onFailure(new TaskCancelledException("request cancelled"));
+                return;
+            }
+            if (renderCbe != null) {
+                // A prior item's render tripped the breaker — fill remaining slots without further work.
+                items[i] = new MultiSearchTemplateResponse.Item(null, renderCbe);
+                continue;
+            }
+
             SearchTemplateRequest searchTemplateRequest = request.requests().get(i);
             SearchTemplateResponse searchTemplateResponse = new SearchTemplateResponse();
             SearchRequest searchRequest;
@@ -107,29 +207,235 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                 }
                 continue;
             }
+
+            // Charge for the rendered source and parsed builder retained in items[] until the response
+            // is sent. Aborted slots (CBE or failure) release early when their SearchTemplateResponse
+            // is decRefed; successful slots release via runAfter when the outer response is freed.
+            long renderBytes = estimateRenderBytes(searchTemplateResponse, searchRequest, counter);
+            try {
+                circuitBreaker.addEstimateBytesAndMaybeBreak(renderBytes, MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                renderBytesPerItem[i] = renderBytes;
+                renderBytesCharged[0] += renderBytes;
+            } catch (CircuitBreakingException cbe) {
+                searchTemplateResponse.decRef();
+                items[i] = new MultiSearchTemplateResponse.Item(null, cbe);
+                long subBytes = TransportMultiSearchAction.estimateFailureBytes(cbe);
+                circuitBreaker.addWithoutBreaking(subBytes, MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
+                failureBytesCharged[0] += subBytes;
+                // Release render bytes for already-queued slots — their sources are freed by fillRemainingWithCbe.
+                for (int slot : searchSlots) {
+                    circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                    renderBytesCharged[0] -= renderBytesPerItem[slot];
+                }
+                // Abort: all search slots queued so far cannot run — replace them with CBE.
+                fillRemainingWithCbe(items, searchSlots, 0, cbe);
+                searchSlots.clear();
+                renderCbe = cbe;
+                continue;
+            }
+
             items[i] = new MultiSearchTemplateResponse.Item(searchTemplateResponse, null);
             if (searchRequest != null) {
                 multiSearchRequest.add(searchRequest);
-                originalSlots.add(i);
+                searchSlots.add(i);
             }
         }
 
-        client.multiSearch(multiSearchRequest, listener.delegateFailureAndWrap((l, r) -> {
-            for (int i = 0; i < r.getResponses().length; i++) {
-                MultiSearchResponse.Item item = r.getResponses()[i];
-                int originalSlot = originalSlots.get(i);
-                if (item.isFailure()) {
-                    var existing = items[originalSlot];
-                    if (existing.getResponse() != null) {
-                        existing.getResponse().decRef();
+        if (searchSlots.isEmpty()) {
+            finishResponse(items, startTimeNanos, safeListener);
+            return;
+        }
+
+        multiSearchRequest.setParentTask(client.getLocalNodeId(), task.getId());
+        client.multiSearch(multiSearchRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(MultiSearchResponse multiSearchResp) {
+                // NOTE: the inner _msearch still holds its own REQUEST-breaker reservation for these
+                // responses during this callback — its runAfter releases only after our listener
+                // returns. We therefore add our own charge for the same bytes we are about to incRef,
+                // causing a transient ~2× peak. This is intentional: after the callback the inner
+                // release drops the duplicate, leaving only our charge until the outer listener
+                // completes. The alternative (handing off the inner reservation) would require
+                // coupling to TransportMultiSearchAction internals.
+                try {
+                    for (int i = 0; i < multiSearchResp.getResponses().length; i++) {
+                        MultiSearchResponse.Item item = multiSearchResp.getResponses()[i];
+                        int slot = searchSlots.get(i);
+                        if (item.isFailure()) {
+                            if (items[slot].getResponse() != null) {
+                                items[slot].getResponse().decRef();
+                            }
+                            circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                            renderBytesCharged[0] -= renderBytesPerItem[slot];
+                            items[slot] = new MultiSearchTemplateResponse.Item(null, item.getFailure());
+                            long failureBytes = TransportMultiSearchAction.estimateFailureBytes(item.getFailure());
+                            try {
+                                circuitBreaker.addEstimateBytesAndMaybeBreak(failureBytes, MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
+                                failureBytesCharged[0] += failureBytes;
+                            } catch (CircuitBreakingException cbe) {
+                                items[slot] = new MultiSearchTemplateResponse.Item(null, cbe);
+                                abortResponsePhase(
+                                    items,
+                                    searchSlots,
+                                    i + 1,
+                                    multiSearchResp.getResponses().length,
+                                    renderBytesPerItem,
+                                    renderBytesCharged,
+                                    failureBytesCharged,
+                                    cbe
+                                );
+                                break;
+                            }
+                        } else {
+                            // Charge breaker BEFORE incRef/setResponse so cleanup is safe if breaker throws.
+                            long responseBytes = TransportMultiSearchAction.estimateActualBytes(item.getResponse());
+                            try {
+                                circuitBreaker.addEstimateBytesAndMaybeBreak(responseBytes, MSEARCH_TEMPLATE_RESPONSE_BREAKER_LABEL);
+                            } catch (CircuitBreakingException cbe) {
+                                items[slot].getResponse().decRef();
+                                items[slot] = new MultiSearchTemplateResponse.Item(null, cbe);
+                                circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                                renderBytesCharged[0] -= renderBytesPerItem[slot];
+                                abortResponsePhase(
+                                    items,
+                                    searchSlots,
+                                    i + 1,
+                                    multiSearchResp.getResponses().length,
+                                    renderBytesPerItem,
+                                    renderBytesCharged,
+                                    failureBytesCharged,
+                                    cbe
+                                );
+                                break;
+                            }
+                            responseBytesCharged[0] += responseBytes;
+                            item.getResponse().incRef(); // incRef before storing so the reference is always reachable
+                            items[slot].getResponse().setResponse(item.getResponse());
+                            // render bytes released by runAfter when the outer response is decRefed
+                        }
                     }
-                    items[originalSlot] = new MultiSearchTemplateResponse.Item(null, item.getFailure());
-                } else {
-                    items[originalSlot].getResponse().setResponse(item.getResponse());
-                    item.getResponse().incRef();
+                } catch (Exception e) {
+                    safeListener.onFailure(e);
+                    return;
                 }
+                finishResponse(items, startTimeNanos, safeListener);
             }
-            ActionListener.respondAndRelease(l, new MultiSearchTemplateResponse(items, r.getTook().millis()));
-        }));
+
+            @Override
+            public void onFailure(Exception e) {
+                safeListener.onFailure(e);
+            }
+        });
     }
+
+    /**
+     * Estimates heap bytes retained by one rendered item while it sits in {@code items[]} waiting
+     * to be sent as the HTTP response.
+     * <ul>
+     *   <li>{@link #RENDER_BASE_OVERHEAD} — fixed wrapper overhead for the {@link SearchTemplateResponse}.</li>
+     *   <li>{@code source.length()} — raw bytes of the retained {@link BytesReference}; counted once
+     *       since it is already a byte array view, not expanded into Java objects.</li>
+     *   <li>For a real search: {@link #RENDER_HEAP_OVERHEAD_FACTOR} × serialised
+     *       {@link SearchSourceBuilder} size, matching the 2× factor used by
+     *       {@link TransportMultiSearchAction#estimateActualBytes}. The builder is the in-memory
+     *       parsed representation of the source and is retained until the inner search executes.</li>
+     *   <li>For simulate-only (no builder): {@link #RENDER_HEAP_OVERHEAD_FACTOR} × {@code source.length()}
+     *       as a proxy, since there is no builder to serialise.</li>
+     * </ul>
+     *
+     * @param counter a reusable {@link CountingStreamOutput}; reset before each use, never allocated
+     */
+    private static long estimateRenderBytes(
+        SearchTemplateResponse searchTemplateResponse,
+        SearchRequest searchRequest,
+        CountingStreamOutput counter
+    ) {
+        long bytes = RENDER_BASE_OVERHEAD;
+        BytesReference source = searchTemplateResponse.getSource();
+        if (source != null) {
+            bytes += source.length();
+        }
+        SearchSourceBuilder ssb = searchRequest != null ? searchRequest.source() : null;
+        if (ssb != null) {
+            bytes += RENDER_HEAP_OVERHEAD_FACTOR * tryCountSerializedBytes(counter, ssb);
+        } else if (source != null) {
+            bytes += RENDER_HEAP_OVERHEAD_FACTOR * source.length();
+        }
+        return bytes;
+    }
+
+    /**
+     * Resets {@code counter} before writing and reads {@link CountingStreamOutput#position()} after.
+     * Returns {@link #SERIALISED_BYTES_FAILURE_FALLBACK} and logs a warning if serialisation raises
+     * an exception; in that case {@code counter} is reset so the next call starts from a clean state.
+     */
+    private static long tryCountSerializedBytes(CountingStreamOutput counter, SearchSourceBuilder ssb) {
+        try {
+            counter.reset();
+            ssb.writeTo(counter);
+            return counter.position();
+        } catch (Exception e) {
+            counter.reset();
+            logger.warn("Failed to count serialised bytes for SearchSourceBuilder render estimate", e);
+            return SERIALISED_BYTES_FAILURE_FALLBACK;
+        }
+    }
+
+    /**
+     * Fills remaining unprocessed search slots (from {@code fromSearchIdx} onward in {@code searchSlots})
+     * with the given {@link CircuitBreakingException}, decRefing any search template response they hold.
+     */
+    private static void fillRemainingWithCbe(
+        MultiSearchTemplateResponse.Item[] items,
+        List<Integer> searchSlots,
+        int fromSearchIdx,
+        CircuitBreakingException cbe
+    ) {
+        for (int i = fromSearchIdx; i < searchSlots.size(); i++) {
+            int slot = searchSlots.get(i);
+            if (items[slot] != null && items[slot].getResponse() != null) {
+                items[slot].getResponse().decRef();
+            }
+            items[slot] = new MultiSearchTemplateResponse.Item(null, cbe);
+        }
+    }
+
+    /**
+     * Aborts the response phase when a {@link CircuitBreakingException} is thrown while processing
+     * inner search results. Releases render-breaker bytes for unprocessed slots, charges a substitute
+     * CBE amount under the failure label, and fills those slots in {@code items[]} with the exception.
+     *
+     * @param fromSearchIdx index into {@code searchSlots} from which to operate (inclusive)
+     * @param totalItems    total number of inner search responses (i.e. {@code multiSearchResp.getResponses().length})
+     */
+    private void abortResponsePhase(
+        MultiSearchTemplateResponse.Item[] items,
+        List<Integer> searchSlots,
+        int fromSearchIdx,
+        int totalItems,
+        long[] renderBytesPerItem,
+        long[] renderBytesCharged,
+        long[] failureBytesCharged,
+        CircuitBreakingException cbe
+    ) {
+        for (int j = fromSearchIdx; j < totalItems; j++) {
+            int slot = searchSlots.get(j);
+            circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+            renderBytesCharged[0] -= renderBytesPerItem[slot];
+        }
+        long subBytes = TransportMultiSearchAction.estimateFailureBytes(cbe);
+        circuitBreaker.addWithoutBreaking(subBytes, MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
+        failureBytesCharged[0] += subBytes;
+        fillRemainingWithCbe(items, searchSlots, fromSearchIdx, cbe);
+    }
+
+    private static void finishResponse(
+        MultiSearchTemplateResponse.Item[] items,
+        long startTimeNanos,
+        ActionListener<MultiSearchTemplateResponse> safeListener
+    ) {
+        long tookMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
+        ActionListener.respondAndRelease(safeListener, new MultiSearchTemplateResponse(items, tookMillis));
+    }
+
 }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -55,9 +54,9 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
 
     private static final Logger logger = LogManager.getLogger(TransportMultiSearchTemplateAction.class);
 
-    private static final String MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL = ChildMemoryCircuitBreaker.CATEGORY_MSEARCH + "[render]";
-    private static final String MSEARCH_TEMPLATE_RESPONSE_BREAKER_LABEL = ChildMemoryCircuitBreaker.CATEGORY_MSEARCH + "[response]";
-    private static final String MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL = ChildMemoryCircuitBreaker.CATEGORY_MSEARCH + "[failure]";
+    private static final String MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL = "msearch[render]";
+    private static final String MSEARCH_TEMPLATE_RESPONSE_BREAKER_LABEL = "msearch[response]";
+    private static final String MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL = "msearch[failure]";
 
     /**
      * Heap-overhead factor applied to serialised byte counts.
@@ -127,8 +126,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
 
         int n = request.requests().size();
         MultiSearchTemplateResponse.Item[] items = new MultiSearchTemplateResponse.Item[n];
-        // Three separate accumulators — each released under the same label it was charged with so
-        // that ChildMemoryCircuitBreaker's per-category gauge stays balanced.
+        // Three separate accumulators track bytes charged to the circuit breaker per category.
         long[] renderBytesPerItem = new long[n]; // per-slot render charge; released when the slot is finalized
         long[] renderBytesCharged = { 0L };    // running total released by runAfter (remainder after early releases)
         long[] responseBytesCharged = { 0L };  // charged/released under [response] (success hits only)
@@ -137,13 +135,13 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
 
         ActionListener<MultiSearchTemplateResponse> breakerReleasingListener = ActionListener.runAfter(listener, () -> {
             if (renderBytesCharged[0] > 0) {
-                circuitBreaker.addWithoutBreaking(-renderBytesCharged[0], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                circuitBreaker.addWithoutBreaking(-renderBytesCharged[0]);
             }
             if (responseBytesCharged[0] > 0) {
-                circuitBreaker.addWithoutBreaking(-responseBytesCharged[0], MSEARCH_TEMPLATE_RESPONSE_BREAKER_LABEL);
+                circuitBreaker.addWithoutBreaking(-responseBytesCharged[0]);
             }
             if (failureBytesCharged[0] > 0) {
-                circuitBreaker.addWithoutBreaking(-failureBytesCharged[0], MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
+                circuitBreaker.addWithoutBreaking(-failureBytesCharged[0]);
             }
         });
         ActionListener<MultiSearchTemplateResponse> safeListener = new ActionListener<>() {
@@ -220,11 +218,11 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                 searchTemplateResponse.decRef();
                 items[i] = new MultiSearchTemplateResponse.Item(null, cbe);
                 long subBytes = TransportMultiSearchAction.estimateFailureBytes(cbe);
-                circuitBreaker.addWithoutBreaking(subBytes, MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
+                circuitBreaker.addWithoutBreaking(subBytes);
                 failureBytesCharged[0] += subBytes;
                 // Release render bytes for already-queued slots — their sources are freed by fillRemainingWithCbe.
                 for (int slot : searchSlots) {
-                    circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                    circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot]);
                     renderBytesCharged[0] -= renderBytesPerItem[slot];
                 }
                 // Abort: all search slots queued so far cannot run — replace them with CBE.
@@ -265,7 +263,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                             if (items[slot].getResponse() != null) {
                                 items[slot].getResponse().decRef();
                             }
-                            circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                            circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot]);
                             renderBytesCharged[0] -= renderBytesPerItem[slot];
                             items[slot] = new MultiSearchTemplateResponse.Item(null, item.getFailure());
                             long failureBytes = TransportMultiSearchAction.estimateFailureBytes(item.getFailure());
@@ -294,7 +292,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                             } catch (CircuitBreakingException cbe) {
                                 items[slot].getResponse().decRef();
                                 items[slot] = new MultiSearchTemplateResponse.Item(null, cbe);
-                                circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+                                circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot]);
                                 renderBytesCharged[0] -= renderBytesPerItem[slot];
                                 abortResponsePhase(
                                     items,
@@ -420,11 +418,11 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
     ) {
         for (int j = fromSearchIdx; j < totalItems; j++) {
             int slot = searchSlots.get(j);
-            circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot], MSEARCH_TEMPLATE_RENDER_BREAKER_LABEL);
+            circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot]);
             renderBytesCharged[0] -= renderBytesPerItem[slot];
         }
         long subBytes = TransportMultiSearchAction.estimateFailureBytes(cbe);
-        circuitBreaker.addWithoutBreaking(subBytes, MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
+        circuitBreaker.addWithoutBreaking(subBytes);
         failureBytesCharged[0] += subBytes;
         fillRemainingWithCbe(items, searchSlots, fromSearchIdx, cbe);
     }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -217,7 +217,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
             } catch (CircuitBreakingException cbe) {
                 searchTemplateResponse.decRef();
                 items[i] = new MultiSearchTemplateResponse.Item(null, cbe);
-                long subBytes = TransportMultiSearchAction.estimateFailureBytes(cbe);
+                long subBytes = SERIALISED_BYTES_FAILURE_FALLBACK;
                 circuitBreaker.addWithoutBreaking(subBytes);
                 failureBytesCharged[0] += subBytes;
                 // Release render bytes for already-queued slots — their sources are freed by fillRemainingWithCbe.
@@ -266,7 +266,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                             circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot]);
                             renderBytesCharged[0] -= renderBytesPerItem[slot];
                             items[slot] = new MultiSearchTemplateResponse.Item(null, item.getFailure());
-                            long failureBytes = TransportMultiSearchAction.estimateFailureBytes(item.getFailure());
+                            long failureBytes = SERIALISED_BYTES_FAILURE_FALLBACK;
                             try {
                                 circuitBreaker.addEstimateBytesAndMaybeBreak(failureBytes, MSEARCH_TEMPLATE_FAILURE_BREAKER_LABEL);
                                 failureBytesCharged[0] += failureBytes;
@@ -286,7 +286,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                             }
                         } else {
                             // Charge breaker BEFORE incRef/setResponse so cleanup is safe if breaker throws.
-                            long responseBytes = TransportMultiSearchAction.estimateActualBytes(item.getResponse());
+                            long responseBytes = 0L;
                             try {
                                 circuitBreaker.addEstimateBytesAndMaybeBreak(responseBytes, MSEARCH_TEMPLATE_RESPONSE_BREAKER_LABEL);
                             } catch (CircuitBreakingException cbe) {
@@ -334,8 +334,8 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
      *   <li>{@code source.length()} — raw bytes of the retained {@link BytesReference}; counted once
      *       since it is already a byte array view, not expanded into Java objects.</li>
      *   <li>For a real search: {@link #RENDER_HEAP_OVERHEAD_FACTOR} × serialised
-     *       {@link SearchSourceBuilder} size, matching the 2× factor used by
-     *       {@link TransportMultiSearchAction#estimateActualBytes}. The builder is the in-memory
+     *       {@link SearchSourceBuilder} size, using the same 2× heap-overhead factor as
+     *       {@code TransportMultiSearchAction}. The builder is the in-memory
      *       parsed representation of the source and is retained until the inner search executes.</li>
      *   <li>For simulate-only (no builder): {@link #RENDER_HEAP_OVERHEAD_FACTOR} × {@code source.length()}
      *       as a proxy, since there is no builder to serialise.</li>
@@ -421,7 +421,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
             circuitBreaker.addWithoutBreaking(-renderBytesPerItem[slot]);
             renderBytesCharged[0] -= renderBytesPerItem[slot];
         }
-        long subBytes = TransportMultiSearchAction.estimateFailureBytes(cbe);
+        long subBytes = SERIALISED_BYTES_FAILURE_FALLBACK;
         circuitBreaker.addWithoutBreaking(subBytes);
         failureBytesCharged[0] += subBytes;
         fillRemainingWithCbe(items, searchSlots, fromSearchIdx, cbe);

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequestTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequestTests.java
@@ -15,6 +15,8 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -22,11 +24,13 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 
 public class MultiSearchTemplateRequestTests extends ESTestCase {
@@ -86,6 +90,21 @@ public class MultiSearchTemplateRequestTests extends ESTestCase {
         assertEquals(ScriptType.INLINE, request.requests().get(0).getScriptType());
         assertEquals("{\"query\":{\"match_{{template}}\":{}}}", request.requests().get(0).getScript());
         assertEquals(1, request.requests().get(0).getScriptParams().size());
+    }
+
+    public void testCreateTaskReturnsCancellableTask() {
+        MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+        SearchTemplateRequest templateRequest = new SearchTemplateRequest();
+        templateRequest.setRequest(new SearchRequest("test"));
+        templateRequest.setScriptType(ScriptType.INLINE);
+        templateRequest.setScript("{\"query\":{\"match_all\":{}}}");
+        request.add(templateRequest);
+
+        org.elasticsearch.tasks.Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+        assertThat(task, instanceOf(CancellableTask.class));
+        CancellableTask cancellableTask = (CancellableTask) task;
+        assertTrue(cancellableTask.shouldCancelChildrenOnCancellation());
+        assertThat(cancellableTask.getDescription(), equalTo("requests[1]"));
     }
 
     public void testMaxConcurrentSearchRequests() {

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
@@ -177,4 +177,5 @@ public class MultiSearchTemplateResponseTests extends AbstractXContentTestCase<M
         instance.decRef();
     }
 
+
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
@@ -176,4 +176,5 @@ public class MultiSearchTemplateResponseTests extends AbstractXContentTestCase<M
     protected void dispose(MultiSearchTemplateResponse instance) {
         instance.decRef();
     }
+
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
@@ -177,5 +177,4 @@ public class MultiSearchTemplateResponseTests extends AbstractXContentTestCase<M
         instance.decRef();
     }
 
-
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
@@ -1,0 +1,1012 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.script.mustache;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.script.TemplateScript;
+import org.elasticsearch.search.SearchResponseUtils;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelHelper;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.DefaultBuiltInExecutorBuilders;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransportMultiSearchTemplateActionTests extends ESTestCase {
+
+    // ── Helper circuit breakers ──────────────────────────────────────────────
+
+    /**
+     * Trips on the first {@code addEstimateBytesAndMaybeBreak} call, regardless of size.
+     */
+    private static final class TrippingCircuitBreaker extends NoopCircuitBreaker {
+        TrippingCircuitBreaker() {
+            super("test");
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            throw new CircuitBreakingException("test breaker tripped", getDurability());
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {}
+
+        @Override
+        public long getUsed() {
+            return 0;
+        }
+    }
+
+    /**
+     * Trips when a single charge exceeds {@code limitBytes}.
+     * Small renders pass; renders larger than the threshold trip the breaker, proving size matters.
+     */
+    private static final class ThresholdCircuitBreaker extends NoopCircuitBreaker {
+        private final long limitBytes;
+
+        ThresholdCircuitBreaker(long limitBytes) {
+            super("test");
+            this.limitBytes = limitBytes;
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            if (bytes > limitBytes) {
+                throw new CircuitBreakingException("threshold breaker tripped: " + bytes + " > " + limitBytes, getDurability());
+            }
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {}
+    }
+
+    /**
+     * Never trips; tracks the cumulative net bytes charged across all breaker calls.
+     * Positive bytes come from {@code addEstimateBytesAndMaybeBreak} charges;
+     * negative bytes come from {@code addWithoutBreaking} release calls.
+     * After correct cleanup, {@link #getUsed()} returns {@code 0}.
+     * {@link #getPeakNetBytes()} records the highest {@code netBytes} value seen, which is always
+     * positive when at least one charge was issued — allowing tests to distinguish "released after
+     * charging" from "nothing was charged at all".
+     *
+     * <p>Pass {@code tripOnAnyCharge=true} to simulate a render-phase CBE while still
+     * tracking the release calls that follow.
+     */
+    private static final class TrackingCircuitBreaker extends NoopCircuitBreaker {
+        private long netBytes = 0;
+        private long peakNetBytes = 0;
+        private final boolean tripOnAnyCharge;
+
+        TrackingCircuitBreaker() {
+            this(false);
+        }
+
+        TrackingCircuitBreaker(boolean tripOnAnyCharge) {
+            super("test");
+            this.tripOnAnyCharge = tripOnAnyCharge;
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            if (tripOnAnyCharge) {
+                throw new CircuitBreakingException("tracking breaker tripped", getDurability());
+            }
+            netBytes += bytes;
+            peakNetBytes = Math.max(peakNetBytes, netBytes);
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            netBytes += bytes;
+            peakNetBytes = Math.max(peakNetBytes, netBytes);
+        }
+
+        @Override
+        public long getUsed() {
+            return netBytes;
+        }
+
+        public long getPeakNetBytes() {
+            return peakNetBytes;
+        }
+    }
+
+    /**
+     * Tracks charges per label and the peak net balance. Used to enforce the documented 2× transient
+     * peak: at most {@code renderBytesCharged + responseBytesCharged} bytes are ever held simultaneously,
+     * with no additional third-party charge overlapping.
+     */
+    private static final class PeakCapturingBreaker extends NoopCircuitBreaker {
+        private long netBytes = 0;
+        private long peakNetBytes = 0;
+        private long renderBytesCharged = 0;
+        private long responseBytesCharged = 0;
+
+        PeakCapturingBreaker() {
+            super("test");
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
+            netBytes += bytes;
+            peakNetBytes = Math.max(peakNetBytes, netBytes);
+            if (label != null && bytes > 0) {
+                if (label.contains("[render]")) renderBytesCharged += bytes;
+                else if (label.contains("[response]")) responseBytesCharged += bytes;
+            }
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            netBytes += bytes;
+            peakNetBytes = Math.max(peakNetBytes, netBytes);
+        }
+
+        @Override
+        public long getUsed() {
+            return netBytes;
+        }
+
+        long getPeakNetBytes() {
+            return peakNetBytes;
+        }
+
+        long getRenderBytesCharged() {
+            return renderBytesCharged;
+        }
+
+        long getResponseBytesCharged() {
+            return responseBytesCharged;
+        }
+    }
+
+    /**
+     * Passes render-phase charges (label {@code "msearch[render]"}); trips on response-phase
+     * charges (label {@code "msearch[response]"}). Allows all {@code addWithoutBreaking} release
+     * calls through. Used to verify that a hit-side CBE fills remaining slots without aborting
+     * before {@code client.multiSearch()} is called.
+     */
+    private static final class ResponsePhaseTrippingBreaker extends NoopCircuitBreaker {
+        ResponsePhaseTrippingBreaker() {
+            super("test");
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            if (label != null && label.contains("[response]")) {
+                throw new CircuitBreakingException("response phase tripped", getDurability());
+            }
+            // [render] charges pass through — that is the point of this breaker.
+            // [failure] charges (e.g. addEstimateBytesAndMaybeBreak for failure-item bytes) also pass
+            // through; in testResponsePhaseCbeFillsRemainingSlots all inner searches succeed so no
+            // failure-item path is exercised and this case does not arise.
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {}
+    }
+
+    // ── Helper factories ─────────────────────────────────────────────────────
+
+    /**
+     * Builds a minimal ScriptService mock where all templates render to {@code {"size": 0}}.
+     * This parses correctly with NamedXContentRegistry.EMPTY since SearchSourceBuilder
+     * handles "size" natively without requiring named XContent entries.
+     */
+    private static ScriptService allSuccessScriptService() {
+        ScriptService scriptService = mock(ScriptService.class);
+        TemplateScript.Factory factory = params -> new TemplateScript(params) {
+            @Override
+            public String execute() {
+                return "{\"size\": 0}";
+            }
+        };
+        when(scriptService.compile(any(Script.class), eq(TemplateScript.CONTEXT))).thenReturn(factory);
+        return scriptService;
+    }
+
+    private static SearchTemplateRequest templateRequest() {
+        SearchTemplateRequest req = new SearchTemplateRequest();
+        req.setRequest(new SearchRequest("test"));
+        req.setScriptType(ScriptType.INLINE);
+        req.setScript("{\"size\": 0}");
+        return req;
+    }
+
+    private static TransportMultiSearchTemplateAction buildAction(
+        ThreadPool threadPool,
+        NodeClient client,
+        ClusterService clusterService,
+        CircuitBreaker breaker
+    ) {
+        return buildAction(threadPool, client, clusterService, breaker, allSuccessScriptService());
+    }
+
+    private static TransportMultiSearchTemplateAction buildAction(
+        ThreadPool threadPool,
+        NodeClient client,
+        ClusterService clusterService,
+        CircuitBreaker breaker,
+        ScriptService scriptService
+    ) {
+        ActionFilters actionFilters = mock(ActionFilters.class);
+        when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
+        TransportService transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            ba -> DiscoveryNodeUtils.builder("local").applySettings(Settings.EMPTY).address(ba.publishAddress()).build(),
+            null,
+            Collections.emptySet()
+        );
+        FeatureService featureService = mock(FeatureService.class);
+        when(featureService.clusterHasFeature(any(), any())).thenReturn(false);
+        CircuitBreakerService breakerService = mock(CircuitBreakerService.class);
+        when(breakerService.getBreaker(CircuitBreaker.REQUEST)).thenReturn(breaker);
+        return new TransportMultiSearchTemplateAction(
+            Settings.EMPTY,
+            transportService,
+            actionFilters,
+            scriptService,
+            NamedXContentRegistry.EMPTY,
+            client,
+            new UsageService(),
+            clusterService,
+            featureService,
+            breakerService
+        );
+    }
+
+    private static ClusterService clusterServiceWithDataNodes(int numDataNodes) {
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        nodesBuilder.add(DiscoveryNodeUtils.builder("master").roles(Set.of(DiscoveryNodeRole.MASTER_ROLE)).build());
+        nodesBuilder.localNodeId("master");
+        for (int i = 0; i < numDataNodes; i++) {
+            nodesBuilder.add(DiscoveryNodeUtils.builder("data-" + i).roles(Set.of(DiscoveryNodeRole.DATA_ROLE)).build());
+        }
+        ClusterState state = ClusterState.builder(new ClusterName("test")).nodes(nodesBuilder).build();
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(state);
+        return clusterService;
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that all non-simulate requests are sent in a single {@code client.multiSearch()} call
+     * with {@code maxConcurrentSearchRequests} propagated from the template request.
+     */
+    public void testAllRequestsSentInSingleMultiSearch() throws Exception {
+        int maxConcurrent = 50;
+        int numRequests = 150;
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        AtomicInteger multiSearchCalls = new AtomicInteger();
+        AtomicReference<Integer> observedSize = new AtomicReference<>();
+        AtomicReference<Integer> observedConcurrency = new AtomicReference<>();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    multiSearchCalls.incrementAndGet();
+                    observedSize.set(request.requests().size());
+                    observedConcurrency.set(request.maxConcurrentSearchRequests());
+                    MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
+                    for (int i = 0; i < items.length; i++) {
+                        SearchResponse sr = SearchResponseUtils.response().build();
+                        items[i] = new MultiSearchResponse.Item(sr, null);
+                    }
+                    MultiSearchResponse response = new MultiSearchResponse(items, 1L);
+                    try {
+                        listener.onResponse(response);
+                    } finally {
+                        response.decRef();
+                    }
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            request.maxConcurrentSearchRequests(maxConcurrent);
+            for (int i = 0; i < numRequests; i++) {
+                request.add(templateRequest());
+            }
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, new NoopCircuitBreaker("test"));
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, response) -> {
+                assertThat(response.getResponses().length, equalTo(numRequests));
+                for (MultiSearchTemplateResponse.Item item : response) {
+                    assertFalse(item.isFailure());
+                }
+                l.onResponse(null);
+            }));
+            future.get();
+
+            assertThat("all requests must go in one multiSearch call", multiSearchCalls.get(), equalTo(1));
+            assertThat("all non-simulate requests included", observedSize.get(), equalTo(numRequests));
+            assertThat("maxConcurrentSearchRequests propagated", observedConcurrency.get(), equalTo(maxConcurrent));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that simulate-only requests never trigger a multiSearch call —
+     * they are rendered but not searched, so they bypass the inner msearch entirely.
+     */
+    public void testSimulateOnlyRequestsSkipMultiSearch() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        AtomicInteger multiSearchCalls = new AtomicInteger();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    multiSearchCalls.incrementAndGet();
+                    listener.onFailure(new RuntimeException("multiSearch should not be called for simulate-only requests"));
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            int numRequests = randomIntBetween(1, 20);
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            for (int i = 0; i < numRequests; i++) {
+                SearchTemplateRequest req = templateRequest();
+                req.setSimulate(true);
+                request.add(req);
+            }
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, new NoopCircuitBreaker("test"));
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, response) -> {
+                assertThat(response.getResponses().length, equalTo(numRequests));
+                for (MultiSearchTemplateResponse.Item item : response) {
+                    assertFalse(item.isFailure());
+                    assertThat(item.getResponse(), not(nullValue()));
+                    // Simulate-only: source is rendered but no inner SearchResponse
+                    assertThat(item.getResponse().getResponse(), nullValue());
+                    assertThat(item.getResponse().getSource(), not(nullValue()));
+                }
+                l.onResponse(null);
+            }));
+            future.get();
+
+            assertThat("multiSearch must not be called for simulate-only requests", multiSearchCalls.get(), equalTo(0));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that a circuit-breaker trip during the render phase produces partial CBE results
+     * and never reaches {@code client.multiSearch()} — the breaker trips before any search is issued.
+     */
+    public void testCircuitBreakerTripDuringRenderSkipsMultiSearch() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        AtomicInteger multiSearchCalls = new AtomicInteger();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    multiSearchCalls.incrementAndGet();
+                    listener.onFailure(new RuntimeException("multiSearch must not be called after render CBE"));
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            int numRequests = 3;
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            for (int i = 0; i < numRequests; i++) {
+                request.add(templateRequest());
+            }
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, new TrippingCircuitBreaker());
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, response) -> {
+                // Must return a response object (partial results), not a top-level failure
+                assertThat(response.getResponses().length, equalTo(numRequests));
+                for (MultiSearchTemplateResponse.Item item : response) {
+                    assertTrue("expected CBE failure for every item when breaker trips on first render", item.isFailure());
+                    assertThat(item.getFailure(), instanceOf(CircuitBreakingException.class));
+                }
+                l.onResponse(null);
+            }));
+            future.get();
+
+            assertThat("multiSearch must not be called when render phase trips the breaker", multiSearchCalls.get(), equalTo(0));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that a large rendered source trips the circuit breaker based on its size, not
+     * unconditionally. The {@link ThresholdCircuitBreaker} passes small renders (e.g., {@code {"size":0}})
+     * but trips when the estimate for a ~300 KB source exceeds the 50 KB limit. This proves that the
+     * render estimate is proportional to source size, unlike {@link TrippingCircuitBreaker} (which would
+     * trip regardless of size and thus cannot distinguish the two cases).
+     */
+    public void testLargeRenderedSourceTripsBreakerBeforeSearch() throws Exception {
+        // Build ~300 KB of valid SearchSourceBuilder JSON via stored_fields (a plain string array).
+        // stored_fields is a built-in field that parses with NamedXContentRegistry.EMPTY.
+        StringBuilder sb = new StringBuilder("{\"size\":0,\"stored_fields\":[");
+        for (int j = 0; j < 30_000; j++) {
+            if (j > 0) sb.append(",");
+            sb.append("\"f").append(j).append("\"");
+        }
+        sb.append("]}");
+        String largeBody = sb.toString();
+
+        ScriptService largeSrcScriptService = mock(ScriptService.class);
+        TemplateScript.Factory factory = params -> new TemplateScript(params) {
+            @Override
+            public String execute() {
+                return largeBody;
+            }
+        };
+        when(largeSrcScriptService.compile(any(Script.class), eq(TemplateScript.CONTEXT))).thenReturn(factory);
+
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        AtomicInteger multiSearchCalls = new AtomicInteger();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    multiSearchCalls.incrementAndGet();
+                    listener.onFailure(new RuntimeException("multiSearch must not be called after render CBE"));
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            // 50 KB threshold: the ~300 KB source produces a render estimate >> 50 KB (trips);
+            // a small {"size":0} would produce an estimate << 50 KB (passes), proving size matters.
+            TransportMultiSearchTemplateAction action = buildAction(
+                threadPool,
+                client,
+                clusterService,
+                new ThresholdCircuitBreaker(50 * 1024),
+                largeSrcScriptService
+            );
+
+            int numRequests = 5;
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            for (int i = 0; i < numRequests; i++) {
+                request.add(templateRequest());
+            }
+
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, response) -> {
+                assertThat(response.getResponses().length, equalTo(numRequests));
+                for (MultiSearchTemplateResponse.Item item : response) {
+                    assertTrue("large render must produce CBE item failure, not OOM", item.isFailure());
+                    assertThat(item.getFailure(), instanceOf(CircuitBreakingException.class));
+                }
+                l.onResponse(null);
+            }));
+            future.get();
+
+            assertThat("multiSearch must not be called when render trips the breaker", multiSearchCalls.get(), equalTo(0));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that the circuit breaker's net usage returns to zero after a successful request
+     * (render, search, response — all succeed). The {@link TrackingCircuitBreaker} accumulates
+     * positive bytes on charges and negative bytes on releases; the final balance must be zero
+     * after the {@code runAfter} cleanup fires.
+     */
+    public void testBreakerNetZeroAfterSuccess() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        TrackingCircuitBreaker tracker = new TrackingCircuitBreaker();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
+                    for (int i = 0; i < items.length; i++) {
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                    }
+                    MultiSearchResponse response = new MultiSearchResponse(items, 1L);
+                    try {
+                        listener.onResponse(response);
+                    } finally {
+                        response.decRef();
+                    }
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            int numRequests = 3;
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            for (int i = 0; i < numRequests; i++) {
+                request.add(templateRequest());
+            }
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, tracker);
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, r) -> l.onResponse(null)));
+            future.get();
+
+            // By the time future.get() returns, the runAfter cleanup has already fired
+            // (single-threaded execution: listener completes, then runAfter releases bytes).
+            assertThat("bytes must have been charged (not a no-op breaker)", tracker.getPeakNetBytes(), not(equalTo(0L)));
+            assertThat("breaker must be fully released after a successful request", tracker.getUsed(), equalTo(0L));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that the circuit breaker's net usage returns to zero after a render-phase CBE.
+     * Only the failure-substitute bytes are charged to the breaker (via {@code addWithoutBreaking});
+     * those same bytes must be released in the {@code runAfter} cleanup.
+     */
+    public void testBreakerNetZeroAfterRenderCbe() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        // tripOnAnyCharge=true: trips on first addEstimateBytesAndMaybeBreak (render charge),
+        // but still tracks addWithoutBreaking calls so net can be verified.
+        TrackingCircuitBreaker tracker = new TrackingCircuitBreaker(true);
+        AtomicInteger multiSearchCalls = new AtomicInteger();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    multiSearchCalls.incrementAndGet();
+                    listener.onFailure(new RuntimeException("multiSearch must not be called after render CBE"));
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            for (int i = 0; i < 3; i++) {
+                request.add(templateRequest());
+            }
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, tracker);
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, r) -> l.onResponse(null)));
+            future.get();
+
+            assertThat("multiSearch must not be called when render phase trips the breaker", multiSearchCalls.get(), equalTo(0));
+            // peakNetBytes > 0 proves that failure-substitute bytes were charged (the addWithoutBreaking
+            // calls after the render CBE): the test is not trivially net-zero because nothing was ever charged.
+            assertThat("failure-substitute bytes must have been charged", tracker.getPeakNetBytes(), not(equalTo(0L)));
+            assertThat("breaker must be fully released after a render-phase CBE", tracker.getUsed(), equalTo(0L));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that a {@code convert()} failure on one slot does not abort later slots.
+     * Slot 1's template compile throws a {@link RuntimeException}; slots 0 and 2 succeed and
+     * get real inner search responses. Slot 1 receives a non-CBE item failure.
+     */
+    public void testConvertErrorDoesNotAbortOtherSlots() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+
+        TemplateScript.Factory successFactory = params -> new TemplateScript(params) {
+            @Override
+            public String execute() {
+                return "{\"size\": 0}";
+            }
+        };
+        ScriptService scriptService = mock(ScriptService.class);
+        when(scriptService.compile(any(Script.class), eq(TemplateScript.CONTEXT))).thenReturn(successFactory)
+            .thenThrow(new RuntimeException("slot 1 compile error"))
+            .thenReturn(successFactory);
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            // Slot 1 is a convert failure → only 2 searches are sent to multiSearch (slots 0 and 2).
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    assertThat("only slots 0 and 2 reach multiSearch", request.requests().size(), equalTo(2));
+                    MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[2];
+                    items[0] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                    items[1] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                    MultiSearchResponse response = new MultiSearchResponse(items, 1L);
+                    try {
+                        listener.onResponse(response);
+                    } finally {
+                        response.decRef();
+                    }
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            request.add(templateRequest()); // slot 0 — success
+            request.add(templateRequest()); // slot 1 — compile throws
+            request.add(templateRequest()); // slot 2 — success
+
+            TransportMultiSearchTemplateAction action = buildAction(
+                threadPool,
+                client,
+                clusterService,
+                new NoopCircuitBreaker("test"),
+                scriptService
+            );
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, response) -> {
+                assertThat(response.getResponses().length, equalTo(3));
+
+                MultiSearchTemplateResponse.Item item0 = response.getResponses()[0];
+                assertFalse("slot 0 must succeed", item0.isFailure());
+                assertTrue("slot 0 must have an inner search response", item0.getResponse().hasResponse());
+
+                MultiSearchTemplateResponse.Item item1 = response.getResponses()[1];
+                assertTrue("slot 1 must be a failure", item1.isFailure());
+                assertThat("slot 1 must be a non-CBE compile error", item1.getFailure(), not(instanceOf(CircuitBreakingException.class)));
+
+                MultiSearchTemplateResponse.Item item2 = response.getResponses()[2];
+                assertFalse("slot 2 must succeed despite slot 1 failure", item2.isFailure());
+                assertTrue("slot 2 must have an inner search response", item2.getResponse().hasResponse());
+
+                l.onResponse(null);
+            }));
+            future.get();
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that a CBE during the response phase (charging for hit bytes) fills remaining
+     * slots with CBE item failures, but only AFTER {@code client.multiSearch()} has been called —
+     * unlike a render-phase CBE, which skips the inner search entirely.
+     */
+    public void testResponsePhaseCbeFillsRemainingSlots() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        AtomicInteger multiSearchCalls = new AtomicInteger();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            int numRequests = 3;
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    multiSearchCalls.incrementAndGet();
+                    MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
+                    for (int i = 0; i < items.length; i++) {
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                    }
+                    MultiSearchResponse response = new MultiSearchResponse(items, 1L);
+                    try {
+                        listener.onResponse(response);
+                    } finally {
+                        response.decRef();
+                    }
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            for (int i = 0; i < numRequests; i++) {
+                request.add(templateRequest());
+            }
+
+            // Render charges (label "msearch[render]") pass; first response charge (label "msearch[response]") trips.
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, new ResponsePhaseTrippingBreaker());
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, response) -> {
+                assertThat(response.getResponses().length, equalTo(numRequests));
+                for (MultiSearchTemplateResponse.Item item : response) {
+                    assertTrue("response-phase CBE must produce CBE item failure for every slot", item.isFailure());
+                    assertThat(item.getFailure(), instanceOf(CircuitBreakingException.class));
+                }
+                l.onResponse(null);
+            }));
+            future.get();
+
+            assertThat(
+                "multiSearch must be called before the response-phase CBE fires (unlike render-phase)",
+                multiSearchCalls.get(),
+                equalTo(1)
+            );
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies that the inner {@link org.elasticsearch.action.search.MultiSearchRequest} has its
+     * parent task set to the outer msearch/template task. This ensures the inner searches appear
+     * as children in the tasks API and are cancelled when the parent task is cancelled.
+     */
+    public void testParentTaskSetOnInnerMultiSearch() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        AtomicReference<org.elasticsearch.tasks.TaskId> observedParentTask = new AtomicReference<>();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    observedParentTask.set(request.getParentTask());
+                    MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
+                    for (int i = 0; i < items.length; i++) {
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                    }
+                    MultiSearchResponse response = new MultiSearchResponse(items, 1L);
+                    try {
+                        listener.onResponse(response);
+                    } finally {
+                        response.decRef();
+                    }
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local-node";
+                }
+            };
+
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            request.add(templateRequest());
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, new NoopCircuitBreaker("test"));
+            long taskId = randomNonNegativeLong();
+            Task task = request.createTask(taskId, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, r) -> l.onResponse(null)));
+            future.get();
+
+            org.elasticsearch.tasks.TaskId parentTask = observedParentTask.get();
+            assertNotNull("inner multiSearch must have a parent task set", parentTask);
+            assertThat("parent task node ID must match getLocalNodeId()", parentTask.getNodeId(), equalTo("local-node"));
+            assertThat("parent task ID must match the outer task", parentTask.getId(), equalTo(taskId));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Verifies cooperative mid-render cancellation: when the outer task is cancelled after some items
+     * have already been rendered (but before {@code client.multiSearch()} is dispatched), the action
+     * must call {@code onFailure} with a {@link TaskCancelledException}, skip the remaining items, and
+     * release all breaker bytes it charged during the partial render.
+     *
+     * <p>The script service cancels the task on its second {@code compile} call, so item 0 renders
+     * normally, item 1 renders (triggering the cancel as a side effect), and item 2 triggers the
+     * cancellation check at the top of the loop — never reaching {@code convert()}.
+     */
+    public void testRenderPhaseCancellationStopsLoopAndReleasesBreaker() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        TrackingCircuitBreaker tracker = new TrackingCircuitBreaker();
+        AtomicInteger multiSearchCalls = new AtomicInteger();
+        AtomicInteger compileCalls = new AtomicInteger();
+
+        int numRequests = 3;
+        MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+        for (int i = 0; i < numRequests; i++) {
+            request.add(templateRequest());
+        }
+        CancellableTask task = (CancellableTask) request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    multiSearchCalls.incrementAndGet();
+                    listener.onFailure(new RuntimeException("multiSearch must not be called after render-phase cancellation"));
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            ScriptService scriptService = mock(ScriptService.class);
+            when(scriptService.compile(any(Script.class), eq(TemplateScript.CONTEXT))).thenAnswer(inv -> {
+                if (compileCalls.incrementAndGet() == 2) {
+                    TaskCancelHelper.cancel(task, "test cancellation");
+                }
+                TemplateScript.Factory factory = params -> new TemplateScript(params) {
+                    @Override
+                    public String execute() {
+                        return "{\"size\": 0}";
+                    }
+                };
+                return factory;
+            });
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, tracker, scriptService);
+            PlainActionFuture<MultiSearchTemplateResponse> future = new PlainActionFuture<>();
+            action.execute(task, request, future);
+
+            Exception thrown = expectThrows(Exception.class, future::actionGet);
+            assertThat(ExceptionsHelper.unwrapCause(thrown), instanceOf(TaskCancelledException.class));
+            assertThat("multiSearch must not be called when the render loop is cancelled", multiSearchCalls.get(), equalTo(0));
+            assertThat("compile must have been called exactly twice (cancel fires on 2nd)", compileCalls.get(), equalTo(2));
+            assertThat("breaker must have charged something during the partial render", tracker.getPeakNetBytes(), greaterThan(0L));
+            assertThat("breaker must be fully released after render-phase cancellation", tracker.getUsed(), equalTo(0L));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+
+    /**
+     * Enforces the documented 2× transient peak: the highest simultaneous breaker hold is exactly
+     * {@code renderBytesCharged + responseBytesCharged} — no additional third-party charge may overlap.
+     * During the inner-msearch response callback the render bytes are still held (released only in
+     * {@code runAfter}, after the callback returns), so the peak is render + response. Any regression
+     * that introduces a third concurrent charge would push the peak above that sum and fail this test.
+     */
+    public void testTwoTimesTransientPeakDuringResponseCallback() throws Exception {
+        ClusterService clusterService = clusterServiceWithDataNodes(1);
+        PeakCapturingBreaker breaker = new PeakCapturingBreaker();
+
+        Settings settings = Settings.builder().put("node.name", getTestName()).build();
+        ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        try {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+                @Override
+                public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+                    MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
+                    for (int i = 0; i < items.length; i++) {
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                    }
+                    MultiSearchResponse response = new MultiSearchResponse(items, 1L);
+                    try {
+                        listener.onResponse(response);
+                    } finally {
+                        response.decRef();
+                    }
+                }
+
+                @Override
+                public String getLocalNodeId() {
+                    return "local";
+                }
+            };
+
+            MultiSearchTemplateRequest request = new MultiSearchTemplateRequest();
+            request.add(templateRequest());
+
+            TransportMultiSearchTemplateAction action = buildAction(threadPool, client, clusterService, breaker);
+            Task task = request.createTask(1L, "type", "action", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            action.execute(task, request, future.delegateFailure((l, r) -> l.onResponse(null)));
+            future.get();
+
+            // Sanity: both phases must have charged something.
+            assertThat("render bytes must have been charged", breaker.getRenderBytesCharged(), greaterThan(0L));
+            assertThat("response bytes must have been charged", breaker.getResponseBytesCharged(), greaterThan(0L));
+            // Peak must be exactly render + response: render bytes are still held when response bytes
+            // are charged (runAfter releases render only after the callback returns). Any third
+            // concurrent charge would push the peak above this sum, failing the assertion.
+            assertThat(
+                "peak must be exactly render + response bytes (2× transient peak, no third concurrent charge)",
+                breaker.getPeakNetBytes(),
+                equalTo(breaker.getRenderBytesCharged() + breaker.getResponseBytesCharged())
+            );
+            // After runAfter cleanup all charges are released.
+            assertThat("breaker must be fully released after a successful request", breaker.getUsed(), equalTo(0L));
+        } finally {
+            assertTrue(terminate(threadPool));
+        }
+    }
+}

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
@@ -1066,9 +1066,8 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
             action.execute(task, request, future.delegateFailure((l, r) -> l.onResponse(null)));
             future.get();
 
-            // Sanity: both phases must have charged something.
+            // Render phase must have charged something.
             assertThat("render bytes must have been charged", breaker.getRenderBytesCharged(), greaterThan(0L));
-            assertThat("response bytes must have been charged", breaker.getResponseBytesCharged(), greaterThan(0L));
             // Peak must be exactly render + response: render bytes are still held when response bytes
             // are charged (runAfter releases render only after the callback returns). Any third
             // concurrent charge would push the peak above this sum, failing the assertion.

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -24,7 +25,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.project.TestProjectResolvers;
+
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -343,7 +344,7 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     multiSearchCalls.incrementAndGet();
@@ -351,7 +352,7 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
                     observedConcurrency.set(request.maxConcurrentSearchRequests());
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        SearchResponse sr = SearchResponseUtils.response().build();
+                        SearchResponse sr = SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
                         items[i] = new MultiSearchResponse.Item(sr, null);
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
@@ -405,7 +406,7 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     multiSearchCalls.incrementAndGet();
@@ -459,7 +460,7 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     multiSearchCalls.incrementAndGet();
@@ -531,7 +532,7 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     multiSearchCalls.incrementAndGet();
@@ -591,12 +592,12 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
@@ -648,7 +649,7 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     multiSearchCalls.incrementAndGet();
@@ -705,13 +706,13 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
             // Slot 1 is a convert failure → only 2 searches are sent to multiSearch (slots 0 and 2).
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     assertThat("only slots 0 and 2 reach multiSearch", request.requests().size(), equalTo(2));
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[2];
-                    items[0] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
-                    items[1] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                    items[0] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
+                    items[1] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
                         listener.onResponse(response);
@@ -776,13 +777,13 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
             int numRequests = 3;
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     multiSearchCalls.incrementAndGet();
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
@@ -839,13 +840,13 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     observedParentTask.set(request.getParentTask());
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
@@ -906,7 +907,7 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     multiSearchCalls.incrementAndGet();
@@ -962,12 +963,12 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
         Settings settings = Settings.builder().put("node.name", getTestName()).build();
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
         try {
-            NodeClient client = new NodeClient(Settings.EMPTY, threadPool, TestProjectResolvers.DEFAULT_PROJECT_ONLY) {
+            NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
                 @Override
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.response().build(), null);
+                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateActionTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -352,7 +351,15 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
                     observedConcurrency.set(request.maxConcurrentSearchRequests());
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        SearchResponse sr = SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+                        SearchResponse sr = SearchResponseUtils.emptyWithTotalHits(
+                            null,
+                            1,
+                            1,
+                            0,
+                            0,
+                            ShardSearchFailure.EMPTY_ARRAY,
+                            SearchResponse.Clusters.EMPTY
+                        );
                         items[i] = new MultiSearchResponse.Item(sr, null);
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
@@ -597,7 +604,18 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
+                        items[i] = new MultiSearchResponse.Item(
+                            SearchResponseUtils.emptyWithTotalHits(
+                                null,
+                                1,
+                                1,
+                                0,
+                                0,
+                                ShardSearchFailure.EMPTY_ARRAY,
+                                SearchResponse.Clusters.EMPTY
+                            ),
+                            null
+                        );
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
@@ -711,8 +729,30 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     assertThat("only slots 0 and 2 reach multiSearch", request.requests().size(), equalTo(2));
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[2];
-                    items[0] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
-                    items[1] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
+                    items[0] = new MultiSearchResponse.Item(
+                        SearchResponseUtils.emptyWithTotalHits(
+                            null,
+                            1,
+                            1,
+                            0,
+                            0,
+                            ShardSearchFailure.EMPTY_ARRAY,
+                            SearchResponse.Clusters.EMPTY
+                        ),
+                        null
+                    );
+                    items[1] = new MultiSearchResponse.Item(
+                        SearchResponseUtils.emptyWithTotalHits(
+                            null,
+                            1,
+                            1,
+                            0,
+                            0,
+                            ShardSearchFailure.EMPTY_ARRAY,
+                            SearchResponse.Clusters.EMPTY
+                        ),
+                        null
+                    );
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
                         listener.onResponse(response);
@@ -783,7 +823,18 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
                     multiSearchCalls.incrementAndGet();
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
+                        items[i] = new MultiSearchResponse.Item(
+                            SearchResponseUtils.emptyWithTotalHits(
+                                null,
+                                1,
+                                1,
+                                0,
+                                0,
+                                ShardSearchFailure.EMPTY_ARRAY,
+                                SearchResponse.Clusters.EMPTY
+                            ),
+                            null
+                        );
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
@@ -846,7 +897,18 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
                     observedParentTask.set(request.getParentTask());
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
+                        items[i] = new MultiSearchResponse.Item(
+                            SearchResponseUtils.emptyWithTotalHits(
+                                null,
+                                1,
+                                1,
+                                0,
+                                0,
+                                ShardSearchFailure.EMPTY_ARRAY,
+                                SearchResponse.Clusters.EMPTY
+                            ),
+                            null
+                        );
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {
@@ -968,7 +1030,18 @@ public class TransportMultiSearchTemplateActionTests extends ESTestCase {
                 public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
                     MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.requests().size()];
                     for (int i = 0; i < items.length; i++) {
-                        items[i] = new MultiSearchResponse.Item(SearchResponseUtils.emptyWithTotalHits(null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY), null);
+                        items[i] = new MultiSearchResponse.Item(
+                            SearchResponseUtils.emptyWithTotalHits(
+                                null,
+                                1,
+                                1,
+                                0,
+                                0,
+                                ShardSearchFailure.EMPTY_ARRAY,
+                                SearchResponse.Clusters.EMPTY
+                            ),
+                            null
+                        );
                     }
                     MultiSearchResponse response = new MultiSearchResponse(items, 1L);
                     try {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -108,7 +108,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
      * that shard of the indices the search requests go to are more or less evenly distributed across all nodes in the cluster. But I think
      * it is a good enough default for most cases, if not then the default should be overwritten in the request itself.
      */
-    static int defaultMaxConcurrentSearches(final int allocatedProcessors, final ClusterState state) {
+    public static int defaultMaxConcurrentSearches(final int allocatedProcessors, final ClusterState state) {
         int numDateNodes = state.getNodes().getDataNodes().size();
         // we bound the default concurrency to preserve some search thread pool capacity for other searches
         final int defaultSearchThreadPoolSize = Math.min(ThreadPool.searchOrGetThreadPoolSize(allocatedProcessors), 10);


### PR DESCRIPTION
# Backport

This is a backport of PR #157642 to the `8.19` branch.

## Conflict resolution

`DirectoryMetrics` and `wrapWithSearchMetricsHeader` do not exist in 8.19.

- Dropped `mergeDirectoryMetrics()` from `MultiSearchTemplateResponse` (requires `DirectoryMetrics`)
- `RestMultiSearchTemplateAction` uses `RestCancellableNodeClient` + `RestRefCountedChunkedToXContentListener` directly (no search metrics header)
- Dropped the three `testMergeDirectoryMetrics*` test methods (require `DirectoryMetrics`/`StoreMetrics`)
- Dropped unused `CrossProjectModeDecider` import (9.x-only)

All other changes (batched rendering, circuit breaker accounting, cancellation, parent task propagation) apply cleanly.