### PR TITLE
ES|QL test suite deletes generated function docs (muted tests, snapshot-only

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -757,7 +757,7 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/158462
 - class: org.elasticsearch.xpack.esql.datasources.FileSplitProviderTests
   issue: https://github.com/elastic/elasticsearch/issues/158517
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.ReverseTests
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.currently
   issue: https://github.com/elastic/elasticsearch/issues/158550
 - class: org.elasticsearch.xpack.esql.CsvFlattenedKeywordIT
   method: test {csv-spec:tdigest.count with bucket, time, and instance in FROM}


### PR DESCRIPTION
This PR fixes the documentation issue reported in #158577: corrects `ReverseTests` to `currently` in `muted-tests.yml`.

Fixes #158577

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.

Fixes #158577