### PR TITLE
Skip dense vector counts on stateless

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/DenseVectorStatsCache.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/DenseVectorStatsCache.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.lucene90.IndexedDISI;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.index.shard.DenseVectorStats;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Caches the per-field vector counts of a segment, keyed on its core cache key so entries survive a refresh and are
+ * dropped when the segment closes. Reading a count opens the field's vector values, which for a sparse field builds an
+ * {@link IndexedDISI} and prefetches; off-heap sizes come from field metadata, so they are neither cached nor skipped.
+ */
+final class DenseVectorStatsCache {
+
+    private final Map<IndexReader.CacheKey, Map<String, Long>> perSegment = ConcurrentCollections.newConcurrentMap();
+
+    /**
+     * Returns what {@code leafReader} contributes to the dense vector stats for the given fields. When
+     * {@code includeCounts} is false the vector values are never opened, and the returned count is zero.
+     */
+    DenseVectorStats get(LeafReader leafReader, Iterable<String> fieldNames, boolean includeCounts) throws IOException {
+        final Map<String, Long> cachedCounts = includeCounts ? cacheFor(leafReader) : null;
+        long count = 0;
+        final Map<String, Map<String, Long>> offHeapStats = new HashMap<>();
+        for (String fieldName : fieldNames) {
+            final FieldInfo info = leafReader.getFieldInfos().fieldInfo(fieldName);
+            if (info == null || info.getVectorDimension() <= 0) {
+                continue;
+            }
+            if (includeCounts) {
+                Long fieldCount = cachedCounts == null ? null : cachedCounts.get(fieldName);
+                if (fieldCount == null) {
+                    fieldCount = countVectors(leafReader, info);
+                    if (cachedCounts != null) {
+                        cachedCounts.put(fieldName, fieldCount);
+                    }
+                }
+                count += fieldCount;
+            }
+            offHeapStats.put(fieldName, offHeapByteSize(leafReader, info));
+        }
+        return new DenseVectorStats(count, Collections.unmodifiableMap(offHeapStats));
+    }
+
+    /**
+     * Returns the per-field map for this segment, or {@code null} if it cannot be cached, in which case the caller
+     * recomputes.
+     */
+    private Map<String, Long> cacheFor(LeafReader leafReader) {
+        final IndexReader.CacheHelper cacheHelper = leafReader.getCoreCacheHelper();
+        if (cacheHelper == null) {
+            return null;
+        }
+        final IndexReader.CacheKey cacheKey = cacheHelper.getKey();
+        final Map<String, Long> existing = perSegment.get(cacheKey);
+        if (existing != null) {
+            return existing;
+        }
+        final Map<String, Long> created = ConcurrentCollections.newConcurrentMap();
+        final Map<String, Long> witness = perSegment.putIfAbsent(cacheKey, created);
+        if (witness != null) {
+            return witness;
+        }
+        try {
+            cacheHelper.addClosedListener(perSegment::remove);
+        } catch (AlreadyClosedException e) {
+            // no listener will fire to drop this entry, so drop it now
+            perSegment.remove(cacheKey, created);
+            return null;
+        }
+        return created;
+    }
+
+    private static long countVectors(LeafReader leafReader, FieldInfo info) throws IOException {
+        return switch (info.getVectorEncoding()) {
+            case FLOAT32 -> {
+                FloatVectorValues values = leafReader.getFloatVectorValues(info.name);
+                yield values != null ? values.size() : 0;
+            }
+            case BYTE -> {
+                ByteVectorValues values = leafReader.getByteVectorValues(info.name);
+                yield values != null ? values.size() : 0;
+            }
+        };
+    }
+
+    private static Map<String, Long> offHeapByteSize(LeafReader leafReader, FieldInfo info) throws IOException {
+        final SegmentReader segmentReader = Lucene.segmentReader(leafReader);
+        KnnVectorsReader vectorsReader = segmentReader.getVectorReader();
+        if (vectorsReader instanceof PerFieldKnnVectorsFormat.FieldsReader fieldsReader) {
+            vectorsReader = fieldsReader.getFieldReader(info.name);
+        }
+        return vectorsReader.getOffHeapByteSize(info);
+    }
+
+    // visible for testing
+    int cachedSegments() {
+        return perSegment.size();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -12,11 +12,9 @@ package org.elasticsearch.index.engine;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
-import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexReader;
@@ -174,6 +172,8 @@ public abstract class Engine implements Closeable {
     private final Releasable releaseEnsureOpenRef = ensureOpenRefs::decRef; // reuse this to avoid allocation for each op
 
     private final boolean isStateless;
+
+    private final DenseVectorStatsCache denseVectorStatsCache = new DenseVectorStatsCache();
 
     /*
      * on {@code lastWriteNanos} we use System.nanoTime() to initialize this since:
@@ -387,7 +387,8 @@ public abstract class Engine implements Closeable {
     }
 
     /**
-     * Returns the {@link DenseVectorStats} for this engine
+     * Returns the {@link DenseVectorStats} for this engine. On stateless the vector counts are not collected, see
+     * {@link DenseVectorStatsCache}.
      */
     public DenseVectorStats denseVectorStats(MappingLookup mappingLookup) {
         if (mappingLookup == null) {
@@ -411,44 +412,21 @@ public abstract class Engine implements Closeable {
     protected final DenseVectorStats denseVectorStats(IndexReader indexReader, List<DenseVectorFieldMapper> fields) {
         // we don't wait for a pending refreshes here since it's a stats call instead we mark it as accessed only which will cause
         // the next scheduled refresh to go through and refresh the stats as well
+        final List<String> fieldNames = new ArrayList<>(fields.size());
+        for (var fieldMapper : fields) {
+            fieldNames.add(fieldMapper.fullPath());
+        }
         var stats = new DenseVectorStats();
         for (LeafReaderContext readerContext : indexReader.leaves()) {
             try {
-                stats.add(getDenseVectorStats(readerContext.reader(), fields));
+                // counting vectors opens their values, which on a remote-backed directory fetches a cache region per
+                // field per segment; off-heap sizes come from field metadata and are always cheap
+                stats.add(denseVectorStatsCache.get(readerContext.reader(), fieldNames, isStateless == false));
             } catch (IOException e) {
                 logger.trace(() -> "failed to get dense vector stats for [" + readerContext + "]", e);
             }
         }
         return stats;
-    }
-
-    private DenseVectorStats getDenseVectorStats(final LeafReader atomicReader, List<DenseVectorFieldMapper> fieldMappers)
-        throws IOException {
-        long count = 0;
-        Map<String, Map<String, Long>> offHeapStats = new HashMap<>();
-        for (var fieldMapper : fieldMappers) {
-            FieldInfo info = atomicReader.getFieldInfos().fieldInfo(fieldMapper.fullPath());
-            if (info != null && info.getVectorDimension() > 0) {
-                switch (info.getVectorEncoding()) {
-                    case FLOAT32 -> {
-                        FloatVectorValues values = atomicReader.getFloatVectorValues(info.name);
-                        count += values != null ? values.size() : 0;
-                    }
-                    case BYTE -> {
-                        ByteVectorValues values = atomicReader.getByteVectorValues(info.name);
-                        count += values != null ? values.size() : 0;
-                    }
-                }
-                SegmentReader reader = Lucene.segmentReader(atomicReader);
-                var vectorsReader = reader.getVectorReader();
-                if (vectorsReader instanceof PerFieldKnnVectorsFormat.FieldsReader fieldsReader) {
-                    vectorsReader = fieldsReader.getFieldReader(info.name);
-                }
-                Map<String, Long> offHeap = vectorsReader.getOffHeapByteSize(info);
-                offHeapStats.put(info.name, offHeap);
-            }
-        }
-        return new DenseVectorStats(count, Collections.unmodifiableMap(offHeapStats));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/engine/DenseVectorStatsCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/DenseVectorStatsCacheTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.index.shard.DenseVectorStats;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class DenseVectorStatsCacheTests extends ESTestCase {
+
+    private static final String FIELD = "vector";
+
+    /** A segment is inspected once, however many times its stats are asked for. */
+    public void testSegmentIsInspectedOnce() throws Exception {
+        final AtomicInteger prefetches = new AtomicInteger();
+        try (Directory directory = new PrefetchCountingDirectory(newDirectory(), prefetches)) {
+            indexVectors(directory, 32);
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                final LeafReader leafReader = reader.leaves().get(0).reader();
+                final DenseVectorStatsCache cache = new DenseVectorStatsCache();
+
+                final DenseVectorStats first = cache.get(leafReader, List.of(FIELD), true);
+                final int afterFirst = prefetches.get();
+                assertThat("opening the vector values should have prefetched", afterFirst, greaterThan(0));
+                assertThat(first.getValueCount(), greaterThan(0L));
+
+                for (int i = 0; i < 5; i++) {
+                    final DenseVectorStats repeated = cache.get(leafReader, List.of(FIELD), true);
+                    assertEquals(first.getValueCount(), repeated.getValueCount());
+                    assertEquals(first.offHeapStats(), repeated.offHeapStats());
+                }
+                assertEquals("repeated stats calls must not touch the directory again", afterFirst, prefetches.get());
+                assertEquals(1, cache.cachedSegments());
+            }
+        }
+    }
+
+    /** A refresh reuses unchanged segment cores, so their entries survive and only the new segment is inspected. */
+    public void testEntriesSurviveRefresh() throws Exception {
+        final AtomicInteger prefetches = new AtomicInteger();
+        try (Directory directory = new PrefetchCountingDirectory(newDirectory(), prefetches)) {
+            try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+                addVectorDocs(writer, 16);
+                writer.commit();
+
+                final DenseVectorStatsCache cache = new DenseVectorStatsCache();
+                DirectoryReader reader = DirectoryReader.open(directory);
+                try {
+                    final long countBefore = statsFor(cache, reader);
+                    assertEquals(1, cache.cachedSegments());
+                    final IndexReader.CacheKey originalSegment = reader.leaves().get(0).reader().getCoreCacheHelper().getKey();
+
+                    addVectorDocs(writer, 16);
+                    writer.commit();
+
+                    final DirectoryReader refreshed = DirectoryReader.openIfChanged(reader);
+                    assertNotNull("expected the commit to be visible", refreshed);
+                    reader.close();
+                    reader = refreshed;
+                    assertEquals(2, reader.leaves().size());
+
+                    // the segment that was already inspected is still cached, so asking for it again is free
+                    final LeafReader carriedOver = leafWithCoreKey(reader, originalSegment);
+                    final int beforeCarriedOver = prefetches.get();
+                    cache.get(carriedOver, List.of(FIELD), true);
+                    assertEquals("the surviving segment must not be inspected again", beforeCarriedOver, prefetches.get());
+
+                    // the new segment is inspected, and contributes to the count
+                    final long countAfter = statsFor(cache, reader);
+                    assertThat(countAfter, greaterThan(countBefore));
+                    assertThat(prefetches.get(), greaterThan(beforeCarriedOver));
+                    assertEquals(2, cache.cachedSegments());
+                } finally {
+                    reader.close();
+                }
+            }
+        }
+    }
+
+    /** A segment closing drops its entry, so the cache does not grow as segments are merged away. */
+    public void testEntryDroppedWhenSegmentCloses() throws Exception {
+        final AtomicInteger prefetches = new AtomicInteger();
+        try (Directory directory = new PrefetchCountingDirectory(newDirectory(), prefetches)) {
+            indexVectors(directory, 16);
+            final DenseVectorStatsCache cache = new DenseVectorStatsCache();
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                cache.get(reader.leaves().get(0).reader(), List.of(FIELD), true);
+                assertEquals(1, cache.cachedSegments());
+            }
+            assertEquals("closing the reader must drop the entry", 0, cache.cachedSegments());
+        }
+    }
+
+    /** A field the segment does not have contributes nothing, and costs nothing. */
+    public void testUnknownFieldIsIgnored() throws Exception {
+        final AtomicInteger prefetches = new AtomicInteger();
+        try (Directory directory = new PrefetchCountingDirectory(newDirectory(), prefetches)) {
+            indexVectors(directory, 16);
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                final DenseVectorStatsCache cache = new DenseVectorStatsCache();
+                final int before = prefetches.get();
+                final DenseVectorStats stats = cache.get(reader.leaves().get(0).reader(), List.of("no_such_field"), true);
+                assertEquals(0L, stats.getValueCount());
+                assertEquals(before, prefetches.get());
+            }
+        }
+    }
+
+    /** With counts excluded the values are never opened, but the off-heap sizes are still reported. */
+    public void testOffHeapReportedWithoutCounts() throws Exception {
+        final AtomicInteger prefetches = new AtomicInteger();
+        try (Directory directory = new PrefetchCountingDirectory(newDirectory(), prefetches)) {
+            indexVectors(directory, 32);
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                final LeafReader leafReader = reader.leaves().get(0).reader();
+                final DenseVectorStatsCache cache = new DenseVectorStatsCache();
+
+                final int before = prefetches.get();
+                final DenseVectorStats stats = cache.get(leafReader, List.of(FIELD), false);
+                assertEquals("the vector values must not be opened", before, prefetches.get());
+                assertEquals(0L, stats.getValueCount());
+                assertEquals(Set.of(FIELD), stats.offHeapStats().keySet());
+                assertThat(stats.offHeapStats().get(FIELD).values().stream().mapToLong(Long::longValue).sum(), greaterThan(0L));
+                assertEquals("nothing should have been cached", 0, cache.cachedSegments());
+            }
+        }
+    }
+
+    private static LeafReader leafWithCoreKey(DirectoryReader reader, IndexReader.CacheKey key) {
+        for (LeafReaderContext context : reader.leaves()) {
+            if (context.reader().getCoreCacheHelper().getKey().equals(key)) {
+                return context.reader();
+            }
+        }
+        throw new AssertionError("the segment did not survive the refresh");
+    }
+
+    private static long statsFor(DenseVectorStatsCache cache, DirectoryReader reader) throws IOException {
+        long count = 0;
+        for (LeafReaderContext context : reader.leaves()) {
+            count += cache.get(context.reader(), List.of(FIELD), true).getValueCount();
+        }
+        return count;
+    }
+
+    private static void indexVectors(Directory directory, int docs) throws IOException {
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig())) {
+            addVectorDocs(writer, docs);
+            writer.commit();
+        }
+    }
+
+    /** Only every other document gets a vector, so the field is sparse and read through an {@code IndexedDISI}. */
+    private static void addVectorDocs(IndexWriter writer, int docs) throws IOException {
+        for (int i = 0; i < docs; i++) {
+            final Document document = new Document();
+            if (i % 2 == 0) {
+                document.add(new KnnFloatVectorField(FIELD, new float[] { i, i + 1, i + 2, i + 3 }, VectorSimilarityFunction.COSINE));
+            }
+            writer.addDocument(document);
+        }
+    }
+
+    /** Counts {@link IndexInput#prefetch} calls, including on slices and clones. */
+    private static class PrefetchCountingDirectory extends FilterDirectory {
+
+        private final AtomicInteger prefetches;
+
+        PrefetchCountingDirectory(Directory in, AtomicInteger prefetches) {
+            super(in);
+            this.prefetches = prefetches;
+        }
+
+        @Override
+        public IndexInput openInput(String name, IOContext context) throws IOException {
+            return new CountingIndexInput(super.openInput(name, context), prefetches);
+        }
+    }
+
+    private static class CountingIndexInput extends FilterIndexInput {
+
+        private final AtomicInteger prefetches;
+
+        CountingIndexInput(IndexInput in, AtomicInteger prefetches) {
+            super("CountingIndexInput(" + in + ")", in);
+            this.prefetches = prefetches;
+        }
+
+        @Override
+        public void prefetch(long offset, long length) throws IOException {
+            prefetches.incrementAndGet();
+            in.prefetch(offset, length);
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+            return new CountingIndexInput(in.slice(sliceDescription, offset, length), prefetches);
+        }
+
+        @Override
+        public IndexInput clone() {
+            return new CountingIndexInput(in.clone(), prefetches);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/DenseVectorStatsStatelessTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/DenseVectorStatsStatelessTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.index.NoMergePolicy;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.shard.DenseVectorStats;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class DenseVectorStatsStatelessTests extends EngineTestCase {
+
+    @Override
+    protected String defaultMapping() {
+        return """
+            {
+              "properties": {
+                "dv": {
+                  "type": "dense_vector",
+                  "dims": 3,
+                  "similarity": "cosine"
+                }
+              }
+            }
+            """;
+    }
+
+    public void testCountsAreCollectedWhenNotStateless() throws Exception {
+        final DenseVectorStats stats = denseVectorStats(Settings.EMPTY);
+        assertThat(stats.getValueCount(), greaterThan(0L));
+        assertThat(offHeapSize(stats), greaterThan(0L));
+    }
+
+    public void testCountsAreSkippedOnStatelessButOffHeapIsNot() throws Exception {
+        final DenseVectorStats stats = denseVectorStats(Settings.builder().put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true).build());
+        assertEquals(0L, stats.getValueCount());
+        assertThat(offHeapSize(stats), greaterThan(0L));
+    }
+
+    private static long offHeapSize(DenseVectorStats stats) {
+        assertEquals(Set.of("dv"), stats.offHeapStats().keySet());
+        return stats.offHeapStats().get("dv").values().stream().mapToLong(Long::longValue).sum();
+    }
+
+    /**
+     * Indexes documents carrying a dense vector into an engine configured with the given node settings, and returns the
+     * stats it reports for them.
+     */
+    private DenseVectorStats denseVectorStats(Settings nodeSettings) throws IOException {
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(defaultSettings.getIndex(), indexSettings(), nodeSettings);
+        assertEquals(nodeSettings.isEmpty() == false, DiscoveryNode.isStateless(indexSettings.getNodeSettings()));
+
+        try (Store store = createStore()) {
+            final EngineConfig config = config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE);
+            final DocumentMapper documentMapper = config.getMapperService().documentMapper();
+            try (InternalEngine engine = createEngine(config)) {
+                for (int i = 0; i < randomIntBetween(4, 16); i++) {
+                    final String source = Strings.format("{\"dv\":[%s,%s,%s]}", randomFloat() + 1, randomFloat() + 1, randomFloat() + 1);
+                    engine.index(indexForDoc(documentMapper.parse(new SourceToParse("d_" + i, new BytesArray(source), XContentType.JSON))));
+                }
+                engine.refresh("test");
+                return engine.denseVectorStats(config.getMapperService().mappingLookup());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Counting a field's vectors opens its vector values, which for a sparse field builds an `IndexedDISI` and prefetches. On a directory backed by remote storage each prefetch fetches a whole cache region, so `_cluster/stats` — which includes `DenseVector` in its hardcoded `SHARD_STATS_FLAGS` — walks every vector field of every segment and pays a region fetch for each one, on every poll.

Skip the counts on stateless. Off-heap sizes are read from field metadata rather than from the values, so they cost nothing and are still reported; only the count is dropped, reporting zero. `DenseVectorStats#valueCount` is a `writeVLong` field, so a negative sentinel is not an option without a wire change.

The count is already in the field entry, right next to the `vectorDataLength` that `getOffHeapByteSize` returns for free — a `KnnVectorsReader#size(FieldInfo)` upstream would let this be reverted.

Also caches the counts per segment, keyed on the core cache key so entries survive a refresh and are dropped when the segment closes. That keeps stateful deployments from re-inspecting a segment on every poll.