### PR TITLE
Gate persisted datafeed preview CPS on stored UIAM envelope

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedAction.java
@@ -177,7 +177,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
             DatafeedConfig effectiveDatafeedConfig = DatafeedConfig.withCrossProjectModeIfEnabled(
                 previewDatafeedConfig,
                 crossProjectModeDecider,
-                callerCredential != null
+                isCrossProjectPreviewAllowed(request, datafeedConfig, callerCredential != null)
             );
             final Client previewClient = cloudCredentialManager.wrapClient(
                 new ParentTaskAssigningClient(client, parentTaskId),
@@ -208,6 +208,24 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                 )
             );
         });
+    }
+
+    /**
+     * Whether preview may promote {@link DatafeedConfig} to cross-project {@link org.elasticsearch.action.support.IndicesOptions}.
+     * Persisted-ID preview requires a stored UIAM envelope (runtime parity); inline preview requires only a cloud caller.
+     */
+    static boolean isCrossProjectPreviewAllowed(
+        PreviewDatafeedAction.Request request,
+        DatafeedConfig persistedConfig,
+        boolean hasCallerCloudCredential
+    ) {
+        if (hasCallerCloudCredential == false) {
+            return false;
+        }
+        if (request.getDatafeedConfig() != null) {
+            return true;
+        }
+        return persistedConfig.getCloudInternalCredential() != null;
     }
 
     /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
@@ -99,6 +99,40 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
         assertThat(previewDatafeed.getCloudInternalCredential(), nullValue());
     }
 
+    public void testIsCrossProjectPreviewAllowed_GivenPersistedLegacyWithoutEnvelope_ShouldReturnFalse() {
+        DatafeedConfig persisted = new DatafeedConfig.Builder("legacy_feed", "job_foo").setIndices(List.of("logs-*")).build();
+        PreviewDatafeedAction.Request request = new PreviewDatafeedAction.Request("legacy_feed", (String) null, (String) null);
+
+        assertThat(TransportPreviewDatafeedAction.isCrossProjectPreviewAllowed(request, persisted, true), is(false));
+    }
+
+    public void testIsCrossProjectPreviewAllowed_GivenPersistedWithEnvelopeAndCaller_ShouldReturnTrue() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("uiam_feed", "job_foo");
+        builder.setIndices(List.of("logs-*"));
+        builder.setCloudInternalCredential(new PersistedCloudCredential("id", randomCloudCredentialEncryptedData()));
+        PreviewDatafeedAction.Request request = new PreviewDatafeedAction.Request("uiam_feed", (String) null, (String) null);
+
+        assertThat(TransportPreviewDatafeedAction.isCrossProjectPreviewAllowed(request, builder.build(), true), is(true));
+    }
+
+    public void testIsCrossProjectPreviewAllowed_GivenInlinePreviewAndCaller_ShouldReturnTrue() {
+        DatafeedConfig inline = new DatafeedConfig.Builder("inline_feed", "job_foo").setIndices(List.of("logs-*")).build();
+        PreviewDatafeedAction.Request request = new PreviewDatafeedAction.Request(inline, null, null, null);
+
+        assertThat(TransportPreviewDatafeedAction.isCrossProjectPreviewAllowed(request, inline, true), is(true));
+    }
+
+    public void testIsCrossProjectPreviewAllowed_GivenNoCallerCredential_ShouldReturnFalse() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("uiam_feed", "job_foo");
+        builder.setIndices(List.of("logs-*"));
+        builder.setCloudInternalCredential(new PersistedCloudCredential("id", randomCloudCredentialEncryptedData()));
+        PreviewDatafeedAction.Request persistedRequest = new PreviewDatafeedAction.Request("uiam_feed", (String) null, (String) null);
+        PreviewDatafeedAction.Request inlineRequest = new PreviewDatafeedAction.Request(builder.build(), null, null, null);
+
+        assertThat(TransportPreviewDatafeedAction.isCrossProjectPreviewAllowed(persistedRequest, builder.build(), false), is(false));
+        assertThat(TransportPreviewDatafeedAction.isCrossProjectPreviewAllowed(inlineRequest, builder.build(), false), is(false));
+    }
+
     public void testWithCrossProjectModeIfEnabled_GivenCpsEnabled_ShouldEnableCrossProjectIndicesOptions() {
         assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("preview_cps_feed", "job_foo");


### PR DESCRIPTION
## Summary

Persisted-ID datafeed preview now promotes cross-project `IndicesOptions` only when the stored datafeed already has `cloud_internal_credential` and the previewing caller carries a cloud-managed credential. Inline preview (`POST /_ml/datafeeds/_preview` with `datafeed_config`) still enables CPS from the caller alone.

This aligns persisted preview with runtime/start behavior for legacy datafeeds that have no UIAM envelope yet (e.g. flat-world `pv_data` preview no longer fans out to linked projects). Preview still clears the stored envelope and executes under the caller credential; it does not mint UIAM keys.

