### PR TITLE
ESQL: cap DOC slices for tiny multi-seg indices

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -534,9 +534,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointAggregatorTests
   method: testDistributionChange
   issue: https://github.com/elastic/elasticsearch/issues/156294
-- class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
-  method: testAutoPartitioning {SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/156243
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecBucketIncludeEmptyBucketsIT
   method: test {csv-spec:bucket_include_empty_buckets.Large number of buckets doesn't OOM - stats}
   issue: https://github.com/elastic/elasticsearch/issues/156356

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSliceQueue.java
@@ -461,13 +461,16 @@ public final class LuceneSliceQueue {
          * <p>Aims for {@code taskConcurrency} slices: {@code desiredSliceSize} =
          * {@code clamp(totalDocs / taskConcurrency, minDocsPerSlice, MAX_DOCS_PER_SLICE)}. {@code minDocsPerSlice}
          * defaults to {@link #MIN_DOCS_PER_SLICE} but may be lowered per query (via the {@code min_docs_per_slice}
-         * pragma) so small-index tests can still exercise multi-slice partitioning. {@code maxSegmentsPerSlice}
-         * scales with {@code totalSegments / taskConcurrency} (with a {@link #MAX_SEGMENTS_PER_SLICE} floor) so
-         * that a heavily fragmented index doesn't force a slice count well above the chosen parallelism.
+         * pragma) so small-index tests can still exercise multi-slice partitioning. The slice target is also capped
+         * at {@code totalDocs / minDocsPerSlice} so a multi-segment index whose total doc count is below the floor
+         * collapses to a single slice — otherwise {@link #balancedBinPack} would open one bin per segment.
+         * {@code maxSegmentsPerSlice} scales with {@code totalSegments / sliceTarget} (with a
+         * {@link #MAX_SEGMENTS_PER_SLICE} floor) so that a heavily fragmented index doesn't force a slice count well
+         * above the chosen parallelism.
          *
          * <p>When the largest unguarded segment is within ~1.5× of {@code desiredSliceSize}, every
-         * non-guarded leaf can be kept whole; we then balance leaves across {@code taskConcurrency}
-         * slices via worst-fit-decreasing bin packing (preserving segment boundaries) instead of
+         * non-guarded leaf can be kept whole; we then balance leaves across the capped slice target
+         * via worst-fit-decreasing bin packing (preserving segment boundaries) instead of
          * splitting segments through {@link AdaptivePartitioner}.
          *
          * <p>If the supplied {@link LeafSplitGuard} marks a leaf as "keep whole" for the supplied
@@ -494,6 +497,11 @@ public final class LuceneSliceQueue {
                     MAX_DOCS_PER_SLICE,
                     Math.max(minDocsPerSlice, Math.ceilDiv(totalDocCount, taskConcurrency))
                 );
+                // Cap parallelism so each slice still carries ~minDocsPerSlice docs. Without this,
+                // balancedBinPack would open one bin per segment (up to taskConcurrency) even when
+                // totalDocs ≪ minDocsPerSlice — over-splitting tiny multi-segment indices.
+                int maxSlicesByDocs = Math.max(1, totalDocCount / Math.max(1, minDocsPerSlice));
+                int sliceTarget = Math.min(taskConcurrency, maxSlicesByDocs);
                 Set<LeafReaderContext> keepWhole = wholeLeaves(leaves, weight, guard);
                 int largestUnguarded = 0;
                 for (LeafReaderContext leaf : leaves) {
@@ -502,9 +510,9 @@ public final class LuceneSliceQueue {
                     }
                 }
                 if (2L * largestUnguarded <= 3L * desiredSliceSize) {
-                    return balancedBinPack(leaves, keepWhole, taskConcurrency);
+                    return balancedBinPack(leaves, keepWhole, sliceTarget);
                 }
-                int maxSegmentsPerSlice = Math.max(MAX_SEGMENTS_PER_SLICE, Math.ceilDiv(leaves.size(), taskConcurrency));
+                int maxSegmentsPerSlice = Math.max(MAX_SEGMENTS_PER_SLICE, Math.ceilDiv(leaves.size(), sliceTarget));
                 return new AdaptivePartitioner(desiredSliceSize, maxSegmentsPerSlice).partition(leaves, keepWhole);
             }
         },

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSliceQueueTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSliceQueueTests.java
@@ -483,6 +483,27 @@ public class LuceneSliceQueueTests extends ESTestCase {
         assertThat(overriddenSlices.size(), greaterThan(1));
     }
 
+    /**
+     * Regression for #158605 / #156243: a multi-segment index whose <em>total</em> doc count is below
+     * {@link LuceneSliceQueue#MIN_DOCS_PER_SLICE} must still collapse to a single slice. Without capping the
+     * bin-pack target by {@code totalDocs / minDocsPerSlice}, {@code balancedBinPack} would open one bin per
+     * segment (up to {@code taskConcurrency}) and over-split.
+     */
+    public void testDocPartitioningDoesNotOverSplitTinyMultiSegmentIndex() throws IOException {
+        IndexSearcher searcher = new IndexSearcher(
+            new MultiReader(new MockLeafReader(400), new MockLeafReader(300), new MockLeafReader(300))
+        );
+        var slices = LuceneSliceQueue.PartitioningStrategy.DOC.groups(
+            searcher,
+            8,
+            null,
+            LuceneSliceQueue.LeafSplitGuard.NEVER,
+            LuceneSliceQueue.MIN_DOCS_PER_SLICE
+        );
+        assertThat(slices, hasSize(1));
+        assertThat(slices.getFirst(), hasSize(3));
+    }
+
     public void testCreateSlice() throws IOException {
         try (var directory = newDirectory()) {
             try (var reader = simpleReader(directory, 1, 1)) {

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -1444,9 +1444,10 @@ public class RestEsqlIT extends RestEsqlTestCase {
                     String name = signature(o);
                     if (name.equals("LuceneSourceOperator")) {
                         // AUTO routes to DOC (docs_threshold_auto_partitioning=20 is below this
-                        // index's 1000 docs), but the DOC partitioner floors slice size at
-                        // MIN_DOCS_PER_SLICE (50_000), so this 1000-doc index must stay on a
-                        // single slice — the previous behavior over-split tiny indices.
+                        // index's 1000 docs), but the DOC partitioner caps slices at
+                        // totalDocs / MIN_DOCS_PER_SLICE (50_000), so this 1000-doc index —
+                        // even when Lucene flushed multiple segments — must stay on a single
+                        // slice rather than opening one bin per segment.
                         MapMatcher status = matchesMap().entry("total_slices", equalTo(1))
                             .entry("partitioning_strategies", matchesMap().entry("rest-esql-test:0", "DOC"))
                             .extraOk();


### PR DESCRIPTION
## Summary
- Cap DOC partitioning's slice target at `totalDocs / minDocsPerSlice` so tiny multi-segment indexes collapse to one slice instead of one bin per segment via `balancedBinPack`.
- Add a unit regression for a 3-segment, 1000-doc index and clarify the `RestEsqlIT.testAutoPartitioning` expectation.
- Unmute `RestEsqlIT.testAutoPartitioning {SYNC}` (#156243); closes the ASYNC flake (#158605).

## Test plan
- [x] `./gradlew :x-pack:plugin:esql:compute:test --tests "org.elasticsearch.compute.lucene.query.LuceneSliceQueueTests.testDocPartitioning*"`
- [x] `./gradlew :x-pack:plugin:esql:qa:server:single-node:javaRestTest --tests "org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT.testAutoPartitioning"` with the CI seed from #158605 (SYNC + ASYNC both pass)

Closes #158605
Closes #156243

Made with [Cursor](https://cursor.com)