### PR TITLE
Added failure metrics for codec operations

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -61,7 +61,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.mapper.MapperMetrics;
@@ -804,7 +803,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             MapperMetrics.NOOP,
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP
+            ShardMetrics.NOOP
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchDirectoryReader.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.index.codec.CodecMetrics;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.ESCacheHelper;
 
@@ -69,21 +70,24 @@ public final class ElasticsearchDirectoryReader extends FilterDirectoryReader {
      * @param shardId the shard ID to expose via the elasticsearch internal reader wrappers.
      */
     public static ElasticsearchDirectoryReader wrap(DirectoryReader reader, ShardId shardId) throws IOException {
-        return wrap(reader, shardId, null);
+        return wrap(reader, shardId, null, CodecMetrics.NOOP);
     }
 
     /**
-     * Wraps the given reader in a {@link ElasticsearchDirectoryReader} as
-     * well as all it's sub-readers in {@link ElasticsearchLeafReader} to
-     * expose the given shard Id.
+     * Wraps the given reader in a {@link ElasticsearchDirectoryReader} as well as all it's sub-readers in {@link ElasticsearchLeafReader}
+     * to expose the given shard Id and count codec read failures seen by the leaf readers.
      * @param reader        the reader to wrap
      * @param shardId       the shard ID to expose via the elasticsearch internal reader wrappers.
-     * @param esCacheHelper the custom {@link ESCacheHelper} implementation that doesn't tie
-     *                      its lifecycle to that of the underlying reader
+     * @param esCacheHelper the custom {@link ESCacheHelper} implementation that doesn't tie its lifecycle to that of the underlying reader
+     * @param codecMetrics  where read failures are counted; {@link CodecMetrics#NOOP} to count nothing
      */
-    public static ElasticsearchDirectoryReader wrap(DirectoryReader reader, ShardId shardId, @Nullable ESCacheHelper esCacheHelper)
-        throws IOException {
-        return new ElasticsearchDirectoryReader(reader, new SubReaderWrapper(shardId), shardId, esCacheHelper);
+    public static ElasticsearchDirectoryReader wrap(
+        DirectoryReader reader,
+        ShardId shardId,
+        @Nullable ESCacheHelper esCacheHelper,
+        CodecMetrics codecMetrics
+    ) throws IOException {
+        return new ElasticsearchDirectoryReader(reader, new SubReaderWrapper(shardId, codecMetrics), shardId, esCacheHelper);
     }
 
     /**
@@ -102,14 +106,16 @@ public final class ElasticsearchDirectoryReader extends FilterDirectoryReader {
 
     private static final class SubReaderWrapper extends FilterDirectoryReader.SubReaderWrapper {
         private final ShardId shardId;
+        private final CodecMetrics codecMetrics;
 
-        SubReaderWrapper(ShardId shardId) {
+        SubReaderWrapper(ShardId shardId, CodecMetrics codecMetrics) {
             this.shardId = shardId;
+            this.codecMetrics = codecMetrics;
         }
 
         @Override
         public LeafReader wrap(LeafReader reader) {
-            return new ElasticsearchLeafReader(reader, shardId);
+            return new ElasticsearchLeafReader(reader, shardId, codecMetrics);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReader.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReader.java
@@ -8,18 +8,48 @@
  */
 package org.elasticsearch.common.lucene.index;
 
+import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.util.IORunnable;
+import org.apache.lucene.util.IOSupplier;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.CodecMetrics;
+import org.elasticsearch.index.codec.CodecMetrics.Format;
 import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
 
 /**
  * A {@link org.apache.lucene.index.FilterLeafReader} that exposes
  * Elasticsearch internal per shard / index information like the shard ID.
+ * <p>
+ * It is also the read-side hook for {@link CodecMetrics}: every engine applies it after Lucene has opened the segment through the
+ * SPI-resolved codec, so it sees reads that a codec wrapper cannot. Failures thrown by the per-field accessors and {@link #storedFields()}
+ * are counted; the iterators those accessors return and the sequential stored fields reader are not wrapped, so failures there escape
+ * to the operation that drives them.
  */
 public final class ElasticsearchLeafReader extends SequentialStoredFieldsLeafReader {
 
     private final ShardId shardId;
+    private final CodecMetrics codecMetrics;
 
     /**
      * <p>Construct a FilterLeafReader based on the specified base reader.
@@ -27,9 +57,10 @@ public final class ElasticsearchLeafReader extends SequentialStoredFieldsLeafRea
      *
      * @param in specified base reader.
      */
-    public ElasticsearchLeafReader(LeafReader in, ShardId shardId) {
+    public ElasticsearchLeafReader(LeafReader in, ShardId shardId, CodecMetrics codecMetrics) {
         super(in);
         this.shardId = shardId;
+        this.codecMetrics = codecMetrics;
     }
 
     /**
@@ -62,6 +93,131 @@ public final class ElasticsearchLeafReader extends SequentialStoredFieldsLeafRea
             }
         }
         return null;
+    }
+
+    /**
+     * Counts {@code e} against {@code format}. The segment's codec and the field's info, when the accessor was about one field, let
+     * {@link Format#formatName} name the concrete format; both are looked up only here, on the failure path.
+     */
+    private void record(Format format, @Nullable String field, Exception e) {
+        codecMetrics.onFailure(format, codec(), field == null ? null : in.getFieldInfos().fieldInfo(field), e);
+    }
+
+    /** The SPI codec the segment was written with, or null if {@link #in} does not wrap a segment (some test readers). */
+    @Nullable
+    private Codec codec() {
+        SegmentReader segmentReader = Lucene.tryUnwrapSegmentReader(in);
+        return segmentReader == null ? null : Codec.forName(segmentReader.getSegmentInfo().info.getCodec().getName());
+    }
+
+    /** Runs {@code call}, recording anything it throws under the given format and field before rethrowing it unchanged. */
+    private <T> T runWithMetrics(Format format, @Nullable String field, IOSupplier<T> call) throws IOException {
+        try {
+            return call.get();
+        } catch (Exception e) {
+            record(format, field, e);
+            throw e;
+        }
+    }
+
+    private void runWithMetrics(Format format, @Nullable String field, IORunnable call) throws IOException {
+        try {
+            call.run();
+        } catch (Exception e) {
+            record(format, field, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public Terms terms(String field) throws IOException {
+        return runWithMetrics(Format.POSTINGS, field, () -> in.terms(field));
+    }
+
+    @Override
+    public NumericDocValues getNumericDocValues(String field) throws IOException {
+        return runWithMetrics(Format.DOC_VALUES, field, () -> in.getNumericDocValues(field));
+    }
+
+    @Override
+    public BinaryDocValues getBinaryDocValues(String field) throws IOException {
+        return runWithMetrics(Format.DOC_VALUES, field, () -> in.getBinaryDocValues(field));
+    }
+
+    @Override
+    public SortedDocValues getSortedDocValues(String field) throws IOException {
+        return runWithMetrics(Format.DOC_VALUES, field, () -> in.getSortedDocValues(field));
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
+        return runWithMetrics(Format.DOC_VALUES, field, () -> in.getSortedNumericDocValues(field));
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
+        return runWithMetrics(Format.DOC_VALUES, field, () -> in.getSortedSetDocValues(field));
+    }
+
+    @Override
+    public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+        return runWithMetrics(Format.DOC_VALUES, field, () -> in.getDocValuesSkipper(field));
+    }
+
+    @Override
+    public NumericDocValues getNormValues(String field) throws IOException {
+        return runWithMetrics(Format.NORMS, field, () -> in.getNormValues(field));
+    }
+
+    @Override
+    public PointValues getPointValues(String field) throws IOException {
+        return runWithMetrics(Format.POINTS, field, () -> in.getPointValues(field));
+    }
+
+    @Override
+    public FloatVectorValues getFloatVectorValues(String field) throws IOException {
+        return runWithMetrics(Format.KNN_VECTORS, field, () -> in.getFloatVectorValues(field));
+    }
+
+    @Override
+    public ByteVectorValues getByteVectorValues(String field) throws IOException {
+        return runWithMetrics(Format.KNN_VECTORS, field, () -> in.getByteVectorValues(field));
+    }
+
+    @Override
+    public void searchNearestVectors(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        runWithMetrics(Format.KNN_VECTORS, field, () -> in.searchNearestVectors(field, target, knnCollector, acceptDocs));
+    }
+
+    @Override
+    public void searchNearestVectors(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        runWithMetrics(Format.KNN_VECTORS, field, () -> in.searchNearestVectors(field, target, knnCollector, acceptDocs));
+    }
+
+    @Override
+    public StoredFields storedFields() throws IOException {
+        StoredFields storedFields = runWithMetrics(Format.STORED_FIELDS, null, in::storedFields);
+        return new StoredFields() {
+            @Override
+            public void prefetch(int docID) throws IOException {
+                try {
+                    storedFields.prefetch(docID);
+                } catch (Exception e) {
+                    record(Format.STORED_FIELDS, null, e);
+                    throw e;
+                }
+            }
+
+            @Override
+            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+                try {
+                    storedFields.document(docID, visitor);
+                } catch (Exception e) {
+                    record(Format.STORED_FIELDS, null, e);
+                    throw e;
+                }
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -105,6 +105,7 @@ import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.search.stats.SearchStatsSettings;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.indices.IndexingMemoryController;
 import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.IndicesRequestCache;
@@ -278,6 +279,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         Metadata.SETTING_READ_ONLY_SETTING,
         Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING,
         ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE,
+        ShardMetrics.CODEC_METRICS_ENABLED,
         IncrementalBulkService.INCREMENTAL_BULK,
         IncrementalBulkService.REQUEST_TIMEOUT,
         BatchIndexingEnabled.BATCH_INDEXING,

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -43,7 +43,6 @@ import org.elasticsearch.index.cache.query.IndexQueryCache;
 import org.elasticsearch.index.cache.query.QueryCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperMetrics;
@@ -55,6 +54,7 @@ import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.MutableOperationGate;
 import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.FsDirectoryFactory;
@@ -196,7 +196,7 @@ public final class IndexModule {
     private final MapperMetrics mapperMetrics;
     private final IndexingStatsSettings indexingStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
     private final PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder;
 
     /**
@@ -207,7 +207,7 @@ public final class IndexModule {
      * @param analysisRegistry   the analysis registry
      * @param engineFactory      the engine factory
      * @param directoryFactories the available store types
-     * @param mergeMetrics
+     * @param shardMetrics       the node-wide shard metrics bundle
      */
     public IndexModule(
         final IndexSettings indexSettings,
@@ -222,7 +222,7 @@ public final class IndexModule {
         final List<SearchOperationListener> searchOperationListeners,
         final IndexingStatsSettings indexingStatsSettings,
         final SearchStatsSettings searchStatsSettings,
-        final MergeMetrics mergeMetrics,
+        final ShardMetrics shardMetrics,
         final PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder
     ) {
         this.indexSettings = indexSettings;
@@ -239,7 +239,7 @@ public final class IndexModule {
         this.mapperMetrics = mapperMetrics;
         this.indexingStatsSettings = indexingStatsSettings;
         this.searchStatsSettings = searchStatsSettings;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
         this.metricHolder = metricHolder;
     }
 
@@ -583,7 +583,7 @@ public final class IndexModule {
                 mapperMetrics,
                 indexingStatsSettings,
                 searchStatsSettings,
-                mergeMetrics,
+                shardMetrics,
                 metricHolder
             );
             success = true;

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -49,7 +49,6 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.cache.query.QueryCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -79,6 +78,7 @@ import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.MutableOperationGate;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.index.shard.ShardNotInPrimaryModeException;
 import org.elasticsearch.index.shard.ShardPath;
@@ -174,7 +174,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final MapperMetrics mapperMetrics;
     private final IndexingStatsSettings indexingStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
     private final PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder;
 
     @SuppressWarnings("this-escape")
@@ -215,7 +215,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         MapperMetrics mapperMetrics,
         IndexingStatsSettings indexingStatsSettings,
         SearchStatsSettings searchStatsSettings,
-        MergeMetrics mergeMetrics,
+        ShardMetrics shardMetrics,
         PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder
     ) {
         super(indexSettings);
@@ -310,7 +310,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         }
         this.indexingStatsSettings = indexingStatsSettings;
         this.searchStatsSettings = searchStatsSettings;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
         this.metricHolder = metricHolder;
         updateFsyncTaskIfNecessary();
     }
@@ -611,7 +611,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 mapperMetrics,
                 indexingStatsSettings,
                 searchStatsSettings,
-                mergeMetrics
+                shardMetrics
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecMetrics.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.metric.LongCounter;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Counts failures thrown by Lucene codec formats. Recorded from two hooks: {@link MetricingCodec} on the write side and
+ * {@link org.elasticsearch.common.lucene.index.ElasticsearchLeafReader} on the read side, which sees the per-field accessors and random
+ * access stored fields but not the iterators they return or the sequential stored fields reader.
+ * <p>
+ * The counter is meant to alarm on any codec failure, so it carries only what an alert needs: the format that failed, resolved to the
+ * concrete class where possible ({@link Format#formatName}), and the {@link MetricAttributes#ERROR_TYPE}. Whether the failure was on the
+ * read or the write path, and in which index, is left to the logged stack trace.
+ */
+public class CodecMetrics {
+
+    public static final String CODEC_FAILURE_TOTAL = "es.codec.failure.total";
+
+    public static final String FORMAT_ATTRIBUTE = "es_codec_format";
+
+    public static final CodecMetrics NOOP = new CodecMetrics(TelemetryProvider.NOOP.getMeterRegistry());
+
+    /** The family of codec format a failure came from. */
+    public enum Format {
+        POSTINGS,
+        DOC_VALUES,
+        STORED_FIELDS,
+        KNN_VECTORS,
+        POINTS,
+        NORMS;
+
+        /** The value recorded when the concrete format cannot be resolved. */
+        public String label() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+
+        public String formatName(@Nullable Codec codec, @Nullable FieldInfo field) {
+            String name = switch (this) {
+                case POSTINGS -> perField(field, PerFieldPostingsFormat.PER_FIELD_FORMAT_KEY, PostingsFormat::forName);
+                case DOC_VALUES -> perField(field, PerFieldDocValuesFormat.PER_FIELD_FORMAT_KEY, DocValuesFormat::forName);
+                case KNN_VECTORS -> perField(field, PerFieldKnnVectorsFormat.PER_FIELD_FORMAT_KEY, KnnVectorsFormat::forName);
+                case STORED_FIELDS -> codec == null ? null : codec.storedFieldsFormat().getClass().getSimpleName();
+                case POINTS -> codec == null ? null : codec.pointsFormat().getClass().getSimpleName();
+                case NORMS -> codec == null ? null : codec.normsFormat().getClass().getSimpleName();
+            };
+            // An anonymous format class has an empty simple name, which is no better than no name.
+            return name == null || name.isEmpty() ? label() : name;
+        }
+
+        /**
+         * The per-field dispatcher stamps the chosen format's SPI name on the field, and a segment cannot be written or opened unless that
+         * name resolves, so the lookup cannot fail here.
+         */
+        @Nullable
+        private static String perField(@Nullable FieldInfo field, String attribute, Function<String, ?> forName) {
+            String spiName = field == null ? null : field.getAttribute(attribute);
+            return spiName == null ? null : forName.apply(spiName).getClass().getSimpleName();
+        }
+    }
+
+    private final LongCounter failures;
+
+    public CodecMetrics(MeterRegistry meterRegistry) {
+        failures = meterRegistry.registerLongCounter(CODEC_FAILURE_TOTAL, "Number of failures thrown by Lucene codec formats", "unit");
+    }
+
+    /**
+     * Counts one failure of {@code format}, unless it is an {@link AlreadyClosedException}: a reader or writer used after its shard closed
+     * is a lifecycle race, not a codec failure, and would otherwise dominate the counter.
+     *
+     * @param codec the codec of the segment, used to resolve the concrete format; see {@link Format#formatName}
+     * @param field the field the failing call was about, used to resolve the concrete format; see {@link Format#formatName}
+     */
+    public void onFailure(Format format, @Nullable Codec codec, @Nullable FieldInfo field, Throwable t) {
+        if (ExceptionsHelper.unwrapCause(t) instanceof AlreadyClosedException) {
+            return;
+        }
+        failures.incrementBy(
+            1,
+            Map.of(FORMAT_ATTRIBUTE, format.formatName(codec, field), MetricAttributes.ERROR_TYPE, MetricAttributes.errorType(t))
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -41,6 +41,15 @@ public class CodecService implements CodecProvider {
     public static final String LUCENE_DEFAULT_CODEC = "lucene_default";
 
     public CodecService(@Nullable MapperService mapperService, BigArrays bigArrays, @Nullable ThreadPool threadPool) {
+        this(mapperService, bigArrays, threadPool, CodecMetrics.NOOP);
+    }
+
+    public CodecService(
+        @Nullable MapperService mapperService,
+        BigArrays bigArrays,
+        @Nullable ThreadPool threadPool,
+        CodecMetrics codecMetrics
+    ) {
         final var codecs = new HashMap<String, Codec>();
 
         var bestSpeedCodec = new PerFieldMapperCodec(
@@ -82,18 +91,15 @@ public class CodecService implements CodecProvider {
             codecs.put(codec, Codec.forName(codec));
         }
 
-        // A codec that does not share field infos gets a wrapper that does, under the codec's own name. Freshly written
-        // segments are read back through the instance that wrote them, so this reaches those reads.
-        this.codecs = codecs.entrySet()
-            .stream()
-            .collect(
-                Collectors.toUnmodifiableMap(
-                    Map.Entry::getKey,
-                    e -> e.getValue().fieldInfosFormat() instanceof ElasticsearchFieldInfosFormat
-                        ? e.getValue()
-                        : new SharedFieldInfosCodec(e.getValue())
-                )
-            );
+        this.codecs = codecs.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> {
+            // A codec that does not share field infos gets a wrapper that does, under the codec's own name. Freshly written
+            // segments are read back through the instance that wrote them, so this reaches those reads.
+            Codec codec = e.getValue();
+            codec = codec.fieldInfosFormat() instanceof ElasticsearchFieldInfosFormat ? codec : new SharedFieldInfosCodec(codec);
+
+            // Skip the metrics layer when nothing records: keeps test codecs unwrapped and casts to the concrete codec working.
+            return codecMetrics == CodecMetrics.NOOP ? codec : new MetricingCodec(codec, codecMetrics);
+        }));
     }
 
     public Codec codec(String name) {

--- a/server/src/main/java/org/elasticsearch/index/codec/MetricingCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/MetricingCodec.java
@@ -1,0 +1,561 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.KnnFieldVectorsWriter;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.NormsConsumer;
+import org.apache.lucene.codecs.NormsFormat;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
+import org.apache.lucene.index.StoredFieldDataInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IORunnable;
+import org.apache.lucene.util.IOSupplier;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.CodecMetrics.Format;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Records every failure thrown while writing or merging the data-bearing formats (postings, doc values, stored fields, vectors, points,
+ * norms) into {@link CodecMetrics}. Keeps the delegate's name so {@code segments_N} still records the SPI-resolvable codec.
+ * <p>
+ * This mostly sees the write side. {@code IndexWriter} writes with the codec from its config and also opens the segments it flushed in
+ * the same session through it (NRT readers, merge sources), so a failing open is counted here too. Segments from earlier sessions are
+ * resolved by name via SPI ({@code SegmentInfos.readCommit} -> {@code Codec.forName}), so they never pass through this instance and, on
+ * stateless search nodes, nothing does. Read failures are recorded by
+ * {@link org.elasticsearch.common.lucene.index.ElasticsearchLeafReader}, which every engine applies after Lucene has opened the segment.
+ * Producers returned here are deliberately not wrapped so {@code instanceof} fast paths on them keep working.
+ * <p>
+ * Calls that are about one field pass its {@link FieldInfo} along so {@link Format#formatName} can name the concrete per-field format;
+ * the per-field dispatcher stamps that name onto the field before handing the call to the format, so it is set by the time the format
+ * fails. Calls spanning many fields (postings writes, merges, flush, close) record the format family instead. Only exceptions are
+ * counted: a JVM error is not a codec failure, and recording it could throw again and mask it.
+ */
+public final class MetricingCodec extends FilterCodec {
+
+    private final CodecMetrics metrics;
+    private final PostingsFormat postingsFormat;
+    private final DocValuesFormat docValuesFormat;
+    private final StoredFieldsFormat storedFieldsFormat;
+    private final KnnVectorsFormat knnVectorsFormat;
+    private final PointsFormat pointsFormat;
+    private final NormsFormat normsFormat;
+
+    @SuppressWarnings("this-escape")
+    public MetricingCodec(Codec delegate, CodecMetrics metrics) {
+        super(delegate.getName(), delegate);
+        this.metrics = metrics;
+        this.postingsFormat = new MetricsPostingsFormat(delegate.postingsFormat());
+        this.docValuesFormat = new MetricsDocValuesFormat(delegate.docValuesFormat());
+        this.storedFieldsFormat = new MetricsStoredFieldsFormat(delegate.storedFieldsFormat());
+        this.knnVectorsFormat = new MetricsKnnVectorsFormat(delegate.knnVectorsFormat());
+        this.pointsFormat = new MetricsPointsFormat(delegate.pointsFormat());
+        this.normsFormat = new MetricsNormsFormat(delegate.normsFormat());
+    }
+
+    public Codec delegate() {
+        return delegate;
+    }
+
+    @Override
+    public PostingsFormat postingsFormat() {
+        return postingsFormat;
+    }
+
+    @Override
+    public DocValuesFormat docValuesFormat() {
+        return docValuesFormat;
+    }
+
+    @Override
+    public StoredFieldsFormat storedFieldsFormat() {
+        return storedFieldsFormat;
+    }
+
+    @Override
+    public KnnVectorsFormat knnVectorsFormat() {
+        return knnVectorsFormat;
+    }
+
+    @Override
+    public PointsFormat pointsFormat() {
+        return pointsFormat;
+    }
+
+    @Override
+    public NormsFormat normsFormat() {
+        return normsFormat;
+    }
+
+    /** Counts {@code e} against {@code format}, naming the concrete format from {@code field} if the failing call was about one field. */
+    private void record(Format format, @Nullable FieldInfo field, Exception e) {
+        metrics.onFailure(format, delegate, field, e);
+    }
+
+    /** Runs {@code call}, recording anything it throws under the given format before rethrowing it unchanged. */
+    private <T> T runWithMetrics(Format format, IOSupplier<T> call) throws IOException {
+        return runWithMetrics(format, null, call);
+    }
+
+    private void runWithMetrics(Format format, IORunnable call) throws IOException {
+        runWithMetrics(format, null, call);
+    }
+
+    private <T> T runWithMetrics(Format format, @Nullable FieldInfo field, IOSupplier<T> call) throws IOException {
+        try {
+            return call.get();
+        } catch (Exception e) {
+            record(format, field, e);
+            throw e;
+        }
+    }
+
+    private void runWithMetrics(Format format, @Nullable FieldInfo field, IORunnable call) throws IOException {
+        try {
+            call.run();
+        } catch (Exception e) {
+            record(format, field, e);
+            throw e;
+        }
+    }
+
+    private final class MetricsPostingsFormat extends PostingsFormat {
+        private final PostingsFormat in;
+
+        MetricsPostingsFormat(PostingsFormat in) {
+            super(in.getName());
+            this.in = in;
+        }
+
+        @Override
+        public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+            return new MetricsFieldsConsumer(runWithMetrics(Format.POSTINGS, () -> in.fieldsConsumer(state)));
+        }
+
+        @Override
+        public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+            return runWithMetrics(Format.POSTINGS, () -> in.fieldsProducer(state));
+        }
+    }
+
+    private final class MetricsFieldsConsumer extends FieldsConsumer {
+        private final FieldsConsumer in;
+
+        MetricsFieldsConsumer(FieldsConsumer in) {
+            this.in = in;
+        }
+
+        @Override
+        public void write(Fields fields, NormsProducer norms) throws IOException {
+            runWithMetrics(Format.POSTINGS, () -> in.write(fields, norms));
+        }
+
+        @Override
+        public void merge(MergeState mergeState, NormsProducer norms) throws IOException {
+            runWithMetrics(Format.POSTINGS, () -> in.merge(mergeState, norms));
+        }
+
+        @Override
+        public void close() throws IOException {
+            runWithMetrics(Format.POSTINGS, in::close);
+        }
+    }
+
+    private final class MetricsDocValuesFormat extends DocValuesFormat {
+        private final DocValuesFormat in;
+
+        MetricsDocValuesFormat(DocValuesFormat in) {
+            super(in.getName());
+            this.in = in;
+        }
+
+        @Override
+        public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+            return new MetricsDocValuesConsumer(runWithMetrics(Format.DOC_VALUES, () -> in.fieldsConsumer(state)));
+        }
+
+        @Override
+        public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+            return runWithMetrics(Format.DOC_VALUES, () -> in.fieldsProducer(state));
+        }
+    }
+
+    private final class MetricsDocValuesConsumer extends DocValuesConsumer {
+        private final DocValuesConsumer in;
+
+        MetricsDocValuesConsumer(DocValuesConsumer in) {
+            this.in = in;
+        }
+
+        @Override
+        public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+            runWithMetrics(Format.DOC_VALUES, field, () -> in.addNumericField(field, valuesProducer));
+        }
+
+        @Override
+        public void addBinaryField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+            runWithMetrics(Format.DOC_VALUES, field, () -> in.addBinaryField(field, valuesProducer));
+        }
+
+        @Override
+        public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+            runWithMetrics(Format.DOC_VALUES, field, () -> in.addSortedField(field, valuesProducer));
+        }
+
+        @Override
+        public void addSortedNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+            runWithMetrics(Format.DOC_VALUES, field, () -> in.addSortedNumericField(field, valuesProducer));
+        }
+
+        @Override
+        public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+            runWithMetrics(Format.DOC_VALUES, field, () -> in.addSortedSetField(field, valuesProducer));
+        }
+
+        @Override
+        public void merge(MergeState mergeState) throws IOException {
+            runWithMetrics(Format.DOC_VALUES, () -> in.merge(mergeState));
+        }
+
+        @Override
+        public void close() throws IOException {
+            runWithMetrics(Format.DOC_VALUES, in::close);
+        }
+    }
+
+    private final class MetricsStoredFieldsFormat extends StoredFieldsFormat {
+        private final StoredFieldsFormat in;
+
+        MetricsStoredFieldsFormat(StoredFieldsFormat in) {
+            this.in = in;
+        }
+
+        @Override
+        public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
+            return runWithMetrics(Format.STORED_FIELDS, () -> in.fieldsReader(directory, si, fn, context));
+        }
+
+        @Override
+        public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo si, IOContext context) throws IOException {
+            return new MetricsStoredFieldsWriter(runWithMetrics(Format.STORED_FIELDS, () -> in.fieldsWriter(directory, si, context)));
+        }
+    }
+
+    /**
+     * The one per-document write path, so every call is wrapped by hand instead of through {@link #runWithMetrics}: no lambda allocation
+     * per stored field.
+     */
+    private final class MetricsStoredFieldsWriter extends StoredFieldsWriter {
+        private final StoredFieldsWriter in;
+
+        MetricsStoredFieldsWriter(StoredFieldsWriter in) {
+            this.in = in;
+        }
+
+        @Override
+        public void startDocument() throws IOException {
+            try {
+                in.startDocument();
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void finishDocument() throws IOException {
+            try {
+                in.finishDocument();
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void writeField(FieldInfo info, int value) throws IOException {
+            try {
+                in.writeField(info, value);
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void writeField(FieldInfo info, long value) throws IOException {
+            try {
+                in.writeField(info, value);
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void writeField(FieldInfo info, float value) throws IOException {
+            try {
+                in.writeField(info, value);
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void writeField(FieldInfo info, double value) throws IOException {
+            try {
+                in.writeField(info, value);
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void writeField(FieldInfo info, StoredFieldDataInput value) throws IOException {
+            try {
+                in.writeField(info, value);
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void writeField(FieldInfo info, BytesRef value) throws IOException {
+            try {
+                in.writeField(info, value);
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void writeField(FieldInfo info, String value) throws IOException {
+            try {
+                in.writeField(info, value);
+            } catch (Exception e) {
+                record(Format.STORED_FIELDS, null, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void finish(int numDocs) throws IOException {
+            runWithMetrics(Format.STORED_FIELDS, () -> in.finish(numDocs));
+        }
+
+        @Override
+        public int merge(MergeState mergeState) throws IOException {
+            return runWithMetrics(Format.STORED_FIELDS, () -> in.merge(mergeState));
+        }
+
+        @Override
+        public void close() throws IOException {
+            runWithMetrics(Format.STORED_FIELDS, in::close);
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return in.ramBytesUsed();
+        }
+
+        @Override
+        public Collection<Accountable> getChildResources() {
+            return in.getChildResources();
+        }
+    }
+
+    private final class MetricsKnnVectorsFormat extends KnnVectorsFormat {
+        private final KnnVectorsFormat in;
+
+        MetricsKnnVectorsFormat(KnnVectorsFormat in) {
+            super(in.getName());
+            this.in = in;
+        }
+
+        @Override
+        public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+            return new MetricsKnnVectorsWriter(runWithMetrics(Format.KNN_VECTORS, () -> in.fieldsWriter(state)));
+        }
+
+        @Override
+        public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+            return runWithMetrics(Format.KNN_VECTORS, () -> in.fieldsReader(state));
+        }
+
+        @Override
+        public int getMaxDimensions(String fieldName) {
+            return in.getMaxDimensions(fieldName);
+        }
+    }
+
+    private final class MetricsKnnVectorsWriter extends KnnVectorsWriter {
+        private final KnnVectorsWriter in;
+
+        MetricsKnnVectorsWriter(KnnVectorsWriter in) {
+            this.in = in;
+        }
+
+        @Override
+        public KnnFieldVectorsWriter<?> addField(FieldInfo fieldInfo) throws IOException {
+            return runWithMetrics(Format.KNN_VECTORS, fieldInfo, () -> in.addField(fieldInfo));
+        }
+
+        @Override
+        public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+            runWithMetrics(Format.KNN_VECTORS, () -> in.flush(maxDoc, sortMap));
+        }
+
+        @Override
+        public void finish() throws IOException {
+            runWithMetrics(Format.KNN_VECTORS, in::finish);
+        }
+
+        @Override
+        public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+            IORunnable deferred = runWithMetrics(Format.KNN_VECTORS, fieldInfo, () -> in.mergeOneField(fieldInfo, mergeState));
+            return deferred == null ? null : () -> runWithMetrics(Format.KNN_VECTORS, fieldInfo, deferred);
+        }
+
+        @Override
+        public void close() throws IOException {
+            runWithMetrics(Format.KNN_VECTORS, in::close);
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return in.ramBytesUsed();
+        }
+
+        @Override
+        public Collection<Accountable> getChildResources() {
+            return in.getChildResources();
+        }
+    }
+
+    private final class MetricsPointsFormat extends PointsFormat {
+        private final PointsFormat in;
+
+        MetricsPointsFormat(PointsFormat in) {
+            this.in = in;
+        }
+
+        @Override
+        public PointsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+            return new MetricsPointsWriter(runWithMetrics(Format.POINTS, () -> in.fieldsWriter(state)));
+        }
+
+        @Override
+        public PointsReader fieldsReader(SegmentReadState state) throws IOException {
+            return runWithMetrics(Format.POINTS, () -> in.fieldsReader(state));
+        }
+    }
+
+    private final class MetricsPointsWriter extends PointsWriter {
+        private final PointsWriter in;
+
+        MetricsPointsWriter(PointsWriter in) {
+            this.in = in;
+        }
+
+        @Override
+        public void writeField(FieldInfo fieldInfo, PointsReader values) throws IOException {
+            runWithMetrics(Format.POINTS, () -> in.writeField(fieldInfo, values));
+        }
+
+        @Override
+        public void merge(MergeState mergeState) throws IOException {
+            runWithMetrics(Format.POINTS, () -> in.merge(mergeState));
+        }
+
+        @Override
+        public void finish() throws IOException {
+            runWithMetrics(Format.POINTS, in::finish);
+        }
+
+        @Override
+        public void close() throws IOException {
+            runWithMetrics(Format.POINTS, in::close);
+        }
+    }
+
+    private final class MetricsNormsFormat extends NormsFormat {
+        private final NormsFormat in;
+
+        MetricsNormsFormat(NormsFormat in) {
+            this.in = in;
+        }
+
+        @Override
+        public NormsConsumer normsConsumer(SegmentWriteState state) throws IOException {
+            return new MetricsNormsConsumer(runWithMetrics(Format.NORMS, () -> in.normsConsumer(state)));
+        }
+
+        @Override
+        public NormsProducer normsProducer(SegmentReadState state) throws IOException {
+            return runWithMetrics(Format.NORMS, () -> in.normsProducer(state));
+        }
+    }
+
+    private final class MetricsNormsConsumer extends NormsConsumer {
+        private final NormsConsumer in;
+
+        MetricsNormsConsumer(NormsConsumer in) {
+            this.in = in;
+        }
+
+        @Override
+        public void addNormsField(FieldInfo field, NormsProducer normsProducer) throws IOException {
+            runWithMetrics(Format.NORMS, () -> in.addNormsField(field, normsProducer));
+        }
+
+        @Override
+        public void merge(MergeState mergeState) throws IOException {
+            runWithMetrics(Format.NORMS, () -> in.merge(mergeState));
+        }
+
+        @Override
+        public void close() throws IOException {
+            runWithMetrics(Format.NORMS, in::close);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.TranslogConfig;
 import org.elasticsearch.indices.IndexingMemoryController;
@@ -159,7 +160,7 @@ public final class EngineConfig {
 
     private final EngineResetLock engineResetLock;
 
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
 
     /**
      * Allows to pass an {@link ElasticsearchIndexDeletionPolicy} wrapper to egine implementations.
@@ -196,7 +197,7 @@ public final class EngineConfig {
         boolean promotableToPrimary,
         MapperService mapperService,
         EngineResetLock engineResetLock,
-        MergeMetrics mergeMetrics,
+        ShardMetrics shardMetrics,
         Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> indexDeletionPolicyWrapper
     ) {
         this.shardId = shardId;
@@ -246,7 +247,7 @@ public final class EngineConfig {
         // always use compound on flush - reduces # of file-handles on refresh
         this.useCompoundFile = indexSettings.getSettings().getAsBoolean(USE_COMPOUND_FILE, true);
         this.engineResetLock = engineResetLock;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
         this.indexDeletionPolicyWrapper = indexDeletionPolicyWrapper;
     }
 
@@ -497,8 +498,8 @@ public final class EngineConfig {
         return engineResetLock;
     }
 
-    public MergeMetrics getMergeMetrics() {
-        return mergeMetrics;
+    public ShardMetrics getShardMetrics() {
+        return shardMetrics;
     }
 
     /**
@@ -538,7 +539,7 @@ public final class EngineConfig {
         private boolean promotableToPrimary;
         private MapperService mapperService;
         private EngineResetLock engineResetLock;
-        private MergeMetrics mergeMetrics;
+        private ShardMetrics shardMetrics;
         private Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> indexDeletionPolicyWrapper;
 
         Builder() {}
@@ -573,7 +574,7 @@ public final class EngineConfig {
             this.promotableToPrimary = config.promotableToPrimary;
             this.mapperService = config.mapperService;
             this.engineResetLock = config.engineResetLock;
-            this.mergeMetrics = config.mergeMetrics;
+            this.shardMetrics = config.shardMetrics;
             this.indexDeletionPolicyWrapper = config.indexDeletionPolicyWrapper;
         }
 
@@ -722,8 +723,8 @@ public final class EngineConfig {
             return this;
         }
 
-        public Builder mergeMetrics(MergeMetrics mergeMetrics) {
-            this.mergeMetrics = mergeMetrics;
+        public Builder shardMetrics(ShardMetrics shardMetrics) {
+            this.shardMetrics = shardMetrics;
             return this;
         }
 
@@ -765,7 +766,7 @@ public final class EngineConfig {
                 promotableToPrimary,
                 mapperService,
                 engineResetLock,
-                mergeMetrics,
+                shardMetrics,
                 indexDeletionPolicyWrapper
             );
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -286,7 +286,7 @@ public class InternalEngine extends Engine {
                 engineConfig.getShardId(),
                 engineConfig.getIndexSettings(),
                 engineConfig.getThreadPoolMergeExecutorService(),
-                engineConfig.getMergeMetrics()
+                engineConfig.getShardMetrics().merge()
             );
             scheduler = mergeScheduler.getMergeScheduler();
             throttle = new IndexThrottle(pauseIndexingOnThrottle);
@@ -854,7 +854,12 @@ public class InternalEngine extends Engine {
         ElasticsearchReaderManager internalReaderManager = null;
         try {
             try {
-                directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(indexWriter), shardId);
+                directoryReader = ElasticsearchDirectoryReader.wrap(
+                    DirectoryReader.open(indexWriter),
+                    shardId,
+                    null,
+                    engineConfig.getShardMetrics().codec()
+                );
                 internalReaderManager = createInternalReaderManager(directoryReader);
                 ExternalReaderManager externalReaderManager = new ExternalReaderManager(internalReaderManager, externalRefreshListener);
                 success = true;

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -216,7 +216,7 @@ public class ReadOnlyEngine extends Engine {
         @Nullable ESCacheHelper esCacheHelper
     ) throws IOException {
         reader = readerWrapperFunction.apply(reader);
-        return ElasticsearchDirectoryReader.wrap(reader, engineConfig.getShardId(), esCacheHelper);
+        return ElasticsearchDirectoryReader.wrap(reader, engineConfig.getShardId(), esCacheHelper, engineConfig.getShardMetrics().codec());
     }
 
     protected DirectoryReader open(IndexCommit commit) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -102,7 +102,6 @@ import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineException;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.IndexOperationBatch;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ReadOnlyEngine;
 import org.elasticsearch.index.engine.RefreshFailedEngineException;
 import org.elasticsearch.index.engine.SafeCommitInfo;
@@ -289,7 +288,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final MeanMetric externalRefreshMetric = new MeanMetric();
     private final MeanMetric flushMetric = new MeanMetric();
     private final CounterMetric periodicFlushMetric = new CounterMetric();
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
 
     private final ShardEventListener shardEventListener = new ShardEventListener();
 
@@ -370,7 +369,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final MapperMetrics mapperMetrics,
         final IndexingStatsSettings indexingStatsSettings,
         final SearchStatsSettings searchStatsSettings,
-        final MergeMetrics mergeMetrics
+        final ShardMetrics shardMetrics
     ) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
@@ -384,7 +383,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             mapperService,
             bigArrays,
             // Using this as a proxy on if the merge execution executor service exists
-            threadPoolMergeExecutorService == null ? null : threadPool
+            threadPoolMergeExecutorService == null ? null : threadPool,
+            shardMetrics.codec()
         );
         this.warmer = warmer;
         this.mutableOperationGate = mutableOperationGate;
@@ -476,7 +476,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.refreshFieldHasValueListener = new RefreshFieldHasValueListener();
         this.relativeTimeInNanosSupplier = relativeTimeInNanosSupplier;
         this.indexCommitListener = indexCommitListener;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
     }
 
     public ThreadPool getThreadPool() {
@@ -4158,7 +4158,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             .promotableToPrimary(routingEntry().isPromotableToPrimary())
             .mapperService(mapperService())
             .engineResetLock(engineResetLock)
-            .mergeMetrics(mergeMetrics)
+            .shardMetrics(shardMetrics)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardMetrics.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.CodecMetrics;
+import org.elasticsearch.index.engine.MergeMetrics;
+import org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics;
+import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+
+/**
+ * Node-wide APM instruments that shards record into.
+ */
+public record ShardMetrics(CodecMetrics codec, MergeMetrics merge, ShardSearchPhaseAPMMetrics search) {
+
+    /**
+     * Rollout toggle for {@link CodecMetrics}. Off by default so the codec wrapping layer stays out of the write path until it has soaked
+     * in QA. Read once at node startup by {@link #create}; changing it needs a restart.
+     */
+    public static final Setting<Boolean> CODEC_METRICS_ENABLED = Setting.boolSetting(
+        "indices.codec.metrics.enabled",
+        false,
+        Setting.Property.NodeScope
+    );
+
+    public static final ShardMetrics NOOP = new ShardMetrics(
+        CodecMetrics.NOOP,
+        MergeMetrics.NOOP,
+        new ShardSearchPhaseAPMMetrics(TelemetryProvider.NOOP.getMeterRegistry())
+    );
+
+    public static ShardMetrics create(MeterRegistry meterRegistry, Settings settings) {
+        return new ShardMetrics(
+            CODEC_METRICS_ENABLED.get(settings) ? new CodecMetrics(meterRegistry) : CodecMetrics.NOOP,
+            new MergeMetrics(meterRegistry),
+            new ShardSearchPhaseAPMMetrics(meterRegistry)
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -102,7 +102,6 @@ import org.elasticsearch.index.cache.request.ShardRequestCache;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.engine.ReadOnlyEngine;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
@@ -137,6 +136,7 @@ import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.DirectoryMetrics;
 import org.elasticsearch.index.store.PluggableDirectoryMetricsHolder;
 import org.elasticsearch.index.store.StoreMetrics;
@@ -293,7 +293,7 @@ public class IndicesService extends AbstractLifecycleComponent
     final ActionLoggingFieldsProvider loggingFieldsProvider; // pkg-private for testingå
     private final IndexingStatsSettings indexStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
     private final PluggableDirectoryMetricsHolder<StoreMetrics> storeMetricHolder;
     private final Map<String, PluggableDirectoryMetricsHolder<?>> directoryMetricHolderMap;
     private final ThrottlingRecoveryService throttlingRecoveryService;
@@ -372,7 +372,7 @@ public class IndicesService extends AbstractLifecycleComponent
         this.requestCacheKeyDifferentiator = builder.requestCacheKeyDifferentiator;
         this.queryRewriteInterceptor = builder.queryRewriteInterceptor;
         this.mapperMetrics = builder.mapperMetrics;
-        this.mergeMetrics = builder.mergeMetrics;
+        this.shardMetrics = builder.shardMetrics;
         // doClose() is called when shutting down a node, yet there might still be ongoing requests
         // that we need to wait for before closing some resources such as the caches. In order to
         // avoid closing these resources while ongoing requests are still being processed, we use a
@@ -837,7 +837,7 @@ public class IndicesService extends AbstractLifecycleComponent
             searchOperationListeners,
             indexStatsSettings,
             searchStatsSettings,
-            mergeMetrics,
+            shardMetrics,
             storeMetricHolder
         );
         for (IndexingOperationListener operationListener : indexingOperationListeners) {
@@ -937,7 +937,7 @@ public class IndicesService extends AbstractLifecycleComponent
             searchOperationListeners,
             indexStatsSettings,
             searchStatsSettings,
-            mergeMetrics,
+            shardMetrics,
             storeMetricHolder
         );
         pluginsService.forEach(p -> p.onIndexModule(indexModule));

--- a/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
@@ -27,10 +27,10 @@ import org.elasticsearch.index.ActionLoggingFieldsProvider;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.PluggableDirectoryMetricsHolder;
 import org.elasticsearch.index.store.StoreMetrics;
 import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
@@ -86,7 +86,7 @@ public class IndicesServiceBuilder {
     @Nullable
     CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator;
     MapperMetrics mapperMetrics;
-    MergeMetrics mergeMetrics;
+    ShardMetrics shardMetrics;
     List<SearchOperationListener> searchOperationListener = List.of();
     QueryRewriteInterceptor queryRewriteInterceptor = null;
     ActionLoggingFieldsProvider loggingFieldsProvider = (context) -> new ActionLoggingFields(context) {};
@@ -196,8 +196,8 @@ public class IndicesServiceBuilder {
         return this;
     }
 
-    public IndicesServiceBuilder mergeMetrics(MergeMetrics mergeMetrics) {
-        this.mergeMetrics = mergeMetrics;
+    public IndicesServiceBuilder shardMetrics(ShardMetrics shardMetrics) {
+        this.shardMetrics = shardMetrics;
         return this;
     }
 
@@ -244,7 +244,7 @@ public class IndicesServiceBuilder {
         Objects.requireNonNull(indexFoldersDeletionListeners);
         Objects.requireNonNull(snapshotCommitSuppliers);
         Objects.requireNonNull(mapperMetrics);
-        Objects.requireNonNull(mergeMetrics);
+        Objects.requireNonNull(shardMetrics);
         Objects.requireNonNull(searchOperationListener);
         Objects.requireNonNull(loggingFieldsProvider);
         Objects.requireNonNull(throttlingRecoveryService);

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -140,8 +140,8 @@ import org.elasticsearch.index.mapper.DefaultRootObjectMapperNamespaceValidator;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.RootObjectMapperNamespaceValidator;
 import org.elasticsearch.index.mapper.SourceFieldMetrics;
-import org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.indices.ExecutorSelector;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
@@ -919,11 +919,9 @@ class NodeConstruction {
         TokenCountingMetrics tokenCountingMetrics = new TokenCountingMetrics(telemetryProvider.getMeterRegistry());
         MapperMetrics mapperMetrics = new MapperMetrics(sourceFieldMetrics, tokenCountingMetrics);
 
-        MergeMetrics mergeMetrics = new MergeMetrics(telemetryProvider.getMeterRegistry());
+        ShardMetrics shardMetrics = ShardMetrics.create(telemetryProvider.getMeterRegistry(), settings);
 
-        final List<SearchOperationListener> searchOperationListeners = List.of(
-            new ShardSearchPhaseAPMMetrics(telemetryProvider.getMeterRegistry())
-        );
+        final List<SearchOperationListener> searchOperationListeners = List.of(shardMetrics.search());
 
         List<? extends ActionLoggingFieldsProvider> loggingFieldsProviders = pluginsService.loadServiceProviders(
             ActionLoggingFieldsProvider.class
@@ -982,7 +980,7 @@ class NodeConstruction {
             .valuesSourceRegistry(searchModule.getValuesSourceRegistry())
             .requestCacheKeyDifferentiator(searchModule.getRequestCacheKeyDifferentiator())
             .mapperMetrics(mapperMetrics)
-            .mergeMetrics(mergeMetrics)
+            .shardMetrics(shardMetrics)
             .searchOperationListeners(searchOperationListeners)
             .loggingFieldsProvider(loggingFieldsProvider)
             .throttlingRecoveryService(throttlingRecoveryService)
@@ -1523,7 +1521,7 @@ class NodeConstruction {
             b.bind(FailureStoreMetrics.class).toInstance(failureStoreMetrics);
             b.bind(ShutdownPrepareService.class).toInstance(shutdownPrepareService);
             b.bind(OnlinePrewarmingService.class).toInstance(onlinePrewarmingService);
-            b.bind(MergeMetrics.class).toInstance(mergeMetrics);
+            b.bind(MergeMetrics.class).toInstance(shardMetrics.merge());
             b.bind(ProjectRoutingResolver.class).toInstance(projectRoutingResolver);
             b.bind(ActionLoggingFieldsProvider.class).toInstance(loggingFieldsProvider);
             b.bind(ActivityLogWriterProvider.class).toInstance(logWriterProvider);

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/MetricAttributes.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/MetricAttributes.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.telemetry.metric;
 
+import org.elasticsearch.ExceptionsHelper;
+
+import java.io.IOException;
 import java.util.Set;
 
 public interface MetricAttributes {
@@ -77,4 +80,13 @@ public interface MetricAttributes {
         "elastic-synthetics"
     );
 
+    /**
+     * The {@link #ERROR_TYPE} value for a failure: the simple class name of the corruption exception if one is anywhere in the cause or
+     * suppressed chain, otherwise of the innermost non-wrapper cause.
+     */
+    static String errorType(Throwable t) {
+        IOException corruption = ExceptionsHelper.unwrapCorruption(t);
+        Throwable cause = corruption != null ? corruption : ExceptionsHelper.unwrapCause(t);
+        return cause.getClass().getSimpleName();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReaderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReaderTests.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.lucene.index;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.codec.CodecMetrics;
+import org.elasticsearch.index.codec.CodecMetrics.Format;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.RemoteTransportException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.hasSize;
+
+public class ElasticsearchLeafReaderTests extends ESTestCase {
+
+    private record Accessor(String name, Format format, CheckedConsumer<ElasticsearchLeafReader, IOException> call) {}
+
+    private static final List<Accessor> ACCESSORS = List.of(
+        new Accessor("terms", Format.POSTINGS, r -> r.terms("f")),
+        new Accessor("getNumericDocValues", Format.DOC_VALUES, r -> r.getNumericDocValues("f")),
+        new Accessor("getBinaryDocValues", Format.DOC_VALUES, r -> r.getBinaryDocValues("f")),
+        new Accessor("getSortedDocValues", Format.DOC_VALUES, r -> r.getSortedDocValues("f")),
+        new Accessor("getSortedNumericDocValues", Format.DOC_VALUES, r -> r.getSortedNumericDocValues("f")),
+        new Accessor("getSortedSetDocValues", Format.DOC_VALUES, r -> r.getSortedSetDocValues("f")),
+        new Accessor("getDocValuesSkipper", Format.DOC_VALUES, r -> r.getDocValuesSkipper("f")),
+        new Accessor("getNormValues", Format.NORMS, r -> r.getNormValues("f")),
+        new Accessor("getPointValues", Format.POINTS, r -> r.getPointValues("f")),
+        new Accessor("getFloatVectorValues", Format.KNN_VECTORS, r -> r.getFloatVectorValues("f")),
+        new Accessor("getByteVectorValues", Format.KNN_VECTORS, r -> r.getByteVectorValues("f")),
+        new Accessor(
+            "searchNearestVectors(float)",
+            Format.KNN_VECTORS,
+            r -> r.searchNearestVectors(
+                "f",
+                new float[] { 1f },
+                new TopKnnCollector(1, Integer.MAX_VALUE),
+                AcceptDocs.fromLiveDocs(null, 1)
+            )
+        ),
+        new Accessor(
+            "searchNearestVectors(byte)",
+            Format.KNN_VECTORS,
+            r -> r.searchNearestVectors("f", new byte[] { 1 }, new TopKnnCollector(1, Integer.MAX_VALUE), AcceptDocs.fromLiveDocs(null, 1))
+        ),
+        new Accessor("storedFields().document", Format.STORED_FIELDS, r -> r.storedFields().document(0)),
+        new Accessor("storedFields().prefetch", Format.STORED_FIELDS, r -> r.storedFields().prefetch(0))
+    );
+
+    public void testFailuresAreCountedPerFormat() throws IOException {
+        try (Directory dir = newDirectory()) {
+            Codec codec = new Lucene104Codec();
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig().setCodec(codec))) {
+                Document doc = new Document();
+                doc.add(new StringField("f", randomAlphaOfLength(5), Field.Store.YES));
+                writer.addDocument(doc);
+            }
+            for (Accessor accessor : ACCESSORS) {
+                Failure failure = randomFailure();
+                RecordingMeterRegistry registry = new RecordingMeterRegistry();
+                String expectedFormat;
+                try (
+                    DirectoryReader reader = ElasticsearchDirectoryReader.wrap(
+                        new ThrowingDirectoryReader(DirectoryReader.open(dir), failure),
+                        new ShardId("index", "_na_", 0),
+                        null,
+                        new CodecMetrics(registry)
+                    )
+                ) {
+                    ElasticsearchLeafReader leaf = (ElasticsearchLeafReader) reader.leaves().get(0).reader();
+                    expectThrows(Exception.class, () -> accessor.call().accept(leaf));
+                    // What the name resolves to is CodecMetricsTests' concern; here it only has to show the reader passed the segment's
+                    // codec and the accessed field along.
+                    expectedFormat = accessor.format().formatName(codec, leaf.getFieldInfos().fieldInfo("f"));
+                }
+                List<Measurement> measurements = registry.getRecorder()
+                    .getMeasurements(InstrumentType.LONG_COUNTER, CodecMetrics.CODEC_FAILURE_TOTAL);
+                assertThat(accessor.name(), measurements, hasSize(1));
+                assertEquals(
+                    accessor.name(),
+                    Map.of(CodecMetrics.FORMAT_ATTRIBUTE, expectedFormat, MetricAttributes.ERROR_TYPE, failure.expectedErrorType()),
+                    measurements.get(0).attributes()
+                );
+            }
+        }
+    }
+
+    private record Failure(Supplier<Exception> supplier, String expectedErrorType) {
+        IOException raise() throws IOException {
+            Exception e = supplier.get();
+            if (e instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw (RuntimeException) e;
+        }
+    }
+
+    /** Includes wrapped failures so both branches of the shared {@code error_type} unwrapping are exercised. */
+    private static Failure randomFailure() {
+        return randomFrom(
+            new Failure(() -> new CorruptIndexException("corrupt", "test"), "CorruptIndexException"),
+            new Failure(() -> new IOException("io"), "IOException"),
+            new Failure(() -> new IllegalStateException("state"), "IllegalStateException"),
+            new Failure(() -> new UncheckedIOException(new CorruptIndexException("corrupt", "test")), "CorruptIndexException"),
+            new Failure(() -> new RemoteTransportException("wrapped", new IOException("io")), "IOException")
+        );
+    }
+
+    private static final class ThrowingDirectoryReader extends FilterDirectoryReader {
+        private final Failure failure;
+
+        ThrowingDirectoryReader(DirectoryReader in, Failure failure) throws IOException {
+            super(in, new SubReaderWrapper() {
+                @Override
+                public LeafReader wrap(LeafReader reader) {
+                    return new ThrowingLeafReader(reader, failure);
+                }
+            });
+            this.failure = failure;
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new ThrowingDirectoryReader(in, failure);
+        }
+
+        @Override
+        public CacheHelper getReaderCacheHelper() {
+            return in.getReaderCacheHelper();
+        }
+    }
+
+    /** Fails every codec-backed accessor, so the test only has to pick which one to call. */
+    private static final class ThrowingLeafReader extends FilterLeafReader {
+        private final Failure failure;
+
+        ThrowingLeafReader(LeafReader in, Failure failure) {
+            super(in);
+            this.failure = failure;
+        }
+
+        @Override
+        public CacheHelper getCoreCacheHelper() {
+            return in.getCoreCacheHelper();
+        }
+
+        @Override
+        public CacheHelper getReaderCacheHelper() {
+            return in.getReaderCacheHelper();
+        }
+
+        @Override
+        public Terms terms(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public NumericDocValues getNumericDocValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public BinaryDocValues getBinaryDocValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public SortedDocValues getSortedDocValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public NumericDocValues getNormValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public PointValues getPointValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public FloatVectorValues getFloatVectorValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public ByteVectorValues getByteVectorValues(String field) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public void searchNearestVectors(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+            throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public void searchNearestVectors(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+            throw failure.raise();
+        }
+
+        @Override
+        public StoredFields storedFields() {
+            return new StoredFields() {
+                @Override
+                public void prefetch(int docID) throws IOException {
+                    throw failure.raise();
+                }
+
+                @Override
+                public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+                    throw failure.raise();
+                }
+            };
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -61,7 +61,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -78,6 +77,7 @@ import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.similarity.NonNegativeScoresSimilarity;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -269,7 +269,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
         module.setReaderWrapper(s -> new Wrapper());
@@ -301,7 +301,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -331,7 +331,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -714,7 +714,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -744,7 +744,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -859,7 +859,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecIntegrationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecIntegrationTests.java
@@ -9,16 +9,53 @@
 
 package org.elasticsearch.index.codec;
 
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.codec.storedfields.TSDBStoredFieldsFormat;
 import org.elasticsearch.index.codec.zstd.Zstd814StoredFieldsFormat;
+import org.elasticsearch.index.shard.ShardMetrics;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.telemetry.TestTelemetryPlugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
+import java.util.Collection;
+
+import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.codec.CodecTests.getLucene90StoredFieldsFormatMode;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CodecIntegrationTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder().put(super.nodeSettings()).put(ShardMetrics.CODEC_METRICS_ENABLED.getKey(), true).build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(TestTelemetryPlugin.class);
+    }
+
+    /** With the node setting on, indexing, merging and fetching all run through {@link MetricingCodec} and a clean run counts nothing. */
+    public void testCodecMetricsWiredThroughEngine() {
+        createIndex("index1");
+        int docs = between(2, 20);
+        for (int i = 0; i < docs; i++) {
+            prepareIndex("index1").setSource("field", randomAlphaOfLength(10)).setRefreshPolicy(IMMEDIATE).get();
+        }
+        indicesAdmin().prepareForceMerge("index1").setMaxNumSegments(1).get();
+        assertHitCount(client().prepareSearch("index1").setSize(docs).addFetchField("field"), docs);
+        TestTelemetryPlugin telemetry = getInstanceFromNode(PluginsService.class).filterPlugins(TestTelemetryPlugin.class)
+            .findFirst()
+            .get();
+        assertThat(telemetry.getLongCounterMeasurement(CodecMetrics.CODEC_FAILURE_TOTAL), empty());
+    }
 
     public void testCanConfigureLegacySettings() {
         createIndex("index1", Settings.builder().put("index.codec", "legacy_default").build());
@@ -42,24 +79,24 @@ public class CodecIntegrationTests extends ESSingleNodeTestCase {
 
     public void testDefaultCodecLogsdb() {
         var indexService = createIndex("index1", Settings.builder().put("index.mode", "logsdb").build());
-        var codecFormat = (ElasticsearchStoredFieldsFormat) ((TSDBStoredFieldsFormat) indexService.getShard(0)
-            .getEngineOrNull()
-            .config()
-            .getCodec()
-            .storedFieldsFormat()).delegate();
-        var storedFieldsFormat = (Zstd814StoredFieldsFormat) codecFormat.writeFormat();
+        var storedFieldsFormat = (Zstd814StoredFieldsFormat) writeStoredFieldsFormat(indexService);
         assertThat(storedFieldsFormat.getMode(), equalTo(Zstd814StoredFieldsFormat.Mode.BEST_COMPRESSION));
     }
 
     public void testDefaultCodec() throws Exception {
         var indexService = createIndex("index1");
-        var codecFormat = (ElasticsearchStoredFieldsFormat) ((TSDBStoredFieldsFormat) indexService.getShard(0)
-            .getEngineOrNull()
-            .config()
-            .getCodec()
-            .storedFieldsFormat()).delegate();
-        var storedFieldsFormat = (Lucene90StoredFieldsFormat) codecFormat.writeFormat();
+        var storedFieldsFormat = (Lucene90StoredFieldsFormat) writeStoredFieldsFormat(indexService);
         var mode = getLucene90StoredFieldsFormatMode(storedFieldsFormat);
         assertThat(mode, equalTo(Lucene90StoredFieldsFormat.Mode.BEST_SPEED));
+    }
+
+    /**
+     * The node setting is on here, so the engine writes through a {@link MetricingCodec} whose stored fields format is a
+     * {@link TSDBStoredFieldsFormat} over an {@link ElasticsearchStoredFieldsFormat}; unwrap all three to reach the concrete Lucene format.
+     */
+    private static StoredFieldsFormat writeStoredFieldsFormat(IndexService indexService) {
+        Codec codec = ((MetricingCodec) indexService.getShard(0).getEngineOrNull().config().getCodec()).delegate();
+        var codecFormat = (ElasticsearchStoredFieldsFormat) ((TSDBStoredFieldsFormat) codec.storedFieldsFormat()).delegate();
+        return codecFormat.writeFormat();
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecMetricsTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.index.codec.CodecMetrics.Format;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.RemoteTransportException;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.empty;
+
+public class CodecMetricsTests extends ESTestCase {
+
+    public void testAlreadyClosedIsNotCounted() {
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        Exception closed = new AlreadyClosedException("closed");
+        new CodecMetrics(registry).onFailure(
+            randomFrom(Format.values()),
+            null,
+            null,
+            randomBoolean() ? closed : new RemoteTransportException("wrapped", closed)
+        );
+        assertThat(registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, CodecMetrics.CODEC_FAILURE_TOTAL), empty());
+    }
+
+    /**
+     * Postings, doc values and vectors are named from the format the per-field dispatcher recorded on the field, codec-wide formats from the
+     * codec. The class name is what makes the value unambiguous: {@code Lucene90} is the SPI name of both a doc values and a postings format.
+     */
+    public void testFormatNameResolvesConcreteFormat() throws IOException {
+        Codec codec = new Lucene104Codec();
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig().setCodec(codec))) {
+                Document doc = new Document();
+                doc.add(new TextField("text", randomAlphaOfLengthBetween(1, 20), Field.Store.NO));
+                doc.add(new NumericDocValuesField("dv", randomLong()));
+                doc.add(new KnnFloatVectorField("vector", new float[] { randomFloat(), randomFloat() }));
+                writer.addDocument(doc);
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                FieldInfos fieldInfos = reader.leaves().get(0).reader().getFieldInfos();
+                assertEquals("Lucene104PostingsFormat", Format.POSTINGS.formatName(codec, fieldInfos.fieldInfo("text")));
+                assertEquals("Lucene90DocValuesFormat", Format.DOC_VALUES.formatName(codec, fieldInfos.fieldInfo("dv")));
+                assertEquals("Lucene99HnswVectorsFormat", Format.KNN_VECTORS.formatName(codec, fieldInfos.fieldInfo("vector")));
+                // A field the format never wrote carries no format name for it.
+                assertEquals(Format.DOC_VALUES.label(), Format.DOC_VALUES.formatName(codec, fieldInfos.fieldInfo("text")));
+                assertEquals("Lucene90StoredFieldsFormat", Format.STORED_FIELDS.formatName(codec, null));
+                assertEquals("Lucene90PointsFormat", Format.POINTS.formatName(codec, null));
+                assertEquals("Lucene90NormsFormat", Format.NORMS.formatName(codec, null));
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.FieldInfoCachingDirectory;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.hamcrest.Matchers;
@@ -411,6 +412,22 @@ public class CodecTests extends ESTestCase {
             null
         );
         return new CodecService(service, BigArrays.NON_RECYCLING_INSTANCE, null);
+    }
+
+    /**
+     * Every codec is wrapped in a {@link MetricingCodec} only when a recording {@link CodecMetrics} is given, and either way keeps the
+     * name that {@code segments_N} stores, so a segment written through it is read back through the SPI codec of that name.
+     */
+    public void testCodecsAreWrappedInMetricingCodecOnlyWhenRecording() {
+        CodecMetrics recording = new CodecMetrics(new RecordingMeterRegistry());
+        for (CodecMetrics codecMetrics : List.of(recording, CodecMetrics.NOOP)) {
+            CodecService codecService = new CodecService(null, BigArrays.NON_RECYCLING_INSTANCE, null, codecMetrics);
+            for (String name : codecService.availableCodecs()) {
+                Codec codec = codecService.codec(name);
+                assertEquals(name, codecMetrics == recording, codec instanceof MetricingCodec);
+                assertEquals(name, codec.getName(), Codec.forName(codec.getName()).getName());
+            }
+        }
     }
 
     @SuppressForbidden(reason = "access violation required in order to read private field for this test")

--- a/server/src/test/java/org/elasticsearch/index/codec/MetricingCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/MetricingCodecTests.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.NormsConsumer;
+import org.apache.lucene.codecs.NormsFormat;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.IOSupplier;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.codec.CodecMetrics.Format;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+
+public class MetricingCodecTests extends ESTestCase {
+
+    public void testNameRoundTripsThroughSpi() {
+        Codec delegate = TestUtil.getDefaultCodec();
+        MetricingCodec codec = new MetricingCodec(delegate, CodecMetrics.NOOP);
+        assertEquals(delegate.getName(), codec.getName());
+        assertEquals(delegate.getClass(), Codec.forName(codec.getName()).getClass());
+    }
+
+    public void testCleanWriteAndMergeRecordNothing() throws IOException {
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        Codec codec = new MetricingCodec(TestUtil.getDefaultCodec(), new CodecMetrics(registry));
+        try (Directory dir = newDirectory()) {
+            writeSegments(dir, codec, between(2, 4));
+            try (IndexWriter writer = new IndexWriter(dir, config(codec, false))) {
+                writer.forceMerge(1);
+            }
+        }
+        assertThat(failures(registry), empty());
+    }
+
+    /**
+     * A failing flush is counted against the failing format, whether the format fails while opening, writing or closing. The failing
+     * formats replace the per-field dispatchers, so no field carries a format name and the family label is recorded.
+     */
+    public void testWriteFailure() throws IOException {
+        Format format = randomFrom(Format.values());
+        Exception failure = randomFailure();
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        Codec failing = new FailingCodec(format, randomFrom(FailAt.WRITER_OPEN, FailAt.WRITER, FailAt.WRITER_CLOSE), failure);
+        Codec codec = new MetricingCodec(failing, new CodecMetrics(registry));
+
+        try (Directory dir = newDirectory()) {
+            IndexWriter writer = new IndexWriter(dir, config(codec, true));
+            expectThrows(Exception.class, () -> {
+                for (int i = 0; i < between(1, 20); i++) {
+                    writer.addDocument(randomDocument());
+                }
+                writer.commit();
+            });
+            IOUtils.closeWhileHandlingException(writer);
+        }
+        assertFailure(registry, format.label(), failure);
+    }
+
+    /**
+     * A failing merge is counted against the failing format, including the close that SegmentMerger issues after merge returns. Vectors
+     * merge one field at a time and the merged field infos keep the format name the source segments were written with, so that is the
+     * one merge failure that resolves to the concrete format; every other one records the family label.
+     */
+    public void testMergeFailure() throws IOException {
+        Format format = randomFrom(Format.values());
+        FailAt failAt = randomFrom(FailAt.WRITER_OPEN, FailAt.WRITER, FailAt.WRITER_CLOSE);
+        Exception failure = randomFailure();
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        Codec codec = new MetricingCodec(new FailingCodec(format, failAt, failure), new CodecMetrics(registry));
+
+        try (Directory dir = newDirectory()) {
+            writeSegments(dir, TestUtil.getDefaultCodec(), between(2, 4));
+            IndexWriter writer = new IndexWriter(dir, config(codec, false));
+            expectThrows(Exception.class, () -> writer.forceMerge(1));
+            IOUtils.closeWhileHandlingException(writer);
+        }
+        String expectedFormat = format == Format.KNN_VECTORS && failAt == FailAt.WRITER
+            ? ((PerFieldKnnVectorsFormat) TestUtil.getDefaultCodec().knnVectorsFormat()).getKnnVectorsFormatForField("vector")
+                .getClass()
+                .getSimpleName()
+            : format.label();
+        assertFailure(registry, expectedFormat, failure);
+    }
+
+    /** Segments flushed by the current writer are opened through its codec (NRT readers, merge sources), so a failing open is counted. */
+    public void testOpenFailure() throws IOException {
+        Format format = randomFrom(Format.values());
+        Exception failure = randomFailure();
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        Codec codec = new MetricingCodec(new FailingCodec(format, FailAt.READER_OPEN, failure), new CodecMetrics(registry));
+
+        try (Directory dir = newDirectory()) {
+            IndexWriter writer = new IndexWriter(dir, config(codec, true));
+            writer.addDocument(randomDocument());
+            expectThrows(Exception.class, () -> DirectoryReader.open(writer).close());
+            IOUtils.closeWhileHandlingException(writer);
+        }
+        assertFailure(registry, format.label(), failure);
+    }
+
+    private static void writeSegments(Directory dir, Codec codec, int segments) throws IOException {
+        try (IndexWriter writer = new IndexWriter(dir, config(codec, true))) {
+            for (int s = 0; s < segments; s++) {
+                for (int i = 0; i < between(1, 20); i++) {
+                    writer.addDocument(randomDocument());
+                }
+                writer.commit();
+            }
+        }
+    }
+
+    private static IndexWriterConfig config(Codec codec, boolean noMerges) {
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(codec).setMergeScheduler(new SerialMergeScheduler());
+        return noMerges ? config.setMergePolicy(NoMergePolicy.INSTANCE) : config;
+    }
+
+    /** One value of every data-bearing format, so whichever format is set up to fail is exercised. */
+    private static Document randomDocument() {
+        Document doc = new Document();
+        doc.add(new StringField("id", randomAlphanumericOfLength(8), Field.Store.YES));
+        doc.add(new TextField("text", randomAlphaOfLengthBetween(1, 20), Field.Store.NO));
+        doc.add(new NumericDocValuesField("dv", randomLong()));
+        doc.add(new IntPoint("point", randomInt()));
+        doc.add(new KnnFloatVectorField("vector", new float[] { randomFloat(), randomFloat() }));
+        return doc;
+    }
+
+    private static List<Measurement> failures(RecordingMeterRegistry registry) {
+        return registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, CodecMetrics.CODEC_FAILURE_TOTAL);
+    }
+
+    private static void assertFailure(RecordingMeterRegistry registry, String expectedFormat, Exception failure) {
+        List<Measurement> measurements = failures(registry);
+        assertThat(measurements, hasSize(1));
+        assertEquals(1L, measurements.get(0).getLong());
+        assertEquals(
+            Map.of(CodecMetrics.FORMAT_ATTRIBUTE, expectedFormat, MetricAttributes.ERROR_TYPE, failure.getClass().getSimpleName()),
+            measurements.get(0).attributes()
+        );
+    }
+
+    private static Exception randomFailure() {
+        return randomFrom(new CorruptIndexException("corrupt", "test"), new IOException("io"), new IllegalStateException("state"));
+    }
+
+    /** Throws the failure; the return type only exists so callers can write {@code throw raise(failure)}. */
+    private static IOException raise(Exception e) throws IOException {
+        if (e instanceof IOException ioException) {
+            throw ioException;
+        }
+        throw (RuntimeException) e;
+    }
+
+    private enum FailAt {
+        WRITER_OPEN,
+        WRITER,
+        WRITER_CLOSE,
+        READER_OPEN
+    }
+
+    /**
+     * The default codec with one format replaced by a version that fails at the chosen point. Which writer method ends up failing is
+     * decided by Lucene: a flush calls the add/write methods, a merge calls merge.
+     */
+    private static final class FailingCodec extends FilterCodec {
+        private final Format format;
+        private final FailAt failAt;
+        private final Exception failure;
+
+        FailingCodec(Format format, FailAt failAt, Exception failure) {
+            super(TestUtil.getDefaultCodec().getName(), TestUtil.getDefaultCodec());
+            this.format = format;
+            this.failAt = failAt;
+            this.failure = failure;
+        }
+
+        /** The failing format's writer: fails to open, fails on every call except the bookkeeping ones, fails on close, or is real. */
+        private <T> T writer(Class<T> type, IOSupplier<T> real) throws IOException {
+            return switch (failAt) {
+                case WRITER_OPEN -> throw raise(failure);
+                case WRITER -> mock(type, invocation -> switch (invocation.getMethod().getName()) {
+                    case "close" -> null;
+                    case "ramBytesUsed" -> 0L;
+                    case "getChildResources" -> List.of();
+                    default -> throw raise(failure);
+                });
+                case WRITER_CLOSE -> {
+                    // Like a real writer, only the first close fails: Lucene closes a flushed writer again when it aborts.
+                    AtomicBoolean closed = new AtomicBoolean();
+                    yield mock(type, invocation -> {
+                        if (invocation.getMethod().getName().equals("close") && closed.getAndSet(true) == false) {
+                            throw raise(failure);
+                        }
+                        return RETURNS_MOCKS.answer(invocation);
+                    });
+                }
+                case READER_OPEN -> real.get();
+            };
+        }
+
+        private <T> T reader(IOSupplier<T> real) throws IOException {
+            if (failAt == FailAt.READER_OPEN) {
+                throw raise(failure);
+            }
+            return real.get();
+        }
+
+        @Override
+        public PostingsFormat postingsFormat() {
+            PostingsFormat in = delegate.postingsFormat();
+            return format != Format.POSTINGS ? in : new PostingsFormat(in.getName()) {
+                @Override
+                public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+                    return writer(FieldsConsumer.class, () -> in.fieldsConsumer(state));
+                }
+
+                @Override
+                public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+                    return reader(() -> in.fieldsProducer(state));
+                }
+            };
+        }
+
+        @Override
+        public DocValuesFormat docValuesFormat() {
+            DocValuesFormat in = delegate.docValuesFormat();
+            return format != Format.DOC_VALUES ? in : new DocValuesFormat(in.getName()) {
+                @Override
+                public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+                    return writer(DocValuesConsumer.class, () -> in.fieldsConsumer(state));
+                }
+
+                @Override
+                public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+                    return reader(() -> in.fieldsProducer(state));
+                }
+            };
+        }
+
+        @Override
+        public StoredFieldsFormat storedFieldsFormat() {
+            StoredFieldsFormat in = delegate.storedFieldsFormat();
+            return format != Format.STORED_FIELDS ? in : new StoredFieldsFormat() {
+                @Override
+                public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context)
+                    throws IOException {
+                    return reader(() -> in.fieldsReader(directory, si, fn, context));
+                }
+
+                @Override
+                public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo si, IOContext context) throws IOException {
+                    return writer(StoredFieldsWriter.class, () -> in.fieldsWriter(directory, si, context));
+                }
+            };
+        }
+
+        @Override
+        public KnnVectorsFormat knnVectorsFormat() {
+            KnnVectorsFormat in = delegate.knnVectorsFormat();
+            return format != Format.KNN_VECTORS ? in : new KnnVectorsFormat(in.getName()) {
+                @Override
+                public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+                    return writer(KnnVectorsWriter.class, () -> in.fieldsWriter(state));
+                }
+
+                @Override
+                public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+                    return reader(() -> in.fieldsReader(state));
+                }
+
+                @Override
+                public int getMaxDimensions(String fieldName) {
+                    return in.getMaxDimensions(fieldName);
+                }
+            };
+        }
+
+        @Override
+        public PointsFormat pointsFormat() {
+            PointsFormat in = delegate.pointsFormat();
+            return format != Format.POINTS ? in : new PointsFormat() {
+                @Override
+                public PointsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+                    return writer(PointsWriter.class, () -> in.fieldsWriter(state));
+                }
+
+                @Override
+                public PointsReader fieldsReader(SegmentReadState state) throws IOException {
+                    return reader(() -> in.fieldsReader(state));
+                }
+            };
+        }
+
+        @Override
+        public NormsFormat normsFormat() {
+            NormsFormat in = delegate.normsFormat();
+            return format != Format.NORMS ? in : new NormsFormat() {
+                @Override
+                public NormsConsumer normsConsumer(SegmentWriteState state) throws IOException {
+                    return writer(NormsConsumer.class, () -> in.normsConsumer(state));
+                }
+
+                @Override
+                public NormsProducer normsProducer(SegmentReadState state) throws IOException {
+                    return reader(() -> in.normsProducer(state));
+                }
+            };
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesFormatSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesFormatSingleNodeTests.java
@@ -23,11 +23,13 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.codec.Elasticsearch96Codec;
+import org.elasticsearch.index.codec.MetricingCodec;
 import org.elasticsearch.index.codec.bwc.ES93TSDBDefaultCompressionLucene103Codec;
 import org.elasticsearch.index.codec.bwc.Elasticsearch93Lucene104Codec;
 import org.elasticsearch.index.codec.perfield.XPerFieldDocValuesFormat;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -40,6 +42,11 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 
 public abstract class AbstractTSDBDocValuesFormatSingleNodeTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder().put(super.nodeSettings()).put(ShardMetrics.CODEC_METRICS_ENABLED.getKey(), randomBoolean()).build();
+    }
 
     protected abstract void assertTSDBDocValuesFormat(DocValuesFormat format, String field);
 
@@ -174,7 +181,10 @@ public abstract class AbstractTSDBDocValuesFormatSingleNodeTests extends ESSingl
     }
 
     private DocValuesFormat getDocValuesFormatForField(final IndexShard shard, final String field) {
-        final Codec codec = shard.withEngineOrNull(engine -> engine.config().getCodec());
+        Codec codec = shard.withEngineOrNull(engine -> engine.config().getCodec());
+        if (codec instanceof MetricingCodec metricingCodec) {
+            codec = metricingCodec.delegate();
+        }
 
         if (codec instanceof Elasticsearch93Lucene104Codec es93104codec) {
             return es93104codec.getDocValuesFormatForField(field);

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -44,7 +44,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -172,7 +171,7 @@ public class RefreshListenersTests extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(EngineTestCase.createMapperService())
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
         engine = new InternalEngine(config);

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardMetricsTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.CodecMetrics;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.test.ESTestCase;
+
+public class ShardMetricsTests extends ESTestCase {
+
+    public void testCodecMetricsAreNoopUnlessEnabled() {
+        ShardMetrics defaults = ShardMetrics.create(new RecordingMeterRegistry(), Settings.EMPTY);
+        assertSame(CodecMetrics.NOOP, defaults.codec());
+
+        boolean enabled = randomBoolean();
+        Settings settings = Settings.builder().put(ShardMetrics.CODEC_METRICS_ENABLED.getKey(), enabled).build();
+        ShardMetrics metrics = ShardMetrics.create(new RecordingMeterRegistry(), settings);
+        assertEquals(enabled, metrics.codec() != CodecMetrics.NOOP);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.cache.request.ShardRequestCache;
+import org.elasticsearch.index.codec.CodecMetrics;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -536,7 +537,8 @@ public class IndicesRequestCacheTests extends ESTestCase {
         DirectoryReader reader = ElasticsearchDirectoryReader.wrap(
             DirectoryReader.open(writer),
             new ShardId("foo", "bar", 1),
-            customCacheHelper
+            customCacheHelper,
+            CodecMetrics.NOOP
         );
         TermQueryBuilder termQuery = new TermQueryBuilder("id", "0");
         BytesReference termBytes = XContentHelper.toXContent(termQuery, XContentType.JSON, false);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -109,12 +109,12 @@ import org.elasticsearch.index.IndexSettingProvider;
 import org.elasticsearch.index.IndexSettingProviders;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.seqno.GlobalCheckpointSyncAction;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
 import org.elasticsearch.index.shard.PrimaryReplicaSyncer;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
@@ -694,7 +694,7 @@ public class SnapshotResiliencyTestHelper {
                     .client(client)
                     .metaStateService(new MetaStateService(nodeEnv, namedXContentRegistry))
                     .mapperMetrics(MapperMetrics.NOOP)
-                    .mergeMetrics(MergeMetrics.NOOP)
+                    .shardMetrics(ShardMetrics.NOOP)
                     .throttlingRecoveryService(throttlingRecoveryService)
                     .build();
 

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -105,6 +105,7 @@ import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.SearcherHelper;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
@@ -177,7 +178,7 @@ public abstract class EngineTestCase extends ESTestCase {
 
     protected InternalEngine engine;
     protected InternalEngine replicaEngine;
-    protected MergeMetrics mergeMetrics;
+    protected ShardMetrics shardMetrics;
 
     protected IndexSettings defaultSettings;
     protected String codecName;
@@ -262,7 +263,7 @@ public abstract class EngineTestCase extends ESTestCase {
         }
         mapperService = createMapperService(defaultSettings.getSettings(), defaultMapping, extraMappers());
         translogHandler = createTranslogHandler(mapperService);
-        mergeMetrics = MergeMetrics.NOOP;
+        shardMetrics = ShardMetrics.NOOP;
         engine = createEngine(defaultSettings, store, primaryTranslogDir, newMergePolicy());
         LiveIndexWriterConfig currentIndexWriterConfig = engine.getCurrentIndexWriterConfig();
 
@@ -892,7 +893,7 @@ public abstract class EngineTestCase extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(mapperService)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(mergeMetrics)
+            .shardMetrics(shardMetrics)
             .indexDeletionPolicyWrapper(indexDeletionPolicyWrapper == null ? Function.identity() : indexDeletionPolicyWrapper)
             .build();
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -57,7 +57,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.mapper.MapperMetrics;
@@ -741,7 +740,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 MapperMetrics.NOOP,
                 new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
                 new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-                MergeMetrics.NOOP
+                ShardMetrics.NOOP
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             success = true;

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.engine.TranslogHandler;
@@ -51,6 +50,7 @@ import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
@@ -292,7 +292,7 @@ public class FollowingEngineTests extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(mapperService)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -49,10 +49,10 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.search.stats.SearchStatsSettings;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.StoreMetrics;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -530,7 +530,7 @@ public class SecurityTests extends ESTestCase {
             List.of(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
         security.onIndexModule(indexModule);

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -1823,7 +1823,7 @@ public class StatelessPlugin extends Plugin
             refreshManagerService.get(),
             reshardIndexService.get(),
             documentParsingProvider.get(),
-            new IndexEngine.EngineMetrics(translogReplicatorMetrics.get(), newConfig.getMergeMetrics(), hollowShardMetrics.get()),
+            new IndexEngine.EngineMetrics(translogReplicatorMetrics.get(), newConfig.getShardMetrics().merge(), hollowShardMetrics.get()),
             indexEngineDynamicSettings.get()
         );
     }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
@@ -195,7 +195,9 @@ public class SearchEngine extends Engine {
             this.searchDirectory = SearchDirectory.unwrapDirectory(store.directory());
             directoryReader = ElasticsearchDirectoryReader.wrap(
                 new SoftDeletesDirectoryReaderWrapper(DirectoryReader.open(directory, config.getLeafSorter()), Lucene.SOFT_DELETES_FIELD),
-                shardId
+                shardId,
+                null,
+                config.getShardMetrics().codec()
             );
             IndexCommit initialCommit = directoryReader.getIndexCommit();
             OptionalLong primaryTerm = searchDirectory.getPrimaryTerm(initialCommit.getSegmentsFileName());

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
@@ -59,6 +59,7 @@ import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
 import org.elasticsearch.index.translog.Translog;
@@ -462,7 +463,7 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(mapperService)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }
@@ -648,7 +649,7 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             })
             .primaryTermSupplier(primaryTermSupplier)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(
@@ -773,7 +774,7 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             })
             .primaryTermSupplier(directory.getCurrentCommit()::primaryTerm)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
@@ -14,10 +14,10 @@ import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.search.stats.SearchStatsSettings;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.StoreMetrics;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -80,7 +80,7 @@ public class WatcherPluginTests extends ESTestCase {
             List.of(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
         // this will trip an assertion if the watcher indexing operation listener is null (which it is) but we try to add it


### PR DESCRIPTION
This change is one of several that introduces new metrics to provide better dashboarding and monitoring capabilities for storage engine.

This change introduces a new failure metric for the codec read and write paths. Namely, we introduce `es.codec.failure.total` with the following attributes:
- es_codec_format, a concrete format class simple name, ex. `S819TSDBDocValuesFormat`, `Lucene104PostingsFormat`. Falls back to one of six family labels (postings, doc_values, stored_fields, knn_vectors, points, norms) when no field is at hand or the class is anonymous. According to Claude, there are 26-34 possible codecs, although the true number depends heavily on whats currently in use and when the index was created.
- error_type (exception class name). This is technically unbounded, but arguably limited by the number of unique exceptions thrown for codec failure. Claude counted 19.

In the worst case, we're looking at ~34 * 19 = 646 unique metrics.

The counter is off by default behind the static node setting `indices.codec.metrics.enabled`.  This should help us determine whether there is any overhead from these metrics.

Note, the read and write path instrumentation is different. This is because on the write path we use the codec instance from the config, which can be wrapped easily to intercept every write operation, meanwhile on the read path, Lucene resolves the codec name from the segment itself. Because that must be the immediate codec, we can't easily store info on the metricing codec in the segment.

So, on the write side, `CodecService` wraps each codec in `MetricingCodec`, a `FilterCodec` whose format writers record write, merge, and open for segments the same `IndexWriter` reopens for NRT readers and merge sources. 

Meanwhile, on the read side, we call `ElasticsearchDirectoryReader.wrap` to wrap the given directory reader in a `ElasticsearchLeafReader`, which counts failures thrown by the per-field accessor methods.