### PR TITLE
Make DiskHealthIndicatorServiceTests MP Aware

### DIFF
--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -15,10 +15,10 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
@@ -26,7 +26,6 @@ import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.ImpactArea;
-import org.elasticsearch.index.Index;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,9 +45,9 @@ import static org.elasticsearch.cluster.node.DiscoveryNode.DISCOVERY_NODE_COMPAR
 import static org.elasticsearch.common.util.CollectionUtils.limitSize;
 import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.are;
 import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.getSortedUniqueValuesString;
-import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.getTruncatedIndices;
+import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.getTruncatedProjectIndices;
 import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.indices;
-import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.indicesComparatorByPriorityAndName;
+import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.indicesComparatorByPriorityAndProjectIndex;
 import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.regularNoun;
 import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.regularVerb;
 import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.these;
@@ -74,9 +73,11 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
     private static final String IMPACT_CLUSTER_FUNCTIONALITY_UNAVAILABLE_ID = "cluster_functionality_unavailable";
 
     private final ClusterService clusterService;
+    private final ProjectResolver projectResolver;
 
-    public DiskHealthIndicatorService(ClusterService clusterService) {
+    public DiskHealthIndicatorService(ClusterService clusterService, ProjectResolver projectResolver) {
         this.clusterService = clusterService;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -104,7 +105,11 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
         }
         logNodesMissingHealthInfo(diskHealthInfoMap, clusterState);
 
-        DiskHealthAnalyzer diskHealthAnalyzer = new DiskHealthAnalyzer(diskHealthInfoMap, clusterState);
+        DiskHealthAnalyzer diskHealthAnalyzer = new DiskHealthAnalyzer(
+            diskHealthInfoMap,
+            clusterState,
+            projectResolver.supportsMultipleProjects()
+        );
         return createIndicator(
             diskHealthAnalyzer.getHealthStatus(),
             diskHealthAnalyzer.getSymptom(),
@@ -145,20 +150,21 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
         public static final String NODES_WITH_UNKNOWN_DISK_STATUS = "nodes_with_unknown_disk_status";
 
         private final ClusterState clusterState;
-        private final Set<String> blockedIndices;
+        private final boolean supportsMultipleProjects;
+        private final Set<ProjectIndexName> blockedIndices;
         private final List<DiscoveryNode> dataNodes = new ArrayList<>();
         // In this context a master node, is a master node that cannot contain data.
         private final Map<HealthStatus, List<DiscoveryNode>> masterNodes = new EnumMap<>(HealthStatus.class);
         // In this context "other" nodes are nodes that cannot contain data and are not masters.
         private final Map<HealthStatus, List<DiscoveryNode>> otherNodes = new EnumMap<>(HealthStatus.class);
         private final Set<DiscoveryNodeRole> affectedRoles = new HashSet<>();
-        private final Set<String> indicesAtRisk;
+        private final Set<ProjectIndexName> indicesAtRisk;
         private final HealthStatus healthStatus;
         private final Map<HealthStatus, Integer> healthStatusNodeCount;
 
-        @FixForMultiProject(description = "blockedIndices and indicesAtRisk should work correctly for indices across projects")
-        DiskHealthAnalyzer(Map<String, DiskHealthInfo> diskHealthByNode, ClusterState clusterState) {
+        DiskHealthAnalyzer(Map<String, DiskHealthInfo> diskHealthByNode, ClusterState clusterState, boolean supportsMultipleProjects) {
             this.clusterState = clusterState;
+            this.supportsMultipleProjects = supportsMultipleProjects;
             blockedIndices = clusterState.metadata()
                 .projects()
                 .keySet()
@@ -169,7 +175,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
                         .entrySet()
                         .stream()
                         .filter(entry -> entry.getValue().contains(IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK))
-                        .map(Map.Entry::getKey)
+                        .map(entry -> new ProjectIndexName(projectId, entry.getKey()))
                 )
                 .collect(Collectors.toSet());
             HealthStatus mostSevereStatusSoFar = blockedIndices.isEmpty() ? HealthStatus.GREEN : HealthStatus.RED;
@@ -282,7 +288,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
                         String.format(
                             Locale.ROOT,
                             "Cannot insert or update documents in the affected indices [%s].",
-                            getTruncatedIndices(blockedIndices, clusterState.getMetadata())
+                            getTruncatedProjectIndices(blockedIndices, clusterState.metadata(), supportsMultipleProjects)
                         ),
                         List.of(ImpactArea.INGEST)
                     )
@@ -297,7 +303,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
                             String.format(
                                 Locale.ROOT,
                                 "The cluster is at risk of not being able to insert or update documents in the affected indices [%s].",
-                                getTruncatedIndices(indicesAtRisk, clusterState.metadata())
+                                getTruncatedProjectIndices(indicesAtRisk, clusterState.metadata(), supportsMultipleProjects)
                             ),
                             List.of(ImpactArea.INGEST)
                         )
@@ -360,7 +366,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             }
             List<Diagnosis> diagnosisList = new ArrayList<>();
             if (hasBlockedIndices() || hasUnhealthyDataNodes()) {
-                Set<String> affectedIndices = Sets.union(blockedIndices, indicesAtRisk);
+                Set<ProjectIndexName> affectedIndices = Sets.union(blockedIndices, indicesAtRisk);
                 List<Diagnosis.Resource> affectedResources = new ArrayList<>();
                 if (dataNodes.size() > 0) {
                     Diagnosis.Resource nodeResources = new Diagnosis.Resource(limitSize(dataNodes, size));
@@ -370,7 +376,8 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
                     Diagnosis.Resource indexResources = new Diagnosis.Resource(
                         Diagnosis.Resource.Type.INDEX,
                         affectedIndices.stream()
-                            .sorted(indicesComparatorByPriorityAndName(clusterState.metadata()))
+                            .sorted(indicesComparatorByPriorityAndProjectIndex(clusterState.metadata(), supportsMultipleProjects))
+                            .map(projectIndex -> projectIndex.toString(supportsMultipleProjects))
                             .limit(Math.min(affectedIndices.size(), size))
                             .collect(Collectors.toList())
                     );
@@ -451,13 +458,18 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
         }
 
         // Non-private for unit testing
-        static Set<String> getIndicesForNodes(List<DiscoveryNode> nodes, ClusterState clusterState) {
+        static Set<ProjectIndexName> getIndicesForNodes(List<DiscoveryNode> nodes, ClusterState clusterState) {
             RoutingNodes routingNodes = clusterState.getRoutingNodes();
             return nodes.stream()
                 .map(node -> routingNodes.node(node.getId()))
                 .filter(Objects::nonNull)
                 .flatMap(routingNode -> Arrays.stream(routingNode.copyIndices()))
-                .map(Index::getName)
+                .flatMap(
+                    index -> clusterState.metadata()
+                        .lookupProject(index)
+                        .map(project -> new ProjectIndexName(project.id(), index.getName()))
+                        .stream()
+                )
                 .collect(Collectors.toSet());
         }
 

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1411,7 +1411,8 @@ class NodeConstruction {
                 threadPool,
                 telemetryProvider,
                 repositoriesService,
-                fileSettingsHealthTracker
+                fileSettingsHealthTracker,
+                projectResolver
             )
         );
 
@@ -1630,7 +1631,8 @@ class NodeConstruction {
         ThreadPool threadPool,
         TelemetryProvider telemetryProvider,
         RepositoriesService repositoriesService,
-        FileSettingsHealthTracker fileSettingsHealthTracker
+        FileSettingsHealthTracker fileSettingsHealthTracker,
+        ProjectResolver projectResolver
     ) {
 
         MasterHistoryService masterHistoryService = new MasterHistoryService(transportService, threadPool, clusterService);
@@ -1644,7 +1646,7 @@ class NodeConstruction {
         var serverHealthIndicatorServices = Stream.of(
             new StableMasterHealthIndicatorService(coordinationDiagnosticsService, clusterService),
             new RepositoryIntegrityHealthIndicatorService(clusterService),
-            new DiskHealthIndicatorService(clusterService),
+            new DiskHealthIndicatorService(clusterService, projectResolver),
             new ShardsCapacityHealthIndicatorService(clusterService),
             new FileSettingsHealthIndicatorService()
         );

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -1088,9 +1088,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         if (multiProject == false) {
             return List.copyOf(indexNames);
         }
-        return indexNames.stream()
-            .flatMap(indexName -> projectIds.stream().map(id -> id.id() + "/" + indexName).sorted())
-            .toList();
+        return indexNames.stream().flatMap(indexName -> projectIds.stream().map(id -> id.id() + "/" + indexName).sorted()).toList();
     }
 
     private Set<ProjectIndexName> toProjectIndices(Set<String> indexNames) {

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -115,7 +116,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testServiceBasics() {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         {
             HealthStatus expectedStatus = HealthStatus.UNKNOWN;
             HealthInfo healthInfo = HealthInfo.EMPTY_HEALTH_INFO;
@@ -139,7 +140,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testIndicatorYieldsGreenWhenNodeHasUnknownStatus() {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
 
         HealthStatus expectedStatus = HealthStatus.GREEN;
         HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(HealthStatus.UNKNOWN, discoveryNodes);
@@ -150,7 +151,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testGreen() throws IOException {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthStatus expectedStatus = HealthStatus.GREEN;
         HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(expectedStatus, discoveryNodes);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
@@ -185,7 +186,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         final var clusterService = createClusterService(Set.of(), allNodes, indexNameToNodeIdsMap);
         HealthStatus expectedStatus = HealthStatus.YELLOW;
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(expectedStatus, allNodes.size(), allNodes));
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
         assertThat(result.status(), equalTo(expectedStatus));
         assertThat(result.symptom(), containsString("with roles: [data"));
@@ -263,7 +264,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             indexNameToNodeIdsMap.put(indexName, new HashSet<>(randomNonEmptySubsetOf(affectedNodeIds)));
         }
         ClusterService clusterService = createClusterService(Set.of(), discoveryNodes, indexNameToNodeIdsMap);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         Map<String, DiskHealthInfo> diskInfoByNode = new HashMap<>();
         for (DiscoveryNode discoveryNode : discoveryNodes) {
             if (affectedNodeIds.contains(discoveryNode.getId())) {
@@ -332,7 +333,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testRedWithBlockedIndicesAndGreenNodes() throws IOException {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
 
         HealthStatus expectedStatus = HealthStatus.RED;
         HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(HealthStatus.GREEN, discoveryNodes);
@@ -377,7 +378,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testRedWithBlockedIndicesAndYellowNodes() throws IOException {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthStatus expectedStatus = HealthStatus.RED;
         int numberOfYellowNodes = randomIntBetween(1, discoveryNodes.size());
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(HealthStatus.YELLOW, numberOfYellowNodes, discoveryNodes));
@@ -456,7 +457,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             }
         }
         ClusterService clusterService = createClusterService(blockedIndices, discoveryNodes, indexNameToNodeIdsMap);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
         assertThat(result.status(), equalTo(expectedStatus));
         assertThat(
@@ -495,7 +496,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             indexNameToNodeIdsMap.put(indexName, nonRedNodeIds);
         }
         ClusterService clusterService = createClusterService(Set.of(), discoveryNodes, indexNameToNodeIdsMap);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
         assertThat(result.status(), equalTo(expectedStatus));
         assertThat(result.impacts().size(), equalTo(3));
@@ -531,7 +532,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNode> discoveryNodesInClusterState = new HashSet<>(discoveryNodes);
         discoveryNodesInClusterState.add(DiscoveryNodeUtils.create(randomAlphaOfLength(30), UUID.randomUUID().toString()));
         ClusterService clusterService = createClusterService(discoveryNodesInClusterState, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         {
             HealthInfo healthInfo = HealthInfo.EMPTY_HEALTH_INFO;
             HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
@@ -563,7 +564,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNodeRole> roles = Set.of(DiscoveryNodeRole.MASTER_ROLE, otherRole);
         Set<DiscoveryNode> discoveryNodes = createNodes(roles);
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthStatus expectedStatus = randomFrom(HealthStatus.RED, HealthStatus.YELLOW);
         int numberOfProblemNodes = randomIntBetween(1, discoveryNodes.size());
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(expectedStatus, numberOfProblemNodes, discoveryNodes));
@@ -618,7 +619,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNodeRole> roles = new HashSet<>(randomNonEmptySubsetOf(OTHER_ROLES));
         Set<DiscoveryNode> nodes = createNodes(roles);
         ClusterService clusterService = createClusterService(nodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthStatus expectedStatus = randomFrom(HealthStatus.RED, HealthStatus.YELLOW);
         int numberOfProblemNodes = randomIntBetween(1, nodes.size());
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(expectedStatus, numberOfProblemNodes, nodes));
@@ -674,7 +675,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNode> masterNodes = createNodes(masterRole);
         Set<DiscoveryNode> otherNodes = createNodes(otherRoles);
         ClusterService clusterService = createClusterService(Sets.union(Sets.union(dataNodes, masterNodes), otherNodes), true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         int numberOfRedMasterNodes = randomIntBetween(1, masterNodes.size());
         int numberOfRedOtherNodes = randomIntBetween(1, otherNodes.size());
         int numberOfYellowDataNodes = randomIntBetween(1, dataNodes.size());
@@ -805,11 +806,11 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         final var clusterService = createClusterService(Set.of(), discoveryNodes.values(), indexNameToNodeIdsMap);
         assertThat(
             DiskHealthIndicatorService.DiskHealthAnalyzer.getIndicesForNodes(redNodes, clusterService.state()),
-            equalTo(redNodeIndices)
+            equalTo(toProjectIndices(redNodeIndices))
         );
         assertThat(
             DiskHealthIndicatorService.DiskHealthAnalyzer.getIndicesForNodes(nonRedNodes, clusterService.state()),
-            equalTo(nonRedNodeIndices)
+            equalTo(toProjectIndices(nonRedNodeIndices))
         );
     }
 
@@ -896,7 +897,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNode> masterNodes = createNodes(20, masterRole);
         Set<DiscoveryNode> otherNodes = createNodes(10, otherRoles);
         ClusterService clusterService = createClusterService(Sets.union(Sets.union(dataNodes, masterNodes), otherNodes), true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         int numberOfRedMasterNodes = masterNodes.size();
         int numberOfRedOtherNodes = otherNodes.size();
         int numberOfYellowDataNodes = dataNodes.size();
@@ -971,7 +972,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testSkippingFieldsWhenVerboseIsFalse() {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthStatus expectedStatus = HealthStatus.RED;
         HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(expectedStatus, discoveryNodes);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(false, healthInfo);
@@ -1054,6 +1055,14 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             }
         }
         return new HealthInfo(diskInfoByNode, DataStreamLifecycleHealthInfo.NO_DSL_ERRORS, Map.of(), FileSettingsHealthInfo.INDETERMINATE);
+    }
+
+    private static DiskHealthIndicatorService createDiskHealthIndicatorService(ClusterService clusterService) {
+        return new DiskHealthIndicatorService(clusterService, TestProjectResolvers.DEFAULT_PROJECT_ONLY);
+    }
+
+    private static Set<ProjectIndexName> toProjectIndices(Set<String> indexNames) {
+        return indexNames.stream().map(name -> new ProjectIndexName(Metadata.DEFAULT_PROJECT_ID, name)).collect(Collectors.toSet());
     }
 
     private static ClusterService createClusterService(Collection<DiscoveryNode> nodes, boolean withBlockedIndex) {

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -14,11 +14,14 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.cluster.routing.GlobalRoutingTable;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -56,6 +59,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
@@ -106,11 +110,17 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     );
 
     private FeatureService featureService;
+    private boolean multiProject;
+    private Set<ProjectId> projectIds;
 
     @Before
-    public void initFeatureService() throws Exception {
+    public void initFeatureService() {
         featureService = Mockito.mock(FeatureService.class);
         Mockito.when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
+        multiProject = randomBoolean();
+        projectIds = multiProject
+            ? IntStream.range(0, randomIntBetween(1, 5)).mapToObj(i -> randomUniqueProjectId()).collect(Collectors.toSet())
+            : Set.of(randomProjectIdOrDefault());
     }
 
     public void testServiceBasics() {
@@ -214,7 +224,10 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
                 .collect(Collectors.toList());
             assertThat(affectedResources.get(0).getNodes(), equalTo(affectedNodes));
             assertThat(affectedResources.get(1).getType(), is(Diagnosis.Resource.Type.INDEX));
-            assertThat(affectedResources.get(1).getValues(), containsInAnyOrder(indexNameToNodeIdsMap.keySet().toArray(new String[0])));
+            assertThat(
+                affectedResources.get(1).getValues(),
+                containsInAnyOrder(indexNameList(indexNameToNodeIdsMap.keySet()).toArray(String[]::new))
+            );
         }
         {
             Diagnosis diagnosis = result.diagnosisList().get(1);
@@ -308,12 +321,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         assertThat(affectedResources.get(1).getType(), is(Diagnosis.Resource.Type.INDEX));
         assertThat(
             affectedResources.get(1).getValues(),
-            is(
-                indexNameToNodeIdsMap.keySet()
-                    .stream()
-                    .sorted(HealthIndicatorDisplayValues.indicesComparatorByPriorityAndName(clusterService.state().metadata()))
-                    .collect(Collectors.toList())
-            )
+            containsInAnyOrder(indexNameList(indexNameToNodeIdsMap.keySet()).toArray(String[]::new))
         );
 
         Map<String, Object> details = xContentToMap(result.details());
@@ -342,8 +350,10 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         assertThat(
             result.symptom(),
             equalTo(
-                "1 index is not allowed to be updated. The cluster is recovering and ingest capabilities should be restored within a "
-                    + "few minutes."
+                (projectIds.size() == 1
+                    ? "1 index is not allowed to be updated."
+                    : projectIds.size() + " indices are not allowed to be updated.")
+                    + " The cluster is recovering and ingest capabilities should be restored within a few minutes."
             )
         );
         assertThat(result.impacts().size(), equalTo(1));
@@ -359,14 +369,14 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         List<Diagnosis.Resource> affectedResources = diagnosis.affectedResources();
         assertThat(affectedResources.size(), is(1));
         assertThat(affectedResources.get(0).getType(), is(Diagnosis.Resource.Type.INDEX));
-        assertThat(affectedResources.get(0).getValues(), iterableWithSize(1));
+        assertThat(affectedResources.get(0).getValues(), iterableWithSize(projectIds.size()));
 
         Map<String, Object> details = xContentToMap(result.details());
         assertThat(details.get(NODES_WITH_ENOUGH_DISK_SPACE), equalTo(discoveryNodes.size()));
         assertThat(details.get(NODES_WITH_UNKNOWN_DISK_STATUS), equalTo(0));
         assertThat(details.get(NODES_OVER_HIGH_WATERMARK), equalTo(0));
         assertThat(details.get(NODES_OVER_FLOOD_STAGE_WATERMARK), equalTo(0));
-        assertThat(details.get(INDICES_WITH_READONLY_BLOCK), equalTo(1));
+        assertThat(details.get(INDICES_WITH_READONLY_BLOCK), equalTo(projectIds.size()));
     }
 
     /*
@@ -387,7 +397,9 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         assertThat(
             result.symptom(),
             equalTo(
-                "1 index is not allowed to be updated. "
+                (projectIds.size() == 1
+                    ? "1 index is not allowed to be updated. "
+                    : projectIds.size() + " indices are not allowed to be updated. ")
                     + (numberOfYellowNodes == 1 ? "1 node is" : numberOfYellowNodes + " nodes are")
                     + " out of disk or running low on disk space."
             )
@@ -407,13 +419,13 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         assertThat(affectedResources.get(0).getType(), is(Diagnosis.Resource.Type.NODE));
         assertThat(affectedResources.get(0).getNodes().size(), is(numberOfYellowNodes));
         assertThat(affectedResources.get(1).getType(), is(Diagnosis.Resource.Type.INDEX));
-        assertThat(affectedResources.get(1).getValues(), iterableWithSize(1));
+        assertThat(affectedResources.get(1).getValues(), iterableWithSize(projectIds.size()));
         Map<String, Object> details = xContentToMap(result.details());
         assertThat(details.get(NODES_WITH_ENOUGH_DISK_SPACE), equalTo(discoveryNodes.size() - numberOfYellowNodes));
         assertThat(details.get(NODES_WITH_UNKNOWN_DISK_STATUS), equalTo(0));
         assertThat(details.get(NODES_OVER_HIGH_WATERMARK), equalTo(numberOfYellowNodes));
         assertThat(details.get(NODES_OVER_FLOOD_STAGE_WATERMARK), equalTo(0));
-        assertThat(details.get(INDICES_WITH_READONLY_BLOCK), equalTo(1));
+        assertThat(details.get(INDICES_WITH_READONLY_BLOCK), equalTo(projectIds.size()));
     }
 
     /*
@@ -460,11 +472,13 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         DiskHealthIndicatorService diskHealthIndicatorService = createDiskHealthIndicatorService(clusterService);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
         assertThat(result.status(), equalTo(expectedStatus));
+        int blockedIndexCount = numberOfBlockedIndices * projectIds.size();
         assertThat(
             result.symptom(),
             equalTo(
-                (numberOfBlockedIndices == 1 ? "1 index is" : numberOfBlockedIndices + " indices are")
-                    + " not allowed to be updated. "
+                (blockedIndexCount == 1
+                    ? "1 index is not allowed to be updated. "
+                    : blockedIndexCount + " indices are not allowed to be updated. ")
                     + (numberOfRedNodes == 1 ? "1 node is" : numberOfRedNodes + " nodes are")
                     + " out of disk or running low on disk space."
             )
@@ -474,7 +488,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         assertThat(details.get(NODES_WITH_UNKNOWN_DISK_STATUS), equalTo(0));
         assertThat(details.get(NODES_OVER_HIGH_WATERMARK), equalTo(0));
         assertThat(details.get(NODES_OVER_FLOOD_STAGE_WATERMARK), equalTo(numberOfRedNodes));
-        assertThat(details.get(INDICES_WITH_READONLY_BLOCK), equalTo(blockedIndices.size()));
+        assertThat(details.get(INDICES_WITH_READONLY_BLOCK), equalTo(blockedIndices.size() * projectIds.size()));
     }
 
     public void testRedNodesWithoutAnyBlockedIndices() throws IOException {
@@ -691,7 +705,9 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         assertThat(
             result.symptom(),
             equalTo(
-                "1 index is not allowed to be updated. "
+                (projectIds.size() == 1
+                    ? "1 index is not allowed to be updated. "
+                    : projectIds.size() + " indices are not allowed to be updated. ")
                     + (numberOfYellowDataNodes + (numberOfYellowDataNodes == 1 ? " node is" : " nodes are"))
                     + " out of disk or running low on disk space. "
                     + (numberOfRedMasterNodes + numberOfRedOtherNodes)
@@ -724,13 +740,17 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             assertThat(dataAffectedResources.get(0).getType(), is(Diagnosis.Resource.Type.NODE));
             assertThat(dataAffectedResources.get(0).getNodes().size(), is(numberOfYellowDataNodes));
             assertThat(dataAffectedResources.get(1).getType(), is(Diagnosis.Resource.Type.INDEX));
-            assertThat(dataAffectedResources.get(1).getValues().size(), is(1));
+            assertThat(dataAffectedResources.get(1).getValues().size(), is(projectIds.size()));
             Diagnosis.Definition dataDiagnosisDefinition = diagnosis.definition();
             assertThat(
                 dataDiagnosisDefinition.cause(),
                 equalTo(
-                    "1 index resides on nodes that have run or are likely to run out of disk space, "
-                        + "this can temporarily disable writing on this index."
+                    projectIds.size() == 1
+                        ? "1 index resides on nodes that have run or are likely to run out of disk space, "
+                            + "this can temporarily disable writing on this index."
+                        : projectIds.size()
+                            + " indices reside on nodes that have run or are likely to run out of disk space, "
+                            + "this can temporarily disable writing on these indices."
                 )
             );
             assertThat(
@@ -949,7 +969,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
                 assertThat(dataAffectedResources.get(0).getType(), is(Diagnosis.Resource.Type.NODE));
                 assertThat(dataAffectedResources.get(0).getNodes().size(), is(10));
                 assertThat(dataAffectedResources.get(1).getType(), is(Diagnosis.Resource.Type.INDEX));
-                assertThat(dataAffectedResources.get(1).getValues().size(), is(1));
+                assertThat(dataAffectedResources.get(1).getValues().size(), is(projectIds.size()));
             }
             {
                 Diagnosis diagnosis = diagnosisList.get(1);
@@ -1057,15 +1077,29 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         return new HealthInfo(diskInfoByNode, DataStreamLifecycleHealthInfo.NO_DSL_ERRORS, Map.of(), FileSettingsHealthInfo.INDETERMINATE);
     }
 
-    private static DiskHealthIndicatorService createDiskHealthIndicatorService(ClusterService clusterService) {
-        return new DiskHealthIndicatorService(clusterService, TestProjectResolvers.DEFAULT_PROJECT_ONLY);
+    private DiskHealthIndicatorService createDiskHealthIndicatorService(ClusterService clusterService) {
+        return new DiskHealthIndicatorService(
+            clusterService,
+            multiProject ? TestProjectResolvers.allProjects() : TestProjectResolvers.singleProjectOnly(projectIds.iterator().next())
+        );
     }
 
-    private static Set<ProjectIndexName> toProjectIndices(Set<String> indexNames) {
-        return indexNames.stream().map(name -> new ProjectIndexName(Metadata.DEFAULT_PROJECT_ID, name)).collect(Collectors.toSet());
+    private List<String> indexNameList(Collection<String> indexNames) {
+        if (multiProject == false) {
+            return List.copyOf(indexNames);
+        }
+        return indexNames.stream()
+            .flatMap(indexName -> projectIds.stream().map(id -> id.id() + "/" + indexName).sorted())
+            .toList();
     }
 
-    private static ClusterService createClusterService(Collection<DiscoveryNode> nodes, boolean withBlockedIndex) {
+    private Set<ProjectIndexName> toProjectIndices(Set<String> indexNames) {
+        return projectIds.stream()
+            .flatMap(projectId -> indexNames.stream().map(name -> new ProjectIndexName(projectId, name)))
+            .collect(Collectors.toSet());
+    }
+
+    private ClusterService createClusterService(Collection<DiscoveryNode> nodes, boolean withBlockedIndex) {
         int numberOfIndices = 1;
         int numberOfBlockedIndices = withBlockedIndex ? 1 : 0;
         Map<String, Set<String>> indexNameToNodeIdsMap = new HashMap<>();
@@ -1080,7 +1114,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         return createClusterService(blockedIndices, nodes, indexNameToNodeIdsMap);
     }
 
-    private static ClusterService createClusterService(
+    private ClusterService createClusterService(
         Set<String> blockedIndices,
         Collection<DiscoveryNode> nodes,
         Map<String, Set<String>> indexNameToNodeIdsMap
@@ -1091,7 +1125,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         return clusterService;
     }
 
-    static ClusterState createClusterState(
+    ClusterState createClusterState(
         Set<String> blockedIndices,
         Collection<DiscoveryNode> nodes,
         Map<String, Set<String>> indexNameToNodeIdsMap
@@ -1102,35 +1136,42 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         nodesBuilder.masterNodeId(randomFrom(nodes).getId());
         ClusterBlocks.Builder clusterBlocksBuilder = new ClusterBlocks.Builder();
         Metadata.Builder metadata = Metadata.builder();
-        RoutingTable.Builder routingTable = RoutingTable.builder();
-        for (String index : indexNameToNodeIdsMap.keySet()) {
-            int numberOfShards = indexNameToNodeIdsMap.get(index).size() == 0 ? 1 : indexNameToNodeIdsMap.get(index).size();
-            IndexMetadata indexMetadata = IndexMetadata.builder(index)
-                .settings(
-                    indexSettings(IndexVersion.current(), numberOfShards, 0).put(SETTING_CREATION_DATE, System.currentTimeMillis())
-                        .put(IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), blockedIndices.contains(index))
-                )
-                .build();
-            if (blockedIndices.contains(index)) {
-                clusterBlocksBuilder.addBlocks(indexMetadata);
-            }
+        GlobalRoutingTable.Builder globalRoutingTable = GlobalRoutingTable.builder();
+        for (ProjectId projectId : projectIds) {
+            ProjectMetadata.Builder projectMetadata = ProjectMetadata.builder(projectId);
+            RoutingTable.Builder routingTable = RoutingTable.builder();
+            for (String index : indexNameToNodeIdsMap.keySet()) {
+                int numberOfShards = indexNameToNodeIdsMap.get(index).size() == 0 ? 1 : indexNameToNodeIdsMap.get(index).size();
+                IndexMetadata indexMetadata = IndexMetadata.builder(index)
+                    .settings(
+                        indexSettings(IndexVersion.current(), numberOfShards, 0).put(SETTING_CREATION_DATE, System.currentTimeMillis())
+                            .put(IndexMetadata.SETTING_INDEX_UUID, randomUUID())
+                            .put(IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), blockedIndices.contains(index))
+                    )
+                    .build();
+                if (blockedIndices.contains(index)) {
+                    clusterBlocksBuilder.addBlocks(projectId, indexMetadata);
+                }
 
-            IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(indexMetadata.getIndex());
-            int shardAutoincrementNumber = 0;
-            for (String nodeId : indexNameToNodeIdsMap.get(index)) {
-                ShardId shardId = new ShardId(indexMetadata.getIndex(), shardAutoincrementNumber);
-                IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
-                indexShardRoutingBuilder.addShard(TestShardRouting.newShardRouting(shardId, nodeId, true, ShardRoutingState.STARTED));
-                indexRoutingTable.addIndexShard(indexShardRoutingBuilder);
-            }
+                IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(indexMetadata.getIndex());
+                int shardAutoincrementNumber = 0;
+                for (String nodeId : indexNameToNodeIdsMap.get(index)) {
+                    ShardId shardId = new ShardId(indexMetadata.getIndex(), shardAutoincrementNumber);
+                    IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
+                    indexShardRoutingBuilder.addShard(TestShardRouting.newShardRouting(shardId, nodeId, true, ShardRoutingState.STARTED));
+                    indexRoutingTable.addIndexShard(indexShardRoutingBuilder);
+                }
 
-            metadata.put(indexMetadata, false);
-            routingTable.add(indexRoutingTable);
+                projectMetadata.put(indexMetadata, false);
+                routingTable.add(indexRoutingTable);
+            }
+            metadata.put(projectMetadata);
+            globalRoutingTable.put(projectId, routingTable.build());
         }
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(nodesBuilder);
         state.metadata(metadata.generateClusterUuidIfNeeded().build());
-        state.routingTable(routingTable.build());
+        state.routingTable(globalRoutingTable.build());
         state.blocks(clusterBlocksBuilder);
         return state.build();
     }


### PR DESCRIPTION
Extends the `DiskHealthIndicatorServiceTests` to run for both single and multi project clusters. As a note, the `disk` indicator is independent to the number of projects in the cluster since it is focussed on nodes not projects. Therefore each test itself does not need to be changed, only the metadata in the cluster state
    
Relates: https://github.com/elastic/elasticsearch-team/issues/4601