### PR TITLE
ESQL: lift position limits on runtime search

### DIFF
--- a/docs/reference/query-languages/esql/limitations.md
+++ b/docs/reference/query-languages/esql/limitations.md
@@ -197,10 +197,25 @@ still not supported after `INLINE STATS`. A `STATS` command before the search fu
 causes the query to fail, even if an `INLINE STATS` comes after it.
 
 {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview`
-This restriction does not apply when `MATCH` targets an expression rather
-than an indexed field (for example, a column produced by `EVAL` or `STATS`).
-In that case, `MATCH` evaluates by scanning values row by row instead of
-using the index, and can appear anywhere in the query.
+`MATCH` can also target an expression rather than an indexed field, for example a column
+produced by `EVAL` or `STATS`. It then evaluates by scanning the column's values row by row
+instead of using the index.
+
+{applies_to}`stack: preview 9.6` {applies_to}`serverless: preview`
+Because such a search does not use the index, the restriction above does not apply to it: it can
+appear anywhere in the query, including after `STATS`, `LIMIT` and `FORK`. In earlier versions it
+was restricted to the same positions as a search on an indexed field. For example:
+
+```esql
+FROM books
+| SORT book_no
+| LIMIT 10
+| EVAL content = TO_TEXT(CONCAT(title, " ", description))
+| WHERE MATCH(content, "Tolkien")
+```
+
+The restriction is lifted per search function, not per `WHERE` command, so a search on an indexed
+field sharing the command still fails.
 
 {applies_to}`stack: preview 9.6` {applies_to}`serverless: preview`
 [`MATCH_PHRASE`](/reference/query-languages/esql/functions-operators/search-functions/match_phrase.md)
@@ -215,6 +230,35 @@ the column is created, through
 `analyzer` option, and the query analyzer defaults to that values analyzer (`standard` when none is
 declared). Analyzer names must name a registered analyzer (prebuilt or plugin-contributed), not a
 per-index custom analyzer. On other expression types options are not supported.
+
+{applies_to}`stack: preview 9.6` {applies_to}`serverless: preview`
+An indexed `text` field reaches the search as an expression when it is the column
+[`MV_EXPAND`](/reference/query-languages/esql/commands/mv_expand.md) expanded, or when it comes
+through [`FORK`](/reference/query-languages/esql/commands/fork.md), whose output columns are all
+expressions. Its values are then analyzed with
+the values analyzer of the column rather than the one its mapping declares: `standard`, unless it uses
+`TO_TEXT` with its optional `analyzer` argument. Searching the field before those commands uses the index, and so the
+mapping's analyzer. `FORK` branches that declare different values analyzers for the same column
+are rejected, since the merged column can only carry one of them.
+
+Which column `MV_EXPAND` expanded therefore decides how the field is searched. Both of these expand
+`author`, which a book can have several of, but only the first searches the expanded column and so
+becomes a runtime search:
+
+```esql
+FROM books
+| MV_EXPAND author
+| WHERE MATCH(author, "Tolkien")
+```
+
+The second searches an indexed field instead, which is still subject to the restriction above and
+fails after `MV_EXPAND`:
+
+```esql
+FROM books
+| MV_EXPAND author
+| WHERE MATCH(title, "Tolkien")
+```
 
 {applies_to}`stack: preview 9.6` {applies_to}`serverless: preview`
 When using `METADATA _score`, `MATCH` on an expression contributes to the relevance score:

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
@@ -381,6 +381,25 @@ book_no:keyword | highlight_title:keyword
 ;
 
 
+# Searching a HIGHLIGHT-generated column is a runtime search on a value that only exists above the HIGHLIGHT, so
+# unlike highlightThenWhereMatchOperator the filter cannot be pushed below it.
+highlightThenWhereMatchOnGeneratedColumn
+required_capability: highlight_v6
+required_capability: fn_match_runtime_anywhere
+
+FROM books
+| HIGHLIGHT "return" ON title
+| EVAL fragment = to_text(highlight_title)
+| WHERE match(fragment, "Shadow")
+| KEEP book_no, highlight_title
+| SORT book_no
+;
+
+book_no:keyword | highlight_title:keyword
+7350            | <em>Return</em> of the Shadow
+;
+
+
 # SCORE after HIGHLIGHT keeps the scores it would produce without it: HIGHLIGHT appends a column and passes the doc
 # vector through, so the score evaluator still runs on the data node where the Lucene doc IDs are available.
 highlightThenEvalScore

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/knn-runtime-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/knn-runtime-function.csv-spec
@@ -161,3 +161,28 @@ FROM knn_hex_vectors METADATA _score
 id:integer | _score:double
 5          | 2.501841187477112
 ;
+
+
+// Test 8: KNN on a runtime field carries no positional restriction, since it too is evaluated per row rather than
+// through the index. The LIMIT keeps ids 0-3, of which 0 and 3 clear the threshold; id 4 clears it as well (see
+// knnRuntimeWithSimThreshold) but is cut, so a filter evaluated before the LIMIT would return it too. The LIMIT
+// also puts the filter on the coordinator, which has no shard context - scoring a runtime KNN there needs none.
+knnRuntimeAfterLimit
+required_capability: knn_runtime_field
+required_capability: fn_match_runtime_anywhere
+pragma: knn_runtime_field=true
+
+FROM knn_hex_vectors METADATA _score
+| EVAL dv = to_dense_vector(emb_hex)
+| SORT id ASC
+| LIMIT 4
+| WHERE knn(dv, [64, 0, 0], {"similarity": 0.6})
+| KEEP id, label, _score
+| SORT id
+| LIMIT 10
+;
+
+id:integer | label:keyword | _score:double
+0          | x             | 1.0
+3          | xy            | 0.8535534143447876
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -1234,6 +1234,86 @@ content:text
 [This is a brown dog, extra]
 ;
 
+// The LIMIT keeps only the six lowest book_no, of which just 1463 and 2130 mention Tolkien. Book 2301 does too but
+// is cut by the LIMIT, so a filter wrongly evaluated before it would return three rows instead of two.
+matchOnRuntimeTextAfterLimit
+
+required_capability: match_function
+required_capability: fn_match_runtime_anywhere
+
+FROM books
+| SORT book_no
+| LIMIT 6
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match(content, "Tolkien")
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+1463            | Realms of Tolkien: Images of Middle-earth
+2130            | The J. R. R. Tolkien Audio Collection
+;
+
+matchOnRuntimeTextAfterStats
+
+required_capability: match_function
+required_capability: fn_match_runtime_anywhere
+
+FROM books
+| STATS max_year = max(year) BY book_no
+| EVAL b = to_text(book_no)
+| WHERE match(b, "2130")
+| KEEP book_no, max_year
+;
+
+book_no:keyword | max_year:integer
+2130            | 2002
+;
+
+// Grouping on a constant makes LIMIT ... BY keep the same six lowest book_no as matchOnRuntimeTextAfterLimit, so the
+// window stays predictable. Book 2301 mentions Tolkien too but falls outside it, and would come back if the filter
+// were evaluated before the breaker.
+matchOnRuntimeTextAfterLimitBy
+
+required_capability: match_function
+required_capability: esql_limit_by
+required_capability: fn_match_runtime_anywhere
+
+FROM books
+| SORT book_no
+| EVAL g = 1
+| LIMIT 6 BY g
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match(content, "Tolkien")
+| KEEP book_no
+| SORT book_no
+;
+
+book_no:keyword
+1463
+2130
+;
+
+// DEDUP compares whole rows, so only book_no is kept going into it - a text column is not something to group on.
+matchOnRuntimeTextAfterDedup
+
+required_capability: match_function
+required_capability: dedup_command
+required_capability: fn_match_runtime_anywhere
+
+FROM books
+| SORT book_no
+| LIMIT 6
+| KEEP book_no
+| DEDUP
+| EVAL b = to_text(book_no)
+| WHERE match(b, "2130")
+;
+
+book_no:keyword | b:text
+2130            | 2130
+;
+
 matchOnRuntimeKeyword
 
 required_capability: match_function
@@ -2288,6 +2368,28 @@ content:text
 the Fox jumped
 ;
 
+matchOnRuntimeTextAfterForkHonorsValuesAnalyzer
+required_capability: match_function
+required_capability: fn_to_text_analyzer
+required_capability: fork_v9
+required_capability: fn_match_runtime_anywhere
+
+// the values analyzer declared below FORK has to survive the merge into its output. Whitespace does not lowercase,
+// so only the capitalised row matches; losing the declaration would fall back to standard and match both rows.
+ROW content = to_text(["the Fox jumped", "the fox jumped"], {"analyzer": "whitespace"})
+| MV_EXPAND content
+| FORK (WHERE true)
+       (WHERE true)
+| WHERE match(content, "Fox")
+| KEEP content, _fork
+| SORT _fork
+;
+
+content:text   | _fork:keyword
+the Fox jumped | fork1
+the Fox jumped | fork2
+;
+
 matchOnRuntimeTextWithKeywordAnalyzer
 required_capability: match_function
 required_capability: fn_to_text_analyzer
@@ -2423,6 +2525,26 @@ book_no:keyword | _score:double
 1463            | 1.0
 2130            | 1.0
 2301            | 1.0
+;
+
+matchOnRuntimeTextAfterLimitWithScore
+required_capability: match_function
+required_capability: metadata_score
+required_capability: fn_match_runtime_anywhere
+
+// The LIMIT puts this filter on the coordinator, which has no shard contexts. Runtime scoring does not need one,
+// so the matched term still scores its point there.
+FROM books METADATA _score
+| SORT book_no
+| LIMIT 6
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match(content, "Tolkien")
+| KEEP book_no, _score
+;
+
+book_no:keyword | _score:double
+1463            | 1.0
+2130            | 1.0
 ;
 
 matchOnRuntimeTextMultipleTermsWithScore

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -1062,6 +1062,25 @@ book_no:keyword | title:text
 2301            | Smith of Wootton Major & Farmer Giles of Ham
 ;
 
+// Same window as matchOnRuntimeText, but the LIMIT runs first: it drops 2301, which the unrestricted filter matches.
+matchOnRuntimeTextAfterLimit
+
+required_capability: match_operator_colon
+required_capability: fn_match_runtime_anywhere
+
+FROM books
+| SORT book_no
+| LIMIT 6
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE content:"Tolkien"
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+1463            | Realms of Tolkien: Images of Middle-earth
+2130            | The J. R. R. Tolkien Audio Collection
+;
+
 matchOnRuntimeTextAndIndexedField
 
 required_capability: match_operator_colon

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
@@ -820,6 +820,38 @@ book_no:keyword
 2883
 ;
 
+// Only the six lowest book_no survive the LIMIT, and 2130 is the one of those titled as an audio collection.
+matchPhraseOnRuntimeTextAfterLimit
+required_capability: match_phrase_function
+required_capability: fn_match_phrase_runtime_anywhere
+
+FROM books
+| SORT book_no
+| LIMIT 6
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match_phrase(content, "Audio Collection")
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+2130            | The J. R. R. Tolkien Audio Collection
+;
+
+matchPhraseOnRuntimeTextAfterStats
+required_capability: match_phrase_function
+required_capability: fn_match_phrase_runtime_anywhere
+
+FROM books
+| STATS max_year = max(year) BY book_no
+| EVAL b = to_text(book_no)
+| WHERE match_phrase(b, "2130")
+| KEEP book_no, max_year
+;
+
+book_no:keyword | max_year:integer
+2130            | 2002
+;
+
 matchPhraseOnTextWithRow
 required_capability: match_phrase_function
 required_capability: fn_match_phrase_runtime_filter

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CoordinatorLookupJoinIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CoordinatorLookupJoinIT.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.esql.VerificationException;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -18,7 +19,7 @@ import static org.hamcrest.Matchers.containsString;
 
 public class CoordinatorLookupJoinIT extends AbstractEsqlIntegTestCase {
 
-    public void testFullTextFunctionsNotAllowedAfterCoordinatorLookupJoin() {
+    public void testFullTextFunctionsAfterCoordinatorLookupJoin() {
         assertAcked(client().admin().indices().prepareCreate("data").setMapping("key", "type=keyword", "country", "type=keyword"));
         client().prepareBulk()
             .add(prepareIndex("data").setSource(Map.of("key", "us", "country", "United States")))
@@ -75,5 +76,21 @@ public class CoordinatorLookupJoinIT extends AbstractEsqlIntegTestCase {
             | KEEP key, country, info
             | SORT key
             """).close());
+
+        // A runtime search is allowed: the reason for the rejections above, that the coordinator has no Lucene shard
+        // context, does not hold for a search that scans the values already in the page. Only the UK row carries the
+        // term and the other leg matches nothing, so the runtime search has to have run for this to return a row.
+        try (var resp = run("""
+            FROM data METADATA _score
+            | LOOKUP JOIN _coordinator:lookup ON key
+            | EVAL c = TO_TEXT(country)
+            | LIMIT 5
+            | WHERE match(c, "Kingdom") OR info == "nonexistent"
+            | KEEP key, c, info, _score
+            | SORT key
+            """)) {
+            assertColumnNames(resp.columns(), List.of("key", "c", "info", "_score"));
+            assertValues(resp.values(), List.of(List.of("uk", "United Kingdom", "Britain", 1.0)));
+        }
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
@@ -339,6 +339,63 @@ public class MatchFunctionIT extends AbstractEsqlIntegTestCase {
         assertThat(error.getMessage(), containsString("[MATCH] function is only supported in WHERE and STATS commands"));
     }
 
+    public void testRuntimeMatchAfterLimit() {
+        var query = """
+            FROM test
+            | EVAL summary = to_text(concat("content: ", content))
+            | SORT id
+            | LIMIT 3
+            | WHERE match(summary, "fox")
+            | KEEP id
+            """;
+
+        // The LIMIT keeps ids 1-3, of which only 1 mentions a fox. Id 6 does too, so a filter that ran before the
+        // LIMIT - or that the LIMIT failed to constrain - would return it as well.
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1)));
+        }
+    }
+
+    public void testRuntimeMatchAfterStats() {
+        var query = """
+            FROM test
+            | STATS ids = count(*) BY summary = to_text(concat("content: ", content))
+            | WHERE match(summary, "fox")
+            | KEEP summary, ids
+            | SORT summary
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("summary", "ids"));
+            assertColumnTypes(resp.columns(), List.of("text", "long"));
+            assertValues(
+                resp.values(),
+                List.of(List.of("content: The quick brown fox jumps over the lazy dog", 1L), List.of("content: This is a brown fox", 1L))
+            );
+        }
+    }
+
+    public void testRuntimeMatchAfterLimitWithScore() {
+        var query = """
+            FROM test METADATA _score
+            | EVAL summary = to_text(concat("content: ", content))
+            | SORT id
+            | LIMIT 3
+            | WHERE match(summary, "fox")
+            | KEEP id, _score
+            """;
+
+        // The LIMIT is a pipeline breaker, so this filter runs on the coordinator. Runtime scoring needs no shard
+        // context, so the matched term must still score its point there, exactly as it does on a data node.
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_score"));
+            assertColumnTypes(resp.columns(), List.of("integer", "double"));
+            assertValues(resp.values(), List.of(List.of(1, 1.0)));
+        }
+    }
+
     public void testMatchAfterMvExpand() {
         var query = """
             FROM test

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchOperatorIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchOperatorIT.java
@@ -344,6 +344,24 @@ public class MatchOperatorIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    public void testRuntimeMatchOperatorAfterLimit() {
+        var query = """
+            FROM test
+            | EVAL summary = to_text(concat("content: ", content))
+            | SORT id
+            | LIMIT 3
+            | WHERE summary : "fox"
+            | KEEP id
+            """;
+
+        // The LIMIT keeps ids 1-3, of which only 1 mentions a fox; id 6 does too but is cut.
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1)));
+        }
+    }
+
     public void testMatchOperatorAfterMvExpand() {
         var query = """
             FROM test

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
@@ -365,6 +365,43 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
         assertThat(error.getMessage(), containsString("[MatchPhrase] function is only supported in WHERE and STATS commands"));
     }
 
+    public void testRuntimeMatchPhraseAfterLimit() {
+        var query = """
+            FROM test
+            | EVAL summary = to_text(concat("content: ", content))
+            | SORT id
+            | LIMIT 3
+            | WHERE match_phrase(summary, "brown fox")
+            | KEEP id
+            """;
+
+        // The LIMIT keeps ids 1-3; id 6 also contains the phrase but is cut, so it must not come back.
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1)));
+        }
+    }
+
+    public void testRuntimeMatchPhraseAfterLimitWithScore() {
+        var query = """
+            FROM test METADATA _score
+            | EVAL summary = to_text(concat("content: ", content))
+            | SORT id
+            | LIMIT 3
+            | WHERE match_phrase(summary, "brown fox")
+            | KEEP id, _score
+            """;
+
+        // The LIMIT is a pipeline breaker, so this filter runs on the coordinator. A matched phrase scores its boost
+        // there too, since runtime scoring needs no shard context.
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_score"));
+            assertColumnTypes(resp.columns(), List.of("integer", "double"));
+            assertValues(resp.values(), List.of(List.of(1, 1.0)));
+        }
+    }
+
     public void testMatchPhraseAfterMvExpand() {
         // After MV_EXPAND on the searched field, the expanded attribute is no longer a direct index field, so
         // runtime search takes over: the MV_EXPAND restriction is bypassed and the phrase is evaluated per row.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1375,7 +1375,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                             null,
                             false,
                             // the expanded values are the target's values, so a declared values analyzer carries over
-                            AnalyzedTextExpression.valuesAnalyzerOf(resolved)
+                            AnalyzedTextExpression.declaredValuesAnalyzerOf(resolved)
                         )
                         : resolved
                 );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Alias.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Alias.java
@@ -142,7 +142,7 @@ public final class Alias extends NamedExpression {
                     nullable(),
                     id(),
                     synthetic(),
-                    AnalyzedTextExpression.valuesAnalyzerOf(child)
+                    AnalyzedTextExpression.declaredValuesAnalyzerOf(child)
                 )
                 : new UnresolvedAttribute(source(), name());
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/AnalyzedTextExpression.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/AnalyzedTextExpression.java
@@ -13,7 +13,7 @@ import org.elasticsearch.core.Nullable;
  * {@code analyzer} plays for an indexed text field. Implemented by {@code TO_TEXT} (the declaration site) and by
  * {@link ReferenceAttribute} (which carries the declaration across {@code EVAL}/{@code RENAME} boundaries, see
  * {@link Alias#toAttribute}). Consumers and propagation sites discover the analyzer through
- * {@link #valuesAnalyzerOf}, whichever form the expression takes.
+ * {@link #declaredValuesAnalyzerOf}, whichever form the expression takes.
  * <p>
  * TODO: the declared analyzer is really a refinement of {@link Expression#dataType()}. If text types could carry
  * parameters ({@code text(analyzer=...)}), the declaration would flow with the type through every place that mints
@@ -23,16 +23,34 @@ import org.elasticsearch.core.Nullable;
 public interface AnalyzedTextExpression {
 
     /**
-     * The declared values analyzer name, or {@code null} when none was declared (the standard analyzer applies).
+     * The analyzer that applies to a text column declaring none. Declaring it explicitly is therefore the same as
+     * declaring nothing, which consumers comparing declarations have to treat as equal.
+     */
+    String STANDARD_ANALYZER = "standard";
+
+    /**
+     * The declared values analyzer name, or {@code null} when none was declared ({@link #STANDARD_ANALYZER} applies).
      */
     @Nullable
     String valuesAnalyzer();
 
     /**
-     * The declared values analyzer of {@code expression}, or {@code null} when it declares none.
+     * The values analyzer {@code expression} declares, or {@code null} when it declares none. Prefer
+     * {@link #effectiveValuesAnalyzerOf} when comparing two expressions, so that declaring the default explicitly
+     * does not read as a difference.
      */
     @Nullable
-    static String valuesAnalyzerOf(Expression expression) {
+    static String declaredValuesAnalyzerOf(Expression expression) {
         return expression instanceof AnalyzedTextExpression analyzed ? analyzed.valuesAnalyzer() : null;
+    }
+
+    /**
+     * The values analyzer that applies to {@code expression}, naming {@link #STANDARD_ANALYZER} rather than returning
+     * {@code null} when none was declared. Use this to compare declarations, so that an explicit {@code standard}
+     * compares equal to no declaration at all.
+     */
+    static String effectiveValuesAnalyzerOf(Expression expression) {
+        String declared = declaredValuesAnalyzerOf(expression);
+        return declared == null ? STANDARD_ANALYZER : declared;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.core.expression;
 
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.TypeConflictedField;
@@ -106,6 +107,36 @@ public final class Expressions {
             list.add(refAttr);
         }
         return list;
+    }
+
+    /**
+     * A property that two same-named attributes disagree on, and so cannot be merged into one output column.
+     *
+     * @param property plural name of the property, for a user-facing message
+     * @param branchValue the value on the attribute being merged in
+     * @param mergedValue the value the merged output carries
+     */
+    public record MergeConflict(String property, String branchValue, String mergedValue) {}
+
+    /**
+     * Why {@code branch} cannot be merged into {@code merged}, or {@code null} when it can.
+     * <p>
+     * {@link #toReferenceAttributesPreservingIds} keeps one attribute per column name, so a branch disagreeing on any
+     * property that changes how the column's values are read would have its rows read as if it had declared the merged
+     * one. Callers report the conflict; this decides what counts as one, so a new text-column property does not have
+     * to be added to every branch-merging plan.
+     */
+    @Nullable
+    public static MergeConflict checkForMergeConflict(Attribute branch, Attribute merged) {
+        if (branch.dataType() != merged.dataType()) {
+            return new MergeConflict("data types", String.valueOf(branch.dataType()), String.valueOf(merged.dataType()));
+        }
+        String branchAnalyzer = AnalyzedTextExpression.effectiveValuesAnalyzerOf(branch);
+        String mergedAnalyzer = AnalyzedTextExpression.effectiveValuesAnalyzerOf(merged);
+        if (branchAnalyzer.equals(mergedAnalyzer) == false) {
+            return new MergeConflict("values analyzers", branchAnalyzer, mergedAnalyzer);
+        }
+        return null;
     }
 
     public static boolean anyMatch(List<? extends Expression> exps, Predicate<? super Expression> predicate) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -389,11 +389,13 @@ public abstract class FullTextFunction extends Function
         Failures failures
     ) {
         condition.forEachDown(typeToken, exp -> {
+            // A runtime search is evaluated row by row over the values already in the page (see RuntimeSearch) instead
+            // of querying a Lucene index, so it doesn't need a shard context or push-down to a data node.
+            if (exp instanceof FullTextFunction ftf && ftf.isRuntimeSearch()) {
+                return;
+            }
             plan.forEachDown(LogicalPlan.class, lp -> {
-                // `checkCommandsBeforeExpression` should be completely skipped for search functions that do not operate on index fields,
-                // but for now all checks apply, except for MV_EXPAND which can be used before a runtime search function
-                if ((lp instanceof MvExpand && exp instanceof FullTextFunction ftf && ftf.isRuntimeSearch()) == false
-                    && commandCheck.test(lp) == false) {
+                if (commandCheck.test(lp) == false) {
                     if (lp instanceof ExternalRelation externalRelation) {
                         // Federated sources are never Lucene-backed, so functions gated to Lucene-only relations (e.g. KQL/QSTR)
                         // fail here regardless of position. Name the actual limitation instead of the generic positional
@@ -725,8 +727,11 @@ public abstract class FullTextFunction extends Function
                 checkFullTextFunctionsInFilter(f, failures, true);
                 // After optimization, if a coordinator-executed join still sits anywhere beneath this filter
                 // (not just as a direct child), the push-down optimizer could not move the filter to the data
-                // nodes. Full-text functions require a Lucene shard context that the coordinator does not have.
-                if (f.anyMatch(p -> p instanceof Join join && join.executesOn() == ExecutesOn.ExecuteLocation.COORDINATOR)) {
+                // nodes. An index-backed search requires a Lucene shard context that the coordinator does not have;
+                // a runtime search scans the values already in the page, so it runs there just as well. This check
+                // sees the final answer from isRuntimeSearch(), running after push-down has settled it.
+                if (isRuntimeSearch() == false
+                    && f.anyMatch(p -> p instanceof Join join && join.executesOn() == ExecutesOn.ExecuteLocation.COORDINATOR)) {
                     failures.add(
                         fail(
                             this,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -108,7 +108,14 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Match", Match::readFrom);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Match.class)
         .ternary(Match::new)
-        .capabilities("runtime_filter", "unmapped_fields_pushdown_fix", "runtime_options", "runtime_analyzer", "runtime_score")
+        .capabilities(
+            "runtime_filter",
+            "unmapped_fields_pushdown_fix",
+            "runtime_options",
+            "runtime_analyzer",
+            "runtime_score",
+            "runtime_anywhere"
+        )
         .name("match");
     public static final Set<DataType> FIELD_DATA_TYPES = Set.of(
         NULL,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.common.Failure;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.AnalyzedTextExpression;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -78,7 +79,14 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
     );
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(MatchPhrase.class)
         .ternary(MatchPhrase::new)
-        .capabilities("runtime_filter", "unmapped_fields_pushdown_fix", "runtime_options", "runtime_analyzer", "runtime_score")
+        .capabilities(
+            "runtime_filter",
+            "unmapped_fields_pushdown_fix",
+            "runtime_options",
+            "runtime_analyzer",
+            "runtime_score",
+            "runtime_anywhere"
+        )
         .name("match_phrase");
     public static final Set<DataType> FIELD_DATA_TYPES = Set.of(KEYWORD, TEXT, NULL);
     public static final Set<DataType> QUERY_DATA_TYPES = Set.of(KEYWORD, TEXT);
@@ -261,7 +269,7 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
      */
     private boolean hasNonStandardValuesAnalyzer() {
         String name = valuesAnalyzerName();
-        return name != null && name.equals("standard") == false;
+        return name != null && name.equals(AnalyzedTextExpression.STANDARD_ANALYZER) == false;
     }
 
     private Map<String, Object> matchPhraseQueryOptions() throws InvalidArgumentException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
@@ -206,7 +206,7 @@ public abstract class SingleFieldFullTextFunction extends FullTextFunction
      */
     @Nullable
     protected String valuesAnalyzerName() {
-        return AnalyzedTextExpression.valuesAnalyzerOf(field());
+        return AnalyzedTextExpression.declaredValuesAnalyzerOf(field());
     }
 
     /** The declared values analyzer resolved through the registry, or the standard analyzer when none was declared. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failure;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -43,6 +44,7 @@ public class Fork extends LogicalPlan implements PostAnalysisPlanVerificationAwa
 
     public static final String FORK_FIELD = "_fork";
     public static final int MAX_BRANCHES = 8;
+
     private final List<Attribute> output;
 
     public Fork(Source source, List<LogicalPlan> children, List<Attribute> output) {
@@ -282,28 +284,35 @@ public class Fork extends LogicalPlan implements PostAnalysisPlanVerificationAwa
             );
         });
 
-        Map<String, DataType> outputTypes = fork.output().stream().collect(Collectors.toMap(Attribute::name, Attribute::dataType));
+        Map<String, Attribute> mergedOutput = fork.output().stream().collect(Collectors.toMap(Attribute::name, attr -> attr));
 
         fork.children().forEach(subPlan -> {
             for (Attribute attr : subPlan.output()) {
-                var expected = outputTypes.get(attr.name());
+                var merged = mergedOutput.get(attr.name());
+
+                // A branch column absent from the merged output cannot be compared against it. Unreachable while the
+                // branches agree on their column names, which expressionsResolved() requires before we get here.
+                if (merged == null) {
+                    continue;
+                }
 
                 // If the FORK output has an UNSUPPORTED data type, we know there is no conflict.
                 // We only assign an UNSUPPORTED attribute in the FORK output when there exists no attribute with the
                 // same name and supported data type in any of the FORK branches.
-                if (expected == DataType.UNSUPPORTED) {
+                if (merged.dataType() == DataType.UNSUPPORTED) {
                     continue;
                 }
 
-                var actual = attr.dataType();
-                if (actual != expected) {
+                var conflict = Expressions.checkForMergeConflict(attr, merged);
+                if (conflict != null) {
                     failures.add(
                         Failure.fail(
                             attr,
-                            "Column [{}] has conflicting data types in FORK branches: [{}] and [{}]",
+                            "Column [{}] has conflicting {} in FORK branches: [{}] and [{}]",
                             attr.name(),
-                            actual,
-                            expected
+                            conflict.property(),
+                            conflict.branchValue(),
+                            conflict.mergedValue()
                         )
                     );
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -150,6 +150,7 @@ import org.elasticsearch.xpack.esql.evaluator.command.IpLocationFunctionBridge;
 import org.elasticsearch.xpack.esql.evaluator.command.UserAgentFunctionBridge;
 import org.elasticsearch.xpack.esql.expression.Foldables;
 import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 import org.elasticsearch.xpack.esql.index.IndexProperties;
 import org.elasticsearch.xpack.esql.inference.InferenceService;
@@ -2261,8 +2262,9 @@ public class LocalExecutionPlanner {
             ),
             source.layout
         );
-        // Add ScoreOperator only on data nodes. Data nodes are able to calculate scores running queries on the resulting docs.
-        if (context.shardContexts.isEmpty() == false && PlannerUtils.usesScoring(filter)) {
+        // Scoring normally needs a data node, which can run the query against the resulting docs. A runtime search is the
+        // exception: it scores per row from the values in the page, so it also contributes on the coordinator.
+        if (PlannerUtils.usesScoring(filter) && (context.shardContexts.isEmpty() == false || scoresWithoutShards(filter.condition()))) {
             // Add scorer operator to add the filter expression scores to the overall scores
             Attribute scoreAttribute = null;
 
@@ -2292,6 +2294,14 @@ public class LocalExecutionPlanner {
             );
         }
         return filterOperation;
+    }
+
+    /**
+     * Whether {@code condition} contains a scoring contributor that can be evaluated without a shard context, which
+     * today means a runtime full-text search.
+     */
+    private static boolean scoresWithoutShards(Expression condition) {
+        return condition.anyMatch(e -> e instanceof FullTextFunction ftf && ftf.isRuntimeSearch() && ftf.contributesToScore());
     }
 
     private PhysicalOperation planInsertEmptyBuckets(InsertEmptyBucketsExec insertEmptyBuckets, LocalExecutionPlannerContext context) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2056,17 +2056,40 @@ public class VerifierTests extends ESTestCase {
         fullText().query("from test | eval x = concat(title, body) | eval t = to_text(x, {\"analyzer\": \"whitespace\"})");
     }
 
-    public void testToTextAnalyzerThroughForkOutputUnreachable() throws Exception {
-        // Full-text functions cannot be used after FORK at all, so a values analyzer declared in or below fork
-        // branches can never be consumed through the fork's merged output. If that restriction is ever relaxed,
-        // Fork's output minting must propagate valuesAnalyzer for agreeing branches and reject conflicting
-        // declarations across branches, like it rejects conflicting data types.
-        fullText().error("""
+    /**
+     * A values analyzer declared below FORK reaches the search through the fork's merged output, so every branch
+     * has to agree on it. Fork's output minting keeps only one declaration per column name, which would otherwise
+     * analyze the other branches' rows with an analyzer they never declared.
+     */
+    public void testToTextAnalyzerThroughForkOutput() throws Exception {
+        // declared once, below the fork: every branch carries the same declaration
+        fullText().query("""
             from test
             | eval t = to_text(concat(title, body), {"analyzer": "whitespace"})
             | fork (where true) (where true)
             | where match(t, "cat")
-            """, containsString("[MATCH] function cannot be used after FORK"));
+            """);
+        // declared per branch, but in agreement
+        fullText().query("""
+            from test
+            | fork (eval t = to_text(concat(title, body), {"analyzer": "whitespace"}))
+                   (eval t = to_text(concat(title, body), {"analyzer": "whitespace"}))
+            | where match(t, "cat")
+            """);
+        // conflicting declarations across branches
+        fullText().error("""
+            from test
+            | fork (eval t = to_text(concat(title, body), {"analyzer": "whitespace"}))
+                   (eval t = to_text(concat(title, body), {"analyzer": "english"}))
+            | where match(t, "cat")
+            """, containsString("Column [t] has conflicting values analyzers in FORK branches: [english] and [whitespace]"));
+        // an undeclared branch means the standard analyzer, which conflicts with an explicit declaration
+        fullText().error("""
+            from test
+            | fork (eval t = to_text(concat(title, body), {"analyzer": "whitespace"}))
+                   (eval t = to_text(concat(title, body)))
+            | where match(t, "cat")
+            """, containsString("conflicting values analyzers in FORK branches"));
     }
 
     public void testToTextAnalyzerOptionOnUnionTypedField() throws Exception {
@@ -2179,18 +2202,58 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testRuntimeFullTextFunctionsAllowedAfterCommands() {
+        checkRuntimeFullTextFunctionAllowedAfterCommands("match(t, \"Meditation\")");
+        checkRuntimeFullTextFunctionAllowedAfterCommands("t : \"Meditation\"");
+        checkRuntimeFullTextFunctionAllowedAfterCommands("match_phrase(t, \"Meditation\")");
+    }
+
+    /**
+     * A runtime search scans the column's values row by row instead of querying the index, so it needs neither a
+     * shard context nor push-down to Lucene and can sit anywhere in the pipeline. The commands checked here are the
+     * ones {@code FullTextFunction#checkCommandsBeforeExpression} rejects for index-backed searches.
+     */
+    private void checkRuntimeFullTextFunctionAllowedAfterCommands(String functionInvocation) {
+        String prefix = "from test | eval t = to_text(concat(title, body)) ";
+        fullText().query(prefix + "| limit 10 | where " + functionInvocation);
+        fullText().query(prefix + "| stats c = count(id) by t | where " + functionInvocation);
+        fullText().query(prefix + "| limit 1 by id | where " + functionInvocation);
+        fullText().query(prefix + "| sort id | limit 1 by id | where " + functionInvocation);
+        // already allowed before this restriction was lifted, through the MV_EXPAND-only carve-out
+        fullText().query(prefix + "| mv_expand id | where " + functionInvocation);
+        if (EsqlCapabilities.Cap.DEDUP_COMMAND.isEnabled()) {
+            fullText().query(prefix + "| dedup | where " + functionInvocation);
+        }
+    }
+
+    /**
+     * The exemption is per full-text function, not per condition: an index-backed search sharing a WHERE with a
+     * runtime one still cannot be pushed to Lucene from above a pipeline breaker, so it must keep failing.
+     * <p>
+     * {@code Failure} equality is keyed on the node, so the single reported failure is whichever function the
+     * condition is walked into first. Naming the runtime function first therefore makes these assertions
+     * discriminating: they only hold once it stops failing and the index-backed one behind it is what surfaces.
+     */
+    public void testMixedRuntimeAndIndexedFullTextRejectedAfterLimit() {
+        fullText().error(
+            "from test | eval t = to_text(concat(title, body)) | limit 10 | where match(t, \"cat\") or match_phrase(title, \"dog\")",
+            containsString("[MatchPhrase] function cannot be used after LIMIT")
+        );
+        fullText().error(
+            "from test | eval t = to_text(concat(title, body)) | limit 10 | where match_phrase(t, \"cat\") or title : \"dog\"",
+            containsString("[:] operator cannot be used after LIMIT")
+        );
+    }
+
     public void testFullTextFunctionsAfterFork() {
-        fullText().error(
-            "from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where title : \"data\"",
-            containsString("[:] operator cannot be used after FORK")
+        // Everything FORK outputs is a ReferenceAttribute, so searching one of its columns is a runtime search and
+        // carries no positional restriction. Only the functions without runtime search support still fail.
+        fullText().query("from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where title : \"data\"");
+        fullText().query(
+            "from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where match(title, \"data\")"
         );
-        fullText().error(
-            "from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where match(title, \"data\")",
-            containsString("[MATCH] function cannot be used after FORK")
-        );
-        fullText().error(
-            "from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where match_phrase(title, \"data\")",
-            containsString("[MatchPhrase] function cannot be used after FORK")
+        fullText().query(
+            "from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where match_phrase(title, \"data\")"
         );
         // No KEEP here: unlike the general per-command check above, KQL/QSTR's own stricter allow-list also
         // rejects Project (i.e. RENAME/KEEP), and since Failure equality is keyed on the failing node - not the
@@ -2209,20 +2272,20 @@ public class VerifierTests extends ESTestCase {
         );
         fullText().stripErrorPrefix(false)
             .error(
-                "from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where match(title, \"data\")",
-                allOf(containsString("Found 1 problem"), containsString("[MATCH] function cannot be used after FORK"))
+                "from test metadata _id, _index, _score | fork (where true) (where true) | keep vector | where knn(vector, [1, 2, 3])",
+                allOf(containsString("Found 1 problem"), containsString("[KNN] function cannot be used after FORK"))
             );
     }
 
     public void testFullTextFunctionsAfterForkWithEvalInBranch() {
-        fullText().stripErrorPrefix(false)
-            .error(
-                "from test metadata _id, _index, _score "
-                    + "| fork (where true) (where true | EVAL title = to_text(\"abc\")) "
-                    + "| keep title "
-                    + "| where title : \"data\"",
-                allOf(containsString("Found 1 problem"), containsString("[:] operator cannot be used after FORK"))
-            );
+        // One branch supplies the mapped field and the other an EVAL column. Neither declares a values analyzer, so
+        // the branches agree and the merged column is searchable.
+        fullText().query(
+            "from test metadata _id, _index, _score "
+                + "| fork (where true) (where true | EVAL title = to_text(\"abc\")) "
+                + "| keep title "
+                + "| where title : \"data\""
+        );
     }
 
     public void testNonFieldBasedFullTextFunctionsNotAllowedAfterCommands() throws Exception {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/ExpressionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/ExpressionsTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.core.expression;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.fieldAttribute;
+import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ExpressionsTests extends ESTestCase {
+
+    private static ReferenceAttribute text(String name, String valuesAnalyzer) {
+        return new ReferenceAttribute(EMPTY, null, name, DataType.TEXT, Nullability.TRUE, null, false, valuesAnalyzer);
+    }
+
+    public void testNoConflictWhenTypeAndAnalyzerAgree() {
+        assertThat(Expressions.checkForMergeConflict(text("t", "whitespace"), text("t", "whitespace")), nullValue());
+        assertThat(Expressions.checkForMergeConflict(text("t", null), text("t", null)), nullValue());
+    }
+
+    /**
+     * Declaring the default explicitly has to compare equal to declaring nothing, since they name the same analyzer.
+     * Comparing the raw declarations would report a conflict where the values are analyzed identically.
+     */
+    public void testExplicitStandardAgreesWithNoDeclaration() {
+        assertThat(Expressions.checkForMergeConflict(text("t", "standard"), text("t", null)), nullValue());
+        assertThat(Expressions.checkForMergeConflict(text("t", null), text("t", "standard")), nullValue());
+    }
+
+    public void testConflictingValuesAnalyzers() {
+        var conflict = Expressions.checkForMergeConflict(text("t", "english"), text("t", "whitespace"));
+        assertThat(conflict, equalTo(new Expressions.MergeConflict("values analyzers", "english", "whitespace")));
+    }
+
+    /**
+     * A field carries no declaration of its own, so it reads as the standard analyzer. This is why an indexed text
+     * field surfacing through a branch merge is searched with the standard analyzer rather than its mapping's.
+     */
+    public void testFieldConflictsWithADeclaredAnalyzer() {
+        var conflict = Expressions.checkForMergeConflict(fieldAttribute("t", DataType.TEXT), text("t", "whitespace"));
+        assertThat(conflict, equalTo(new Expressions.MergeConflict("values analyzers", "standard", "whitespace")));
+    }
+
+    public void testConflictingDataTypes() {
+        var conflict = Expressions.checkForMergeConflict(fieldAttribute("t", DataType.INTEGER), fieldAttribute("t", DataType.KEYWORD));
+        assertThat(conflict, equalTo(new Expressions.MergeConflict("data types", "INTEGER", "KEYWORD")));
+    }
+
+    /**
+     * Reported before the analyzer, so a column disagreeing on both gets the message naming the cause a reader can
+     * act on rather than whichever check happened to run first.
+     */
+    public void testDataTypeConflictTakesPrecedenceOverAnalyzer() {
+        var conflict = Expressions.checkForMergeConflict(
+            new ReferenceAttribute(EMPTY, null, "t", DataType.KEYWORD, Nullability.TRUE, null, false, "english"),
+            text("t", "whitespace")
+        );
+        assertThat(conflict, equalTo(new Expressions.MergeConflict("data types", "KEYWORD", "TEXT")));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -79,6 +79,18 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
         assertThat(err, containsString("[LIKE] pattern must be a constant"));
     }
 
+    /**
+     * Whether a full-text function is a runtime search is not stable across planning phases. Here {@code name} is a
+     * {@code ReferenceAttribute} when the plan is analyzed, so the positional check lets it past the LIMIT, but
+     * {@code PushDownAndCombineFilters} then pushes the filter past the RENAME and substitutes the underlying
+     * {@code FieldAttribute}, turning it back into an index-backed search that still sits above the LIMIT. The
+     * post-optimization re-run has to catch what the post-analysis pass let through.
+     */
+    public void testRuntimeFullTextRejectedAfterLimitWhenRenamePushesDownToField() {
+        var err = error(defaultAnalyzer().query("from test | limit 5 | rename first_name as name | where match(name, \"Meditation\")"));
+        assertThat(err, containsString("[MATCH] function cannot be used after LIMIT"));
+    }
+
     private String error(LogicalPlan plan) {
         Throwable e = expectThrows(
             VerificationException.class,


### PR DESCRIPTION
A runtime match/match_phrase is evaluated row by row over the values already in the page, so it needs neither a shard context nor push-down to a data node. It was nevertheless rejected after LIMIT, STATS and friends. Skip the positional check for such a search, deciding per full-text function rather than per condition so that an index-backed search sharing a WHERE still fails. QSTR and KQL never report a runtime search and keep their own, stricter allow-list. The coordinator-join check from #154956 is skipped on the same grounds. This reaches runtime KNN as well, which is evaluated per row in the same way, though only under the snapshot pragma that enables it.

Scoring made the same assumption: planFilter added the ScoreOperator only where there were shard contexts, so a runtime search above a breaker returned the right rows but contributed nothing to _score. Add it when the condition holds a scorer that needs no shard.

FORK needed one more thing. Its output columns are never index-backed fields, so searching one was always going to be a runtime search; lifting the restriction is what makes those searches reachable rather than rejected outright. FORK keeps only one values analyzer per column name, and branches declaring different ones would then have their rows analyzed with an analyzer they never declared; this is rejected via `checkForMergeConflict`.
