### PR TITLE
Finalize release notes for v9.5.3 release

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -13,9 +13,6 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 % ## Next version [elasticsearch-nextversion-breaking-changes]
 
 ## 9.5.3 [elasticsearch-9.5.3-breaking-changes]
-```{applies_to}
-stack: ga 9.5.3
-```
 
 There are no breaking changes associated with this release.
 

--- a/docs/release-notes/changelog-bundles/9.5.3.yml
+++ b/docs/release-notes/changelog-bundles/9.5.3.yml
@@ -1,6 +1,6 @@
 version: 9.5.3
-released: false
-generated: 2026-09-03T08:04:39.081731Z
+released: true
+generated: 2026-09-04T13:51:13.406491Z
 changelogs:
   - pr: 149429
     summary: Fix translog resource leaks and leftover upload tasks on node shutdown

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -17,9 +17,6 @@ To give you insight into what deprecated features you’re using, {{es}}:
 % ## Next version [elasticsearch-nextversion-deprecations]
 
 ## 9.5.3 [elasticsearch-9.5.3-deprecations]
-```{applies_to}
-stack: ga 9.5.3
-```
 
 Monitoring:
 * Deprecate the legacy monitoring REST APIs [#152269](https://github.com/elastic/elasticsearch/pull/152269)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -21,9 +21,6 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % *
 
 ## 9.5.3 [elasticsearch-9.5.3-release-notes]
-```{applies_to}
-stack: ga 9.5.3
-```
 
 ### Features and enhancements [elasticsearch-9.5.3-features-enhancements]
 
@@ -38,8 +35,8 @@ Vector Search:
 ### Fixes [elasticsearch-9.5.3-fixes]
 
 Analysis:
-* Prevent out-of-memory errors from extreme `min_hash` filter settings [#154480](https://github.com/elastic/elasticsearch/pull/154480)
 * Limit `min_hash` filter parameters to prevent integer overflow [#158211](https://github.com/elastic/elasticsearch/pull/158211)
+* Prevent out-of-memory errors from extreme `min_hash` filter settings [#154480](https://github.com/elastic/elasticsearch/pull/154480)
 
 Authorization:
 * Fix field-level security filtering for `_field_names` terms [#157889](https://github.com/elastic/elasticsearch/pull/157889)
@@ -55,12 +52,12 @@ Data streams:
 * Fix data stream auto-sharding using stale index settings [#157634](https://github.com/elastic/elasticsearch/pull/157634) (issue: [#134505](https://github.com/elastic/elasticsearch/issues/134505))
 
 ES|QL:
-* Fix failures in string functions that use extracted fields [#156980](https://github.com/elastic/elasticsearch/pull/156980)
-* Fix query failures when a multi-field sub-field has conflicting types across indices [#156326](https://github.com/elastic/elasticsearch/pull/156326)
+* Fix `MV_MIN` and `MV_MAX` on `ip` fields in columnar mode [#157790](https://github.com/elastic/elasticsearch/pull/157790) (issue: [#157521](https://github.com/elastic/elasticsearch/issues/157521))
 * Fix `ROUND` overflowing integer values when used with negative precision [#156412](https://github.com/elastic/elasticsearch/pull/156412) (issue: [#156411](https://github.com/elastic/elasticsearch/issues/156411))
 * Fix `TS` `STATS` dropping constant literal aggregates [#157148](https://github.com/elastic/elasticsearch/pull/157148) (issue: [#157103](https://github.com/elastic/elasticsearch/issues/157103))
+* Fix failures in string functions that use extracted fields [#156980](https://github.com/elastic/elasticsearch/pull/156980)
 * Fix failures when reading `_ignored_source` out of document order [#157798](https://github.com/elastic/elasticsearch/pull/157798)
-* Fix `MV_MIN` and `MV_MAX` on `ip` fields in columnar mode [#157790](https://github.com/elastic/elasticsearch/pull/157790) (issue: [#157521](https://github.com/elastic/elasticsearch/issues/157521))
+* Fix query failures when a multi-field sub-field has conflicting types across indices [#156326](https://github.com/elastic/elasticsearch/pull/156326)
 
 Engine:
 * Fix translog resource leaks and leftover upload tasks on node shutdown [#149429](https://github.com/elastic/elasticsearch/pull/149429) (issue: [#149343](https://github.com/elastic/elasticsearch/issues/149343))
@@ -75,8 +72,8 @@ Machine Learning:
 
 Mapping:
 * Fix composite aggregations returning no buckets on logsdb timestamp fields [#158060](https://github.com/elastic/elasticsearch/pull/158060) (issue: [#158008](https://github.com/elastic/elasticsearch/issues/158008))
-* Fix search crashes from empty collect ranges in doc-values queries [#157630](https://github.com/elastic/elasticsearch/pull/157630)
 * Fix contains queries failing on single-valued keyword fields [#158187](https://github.com/elastic/elasticsearch/pull/158187)
+* Fix search crashes from empty collect ranges in doc-values queries [#157630](https://github.com/elastic/elasticsearch/pull/157630)
 
 Reindex:
 * Fail reindex tasks that cannot relocate during node shutdown [#150342](https://github.com/elastic/elasticsearch/pull/150342) (issues: [#150294](https://github.com/elastic/elasticsearch/issues/150294), [#150295](https://github.com/elastic/elasticsearch/issues/150295))
@@ -85,8 +82,8 @@ SQL:
 * Fix the SQL `INSERT` function ignoring the result size limit [#157752](https://github.com/elastic/elasticsearch/pull/157752)
 
 Search:
-* Speed up `_shard_doc` `search_after` pagination by applying sort pruning [#157044](https://github.com/elastic/elasticsearch/pull/157044) (issue: [#155559](https://github.com/elastic/elasticsearch/issues/155559))
 * Fix kNN automatic pre-filtering for `exists` queries on inference fields [#158296](https://github.com/elastic/elasticsearch/pull/158296) (issue: [#157951](https://github.com/elastic/elasticsearch/issues/157951))
+* Speed up `_shard_doc` `search_after` pagination by applying sort pruning [#157044](https://github.com/elastic/elasticsearch/pull/157044) (issue: [#155559](https://github.com/elastic/elasticsearch/issues/155559))
 
 Task Management:
 * Fix leaking cancellation tasks in incremental bulk indexing [#158108](https://github.com/elastic/elasticsearch/pull/158108) (issue: [#158018](https://github.com/elastic/elasticsearch/issues/158018))


### PR DESCRIPTION
Finalizes the 9.5.3 release notes now that the release has shipped. Marks the changelog bundle as released and removes the `applies_to` unreleased markers. Generated manually with `./gradlew bundleChangelogs --branch=9.5 --bc-ref=d89b36a3bd00f4a74f4ceb2e64356d9336cc37d2 --finalize`