### PR TITLE
[CI] Resolve ml-cpp artifacts via DRA build id

### DIFF
--- a/.buildkite/scripts/release-tests.sh
+++ b/.buildkite/scripts/release-tests.sh
@@ -2,15 +2,59 @@
 
 set -euo pipefail
 
+curl_retrying() {
+  curl --fail --location --show-error --silent \
+    --retry 5 --retry-connrefused --retry-delay 2 --retry-max-time 120 "$@"
+}
+
 curl_with_retry() {
   local output_path="$1"
   local url="$2"
 
   echo "Downloading $(basename "${output_path}")"
-  curl --fail --location --show-error --silent \
-    --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 120 \
-    -o "${output_path}" "${url}"
+  curl_retrying --retry-all-errors -o "${output_path}" "${url}"
 }
+
+# Resolve the id of the most recent published snapshot build of a DRA project.
+#
+# DRA publishes each build under an immutable "<build-id>/" prefix and updates a
+# "latest/<version>-SNAPSHOT.json" pointer to name it. Only these two are
+# guaranteed; the floating "<version>-SNAPSHOT/" prefix is not maintained by all
+# projects, so artifacts must be fetched via the resolved build id. The pointer
+# is keyed by version rather than branch on purpose: this script also runs on
+# pull request branches, whose names carry no relation to the publishing project.
+resolve_latest_build_id() {
+  local project="$1"
+  local version="$2"
+  local pointer_url="https://artifacts-snapshot.elastic.co/${project}/latest/${version}-SNAPSHOT.json"
+  local pointer_json
+  local build_id
+
+  if ! pointer_json=$(curl_retrying "${pointer_url}"); then
+    echo "No ${project} snapshot build pointer exists at ${pointer_url}." >&2
+    echo "If Elasticsearch was just bumped to ${version}, ${project} has not published that version yet." >&2
+    return 1
+  fi
+
+  if ! build_id=$(jq -r '.build_id // empty' <<<"${pointer_json}"); then
+    echo "Could not parse the ${project} build pointer at ${pointer_url}; it returned:" >&2
+    echo "${pointer_json}" >&2
+    return 1
+  fi
+
+  if [[ -z "${build_id}" ]]; then
+    echo "The ${project} build pointer at ${pointer_url} names no build id; it returned:" >&2
+    echo "${pointer_json}" >&2
+    return 1
+  fi
+
+  echo "${build_id}"
+}
+
+
+# The build resolves dependencies without the -SNAPSHOT qualifier under
+# -Dbuild.snapshot=false, so the snapshot artifacts are staged into a local ivy
+# repository under their release names.
 
 # Fetch beats artifacts
 export ES_VERSION=$(grep 'elasticsearch' build-tools-internal/version.properties | awk '{print $3}')
@@ -28,11 +72,15 @@ curl_with_retry "${BEATS_DIR}/filebeat-fips-${ES_VERSION}-linux-x86_64.tar.gz" "
 curl_with_retry "${BEATS_DIR}/filebeat-fips-${ES_VERSION}-linux-arm64.tar.gz" "https://artifacts-snapshot.elastic.co/beats/${ES_VERSION}-SNAPSHOT/downloads/beats/filebeat/filebeat-fips-${ES_VERSION}-SNAPSHOT-linux-arm64.tar.gz"
 
 # Fetch ML artifacts
+ML_CPP_BUILD_ID=$(resolve_latest_build_id ml-cpp "${ES_VERSION}")
+echo "ML_CPP_BUILD_ID=${ML_CPP_BUILD_ID}"
+
+ML_CPP_DOWNLOADS="https://artifacts-snapshot.elastic.co/ml-cpp/${ML_CPP_BUILD_ID}/downloads/ml-cpp"
 export ML_IVY_REPO=$(mktemp -d)
 mkdir -p ${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}
-curl_with_retry "${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}/ml-cpp-${ES_VERSION}-deps.zip" "https://artifacts-snapshot.elastic.co/ml-cpp/${ES_VERSION}-SNAPSHOT/downloads/ml-cpp/ml-cpp-${ES_VERSION}-SNAPSHOT-deps.zip"
-curl_with_retry "${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}/ml-cpp-${ES_VERSION}-nodeps.zip" "https://artifacts-snapshot.elastic.co/ml-cpp/${ES_VERSION}-SNAPSHOT/downloads/ml-cpp/ml-cpp-${ES_VERSION}-SNAPSHOT-nodeps.zip"
-curl_with_retry "${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}/ml-cpp-${ES_VERSION}.zip" "https://artifacts-snapshot.elastic.co/ml-cpp/${ES_VERSION}-SNAPSHOT/downloads/ml-cpp/ml-cpp-${ES_VERSION}-SNAPSHOT.zip"
+curl_with_retry "${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}/ml-cpp-${ES_VERSION}-deps.zip" "${ML_CPP_DOWNLOADS}/ml-cpp-${ES_VERSION}-SNAPSHOT-deps.zip"
+curl_with_retry "${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}/ml-cpp-${ES_VERSION}-nodeps.zip" "${ML_CPP_DOWNLOADS}/ml-cpp-${ES_VERSION}-SNAPSHOT-nodeps.zip"
+curl_with_retry "${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}/ml-cpp-${ES_VERSION}.zip" "${ML_CPP_DOWNLOADS}/ml-cpp-${ES_VERSION}-SNAPSHOT.zip"
 
 .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dbuild.snapshot=false -Dbuild.ml_cpp.repo=file://${ML_IVY_REPO} \
   -Dtests.jvm.argline=-Dbuild.snapshot=false -Dlicense.key=${WORKSPACE}/x-pack/license-tools/src/test/resources/public.key -Dbuild.id=deadbeef ${@:-functionalTests}


### PR DESCRIPTION
The `release-tests` jobs started failing on every pull request with `curl` exit status 22:

```
Downloading ml-cpp-9.6.0-deps.zip
curl: (22) The requested URL returned error: 404
```

The 404 is on `.../ml-cpp/9.6.0-SNAPSHOT/downloads/ml-cpp/ml-cpp-9.6.0-SNAPSHOT-deps.zip`.

## Why it broke

ml-cpp migrated its DRA publishing from Release Manager to the `dra-prep` plugin in [elastic/ml-cpp#3161](https://github.com/elastic/ml-cpp/pull/3161).
The replacement pipeline writes artifacts to `ml-cpp/<build-id>/` and updates the `ml-cpp/latest/<version>-SNAPSHOT.json` pointer, but nothing writes the floating `ml-cpp/<version>-SNAPSHOT/downloads/` prefix that this script used.

Stale objects from the last Release Manager run kept the old path working, so nothing broke at migration time.
Once those were cleaned up, the path 404'd for every ml-cpp version at once.
A periodic build downloaded the same URL successfully at 00:44 UTC the same day it started failing.

A side effect worth noting: between the migration and the cleanup, release-tests was quietly building against ml-cpp binaries frozen at the migration date.

## The fix

Resolve the build id from `latest/<version>-SNAPSHOT.json` and download from the immutable `<build-id>/` prefix.
That pointer is written on every publish by the new pipeline, so it does not depend on a path no one maintains.

The pointer is keyed by **version**, not branch.
`release-tests.sh` runs on contributor pull request branches, so `BUILDKITE_BRANCH` can never be a valid DRA key.
Version keying also avoids ml-cpp's branch naming: `latest/main.json` is 404 (its branch is `master`) and `latest/9.6.json` is 404 (9.6 has no branch yet, master carries it).

This is the same resolution `.ci/scripts/resolve-dra-manifest.sh` performs for `dra-workflow.sh`.
That script is not reused here because its snapshot path is branch-keyed, and extending it would put a PR-only fix on the release publishing path.

Failures are loud by design.
A missing pointer, an unparseable body, and a pointer naming no build id each report distinctly, and `set -euo pipefail` aborts before any download rather than proceeding with an empty build id.
Retries on the pointer cover transient errors only, so a 404 fails in under a second instead of repeating six times over 11 seconds.

## Verification

Resolution and all three artifact URLs confirmed for every version release-tests builds against:

| version | resolved build id | artifacts |
|---|---|---|
| 9.6.0 | `9.6.0-6096fae7` | deps, nodeps, main zip all reachable |
| 9.5.4 | `9.5.4-012197bf` | all reachable |
| 8.19.22 | `8.19.22-78792576` | all reachable |

Each error path was exercised, including the version-bump-skew case (`latest/9.7.0-SNAPSHOT.json` is 404 today), and confirmed to abort before the download block.

## Scope

The beats downloads still use the floating prefix.
Beats publishes it and is not broken, so switching a working path is out of scope.
`resolve_latest_build_id` takes the project as a parameter, so migrating beats later is a small change.

This does not fix the underlying regression in ml-cpp's publishing; the missing alias is still worth reporting so other consumers are not caught by it.
