### PR TITLE
Fall back to glob matching when a _source filter cannot be determinized

### DIFF
--- a/docs/changelog/158622.yaml
+++ b/docs/changelog/158622.yaml
@@ -1,0 +1,6 @@
+pr: 158622
+summary: Match `_source` filter patterns without an automaton when the patterns cannot be determinized
+area: ES|QL
+type: bug
+issues:
+ - 142554

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -44,6 +45,11 @@ public final class SourceFilter {
     private final String[] excludes;
     private CharacterRunAutomaton includeAut;
     private CharacterRunAutomaton excludeAut;
+    private boolean includesUncompilable;
+    private boolean excludesUncompilable;
+    private IllegalArgumentException includesCompileException;
+    private IllegalArgumentException excludesCompileException;
+    private int pathFilteredCount;
 
     /**
      * Construct a new filter based on a list of includes and excludes
@@ -81,11 +87,12 @@ public final class SourceFilter {
         if (includes.length == 0) {
             return false;
         }
-        if (includeAut == null) {
-            includeAut = XContentMapValues.compileAutomaton(includes, new CharacterRunAutomaton(Automata.makeAnyString()));
+        CharacterRunAutomaton aut = compileIncludes();
+        if (aut == null) {
+            return matchesPathOrAncestor(includes, fullPath);
         }
-        int state = step(includeAut, fullPath, 0);
-        return state != -1 && includeAut.isAccept(state);
+        int state = step(aut, fullPath, 0);
+        return state != -1 && aut.isAccept(state);
     }
 
     /**
@@ -96,28 +103,102 @@ public final class SourceFilter {
      * @return {@code true} if the path should be filtered out, {@code false} otherwise.
      */
     public boolean isPathFiltered(String fullPath, boolean isObject) {
+        pathFilteredCount++;
         final boolean included;
         if (includes.length > 0) {
-            if (includeAut == null) {
-                includeAut = XContentMapValues.compileAutomaton(includes, new CharacterRunAutomaton(Automata.makeAnyString()));
+            CharacterRunAutomaton aut = compileIncludes();
+            if (aut == null) {
+                // Object semantics ("could any pattern match a descendant?") are not needed by the
+                // vector-walk callers, which pass isObject=false. Callers that pass true keep today's
+                // behaviour, now as a 400 instead of a 500.
+                if (isObject) {
+                    throw includesCompileException;
+                }
+                included = matchesPathOrAncestor(includes, fullPath);
+            } else {
+                int state = step(aut, fullPath, 0);
+                included = state != -1 && (isObject || aut.isAccept(state));
             }
-            int state = step(includeAut, fullPath, 0);
-            included = state != -1 && (isObject || includeAut.isAccept(state));
         } else {
             included = true;
         }
 
         if (excludes.length > 0) {
-            if (excludeAut == null) {
-                excludeAut = XContentMapValues.compileAutomaton(excludes, new CharacterRunAutomaton(Automata.makeEmpty()));
-            }
-            int state = step(excludeAut, fullPath, 0);
-            if (state != -1 && excludeAut.isAccept(state)) {
-                return true;
+            CharacterRunAutomaton aut = compileExcludes();
+            if (aut == null) {
+                if (isObject) {
+                    throw excludesCompileException;
+                }
+                if (matchesPathOrAncestor(excludes, fullPath)) {
+                    return true;
+                }
+            } else {
+                int state = step(aut, fullPath, 0);
+                if (state != -1 && aut.isAccept(state)) {
+                    return true;
+                }
             }
         }
 
         return included == false;
+    }
+
+    private CharacterRunAutomaton compileIncludes() {
+        if (includeAut != null) {
+            return includeAut;
+        }
+        if (includesUncompilable) {
+            return null;
+        }
+        try {
+            includeAut = XContentMapValues.compileAutomaton(includes, new CharacterRunAutomaton(Automata.makeAnyString()));
+            return includeAut;
+        } catch (IllegalArgumentException e) {
+            includesUncompilable = true;
+            includesCompileException = e;
+            return null;
+        }
+    }
+
+    private CharacterRunAutomaton compileExcludes() {
+        if (excludeAut != null) {
+            return excludeAut;
+        }
+        if (excludesUncompilable) {
+            return null;
+        }
+        try {
+            excludeAut = XContentMapValues.compileAutomaton(excludes, new CharacterRunAutomaton(Automata.makeEmpty()));
+            return excludeAut;
+        } catch (IllegalArgumentException e) {
+            excludesUncompilable = true;
+            excludesCompileException = e;
+            return null;
+        }
+    }
+
+    /**
+     * The language accepted by the compiled automaton plus its {@code ("" | "." .*)} tail, restricted
+     * to leaf paths.
+     */
+    private static boolean matchesPathOrAncestor(String[] patterns, String fullPath) {
+        if (patterns.length == 0) {
+            return false;
+        }
+        if (Regex.simpleMatch(patterns, fullPath)) {
+            return true;
+        }
+        for (int dot = fullPath.indexOf('.'); dot >= 0; dot = fullPath.indexOf('.', dot + 1)) {
+            if (Regex.simpleMatch(patterns, fullPath.substring(0, dot))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Package-private for tests that assert the synthetic-vectors walk does not probe every mapper. */
+    int pathFilteredCount() {
+        return pathFilteredCount;
     }
 
     private static int step(CharacterRunAutomaton automaton, String key, int state) {

--- a/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterDeterminizeLimitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterDeterminizeLimitTests.java
@@ -9,19 +9,31 @@
 
 package org.elasticsearch.search.lookup;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
+import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceFieldMetrics;
+import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 
 /** Regression tests for https://github.com/elastic/elasticsearch/issues/142554. */
@@ -73,5 +85,249 @@ public class SourceFilterDeterminizeLimitTests extends MapperServiceTestCase {
         String[] patterns = patterns(200, "*group_N.field");
         expectThrows(TooComplexToDeterminizeException.class, () -> Regex.simpleMatchToAutomaton(patterns));
         new SourceFilter(patterns, null).filterMap(Source.empty(null));
+    }
+
+    /**
+     * Extra {@code *__nomatch_N__*} includes cannot be determinized, so the second filter uses glob
+     * matching; they do not match the paths under test, so results must agree with the compiled filter.
+     */
+    public void testFallbackMatchesAutomaton() {
+        String[] includes = { "title", "obj", "prefix*", "*suffix", "a*b" };
+        String[] excludes = { "obj.secret", "*private*" };
+        SourceFilter compiled = new SourceFilter(includes, excludes);
+
+        String[] uncompilableIncludes = new String[includes.length + 40];
+        System.arraycopy(includes, 0, uncompilableIncludes, 0, includes.length);
+        System.arraycopy(patterns(40, "*__nomatch_N__*"), 0, uncompilableIncludes, includes.length, 40);
+        SourceFilter fallback = new SourceFilter(uncompilableIncludes, excludes);
+
+        for (String path : List.of(
+            "title",
+            "titles",
+            "obj",
+            "obj.nested",
+            "obj.nested.deep",
+            "obj.secret",
+            "prefix_thing",
+            "thing_suffix",
+            "axxb",
+            "unrelated",
+            "obj.private_thing",
+            "a.b"
+        )) {
+            assertThat(path, fallback.isExplicitlyIncluded(path), equalTo(compiled.isExplicitlyIncluded(path)));
+            assertThat(path, fallback.isPathFiltered(path, false), equalTo(compiled.isPathFiltered(path, false)));
+        }
+    }
+
+    /**
+     * Glob-match the path and every ancestor prefix, then apply includes minus excludes. Exercises both
+     * the compiled automaton and the fallback across randomized pattern sets.
+     */
+    public void testFallbackAgreesWithBruteForceReference() {
+        boolean sawCompiled = false;
+        boolean sawFallback = false;
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            paths.add(randomDottedPath());
+        }
+        for (int iter = 0; iter < 30; iter++) {
+            boolean hard = randomBoolean() || (sawFallback == false && iter >= 15);
+            String[] includes = hard ? patterns(40, "*group_N.field*") : randomPatterns(randomIntBetween(5, 20));
+            String[] excludes = randomBoolean() ? randomPatterns(randomIntBetween(0, 5)) : new String[0];
+            SourceFilter filter = new SourceFilter(includes, excludes);
+            boolean compiled;
+            try {
+                new SourceFilter(includes, excludes).filterMap(Source.empty(null));
+                compiled = true;
+                sawCompiled = true;
+            } catch (IllegalArgumentException e) {
+                compiled = false;
+                sawFallback = true;
+            }
+            for (String path : paths) {
+                assertThat(path, filter.isPathFiltered(path, false), equalTo(referenceIsPathFiltered(includes, excludes, path)));
+                assertThat(path, filter.isExplicitlyIncluded(path), equalTo(referenceIsExplicitlyIncluded(includes, path)));
+            }
+            assertThat("iteration compiled=" + compiled, compiled || hard, equalTo(true));
+        }
+        assertTrue("compiled branch must run", sawCompiled);
+        assertTrue("fallback branch must run", sawFallback);
+    }
+
+    public void testFallbackSurvivesUndeterminizablePatterns() {
+        SourceFilter filter = new SourceFilter(patterns(40, "*group_N.field*"), null);
+        assertFalse(filter.isExplicitlyIncluded("embedding"));
+        assertTrue(filter.isExplicitlyIncluded("xxgroup_3.fieldyy"));
+        assertFalse(filter.isPathFiltered("xxgroup_3.fieldyy", false));
+        assertTrue(filter.isPathFiltered("embedding", false));
+    }
+
+    public void testWildcardsAtBothEndsAreHandledWhenMappingHasVectors() throws IOException {
+        MapperService mapperService = createMapperService(
+            Settings.builder().put(IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey(), true).build(),
+            mapping(b -> {
+                b.startObject("title").field("type", "text").endObject();
+                b.startObject("embedding")
+                    .field("type", "dense_vector")
+                    .field("dims", 3)
+                    .field("index", true)
+                    .field("similarity", "l2_norm")
+                    .endObject();
+            })
+        );
+        assertFalse(mapperService.mappingLookup().syntheticVectorFields().isEmpty());
+
+        SourceFilter filter = new SourceFilter(patterns(10, "*group_N.field*"), null);
+        loadOneDocument(mapperService, filter, b -> {
+            b.field("title", "hello");
+            b.array("embedding", 1f, 2f, 3f);
+        });
+    }
+
+    public void testEsqlStyleSourceLoaderOverFieldNamesContainingWildcards() throws IOException {
+        List<String> names = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            names.add("*metric_" + i + ".value*");
+        }
+        MapperService mapperService = createMapperService(
+            Settings.builder().put(IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey(), true).build(),
+            mapping(b -> {
+                for (String name : names) {
+                    b.startObject(name).field("type", "text").endObject();
+                }
+                b.startObject("embedding")
+                    .field("type", "dense_vector")
+                    .field("dims", 3)
+                    .field("index", true)
+                    .field("similarity", "l2_norm")
+                    .endObject();
+            })
+        );
+        Set<String> sourcePaths = new LinkedHashSet<>(names);
+        SourceFilter filter = new SourceFilter(sourcePaths.toArray(String[]::new), null);
+        Source loaded = loadOneDocument(mapperService, filter, b -> {
+            b.array("embedding", 1f, 2f, 3f);
+            for (int i = 0; i < 10; i++) {
+                b.startObject("*metric_" + i).field("value*", "v" + i).endObject();
+            }
+        });
+        assertThat(loaded.source(), notNullValue());
+    }
+
+    /**
+     * MappingLookup.syntheticVectorsLoader iterates vector fields only. A SourceFilter test double is
+     * not possible because SourceFilter is final, so this counts isPathFiltered calls on the real filter.
+     */
+    public void testSyntheticVectorsWalkDoesNotProbeEveryMapper() throws IOException {
+        MapperService mapperService = createMapperService(
+            Settings.builder()
+                .put(IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey(), true)
+                .put("index.mapping.total_fields.limit", 5000)
+                .build(),
+            mapping(b -> {
+                for (int i = 0; i < 1000; i++) {
+                    b.startObject("f" + i).field("type", "keyword").endObject();
+                }
+                b.startObject("a")
+                    .startObject("properties")
+                    .startObject("b")
+                    .startObject("properties")
+                    .startObject("c")
+                    .field("type", "dense_vector")
+                    .field("dims", 3)
+                    .field("index", true)
+                    .field("similarity", "l2_norm")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject();
+            })
+        );
+        String[] includes = new String[1000];
+        for (int i = 0; i < 1000; i++) {
+            includes[i] = "f" + i;
+        }
+        SourceFilter filter = new SourceFilter(includes, null);
+        assertThat(mapperService.mappingLookup().newSourceLoader(filter, SourceFieldMetrics.NOOP, null), notNullValue());
+        assertThat(filter.pathFilteredCount(), lessThan(10));
+    }
+
+    public void testIsPathFilteredForObjectsStillThrowsWhenUncompilable() {
+        SourceFilter filter = new SourceFilter(patterns(40, "*group_N.field*"), null);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> filter.isPathFiltered("x", true));
+        assertThat(ExceptionsHelper.status(e), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(e.getCause(), instanceOf(TooComplexToDeterminizeException.class));
+    }
+
+    private static boolean referenceIsExplicitlyIncluded(String[] includes, String path) {
+        return includes.length > 0 && matchesPathOrAncestor(includes, path);
+    }
+
+    private static boolean referenceIsPathFiltered(String[] includes, String[] excludes, String path) {
+        boolean included = includes.length == 0 || matchesPathOrAncestor(includes, path);
+        boolean excluded = excludes.length > 0 && matchesPathOrAncestor(excludes, path);
+        return excluded || included == false;
+    }
+
+    private static boolean matchesPathOrAncestor(String[] patterns, String fullPath) {
+        if (Regex.simpleMatch(patterns, fullPath)) {
+            return true;
+        }
+        for (int dot = fullPath.indexOf('.'); dot >= 0; dot = fullPath.indexOf('.', dot + 1)) {
+            if (Regex.simpleMatch(patterns, fullPath.substring(0, dot))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String[] randomPatterns(int count) {
+        String[] out = new String[count];
+        for (int i = 0; i < count; i++) {
+            int n = randomIntBetween(0, 20);
+            out[i] = switch (randomIntBetween(0, 5)) {
+                case 0 -> "group_" + n + ".field";
+                case 1 -> "group_" + n + ".field*";
+                case 2 -> "group_" + n + "*field";
+                case 3 -> "*group_" + n + ".field";
+                case 4 -> "*group_" + n + ".field*";
+                case 5 -> "obj.group_" + n + ".field";
+                default -> throw new AssertionError();
+            };
+        }
+        return out;
+    }
+
+    private String randomDottedPath() {
+        return switch (randomIntBetween(0, 4)) {
+            case 0 -> randomAlphaOfLength(5);
+            case 1 -> randomAlphaOfLength(3) + "." + randomAlphaOfLength(3);
+            case 2 -> "obj.nested.deep";
+            case 3 -> "group_" + randomIntBetween(0, 20) + ".field";
+            case 4 -> "prefix_thing";
+            default -> throw new AssertionError();
+        };
+    }
+
+    private Source loadOneDocument(
+        MapperService mapperService,
+        SourceFilter filter,
+        org.elasticsearch.core.CheckedConsumer<org.elasticsearch.xcontent.XContentBuilder, IOException> document
+    ) throws IOException {
+        ParsedDocument parsed = mapperService.documentMapper().parse(source(document));
+        Source[] loaded = new Source[1];
+        withLuceneIndex(mapperService, iw -> iw.addDocuments(parsed.docs()), reader -> {
+            SourceLoader loader = mapperService.mappingLookup().newSourceLoader(filter, SourceFieldMetrics.NOOP, null);
+            LeafReaderContext leaf = reader.leaves().get(0);
+            int[] docs = new int[] { 0 };
+            SourceLoader.Leaf sourceLeaf = loader.leaf(leaf, docs);
+            LeafStoredFieldLoader sfLoader = StoredFieldLoader.create(false, loader.requiredStoredFields()).getLoader(leaf, docs);
+            sfLoader.advanceTo(0);
+            loaded[0] = sourceLeaf.source(sfLoader, 0);
+            assertThat(loaded[0], notNullValue());
+        });
+        return loaded[0];
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
@@ -235,7 +235,10 @@ public class SourceFilterTests extends ESTestCase {
         for (int i = 0; i < complexPatterns.length; i++) {
             complexPatterns[i] = "*" + randomAlphaOfLength(10) + "*";
         }
-        expectThrows(IllegalArgumentException.class, () -> new SourceFilter(complexPatterns, null).isPathFiltered("foo", false));
-        expectThrows(IllegalArgumentException.class, () -> new SourceFilter(null, complexPatterns).isPathFiltered("foo", false));
+        // Leaf probes fall back to glob matching. Object probes and per-document map filtering still fail closed.
+        new SourceFilter(complexPatterns, null).isPathFiltered("foo", false);
+        new SourceFilter(null, complexPatterns).isPathFiltered("foo", false);
+        expectThrows(IllegalArgumentException.class, () -> new SourceFilter(complexPatterns, null).isPathFiltered("foo", true));
+        expectThrows(IllegalArgumentException.class, () -> new SourceFilter(complexPatterns, null).filterMap(Source.empty(null)));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
@@ -346,7 +346,7 @@ public class EsPhysicalOperationProvidersTests extends MapperServiceTestCase {
         assertThat("exactly 2 fields survive", result.size(), equalTo(2));
     }
 
-    public void testBuildSourceFilterWithTooComplexPatternsThrowsIllegalArgument() throws IOException {
+    public void testBuildSourceFilterWithTooComplexPatternsStillBuilds() throws IOException {
         var indexSettings = Settings.builder().put("index.mapping.exclude_source_vectors", true).build();
         var mapperService = createMapperService(indexSettings, mapping(b -> {
             b.startObject("text_field").field("type", "text").endObject();
@@ -361,10 +361,11 @@ public class EsPhysicalOperationProvidersTests extends MapperServiceTestCase {
 
         var mappingLookup = searchExecutionContext.getMappingLookup();
         var idxSettings = searchExecutionContext.getIndexSettings();
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> EsPhysicalOperationProviders.DefaultShardContext.buildSourceFilter(complexPaths, mappingLookup, idxSettings)
-        );
+        SourceFilter filter = EsPhysicalOperationProviders.DefaultShardContext.buildSourceFilter(complexPaths, mappingLookup, idxSettings);
+        assertNotNull(filter);
+        assertThat(Set.of(filter.getIncludes()), equalTo(complexPaths));
+        assertThat(List.of(filter.getExcludes()), equalTo(List.of("embedding")));
+        searchExecutionContext.newSourceLoader(filter, false);
     }
 
     private ValuesSourceReaderOperator.LoaderAndConverter temporalityLoader(EsPhysicalOperationProviders provider) {


### PR DESCRIPTION
Stack: #158621, then this PR.

## Summary

`TooComplexToDeterminizeException` from compiling `_source` include/exclude patterns was an HTTP 500 for user- or mapping-derived input. The automaton is the right tool for filtering every field of every document, but the wrong tool for probing a handful of vector-field paths, and ES|QL rebuilt that automaton on every page. Closes #142554.

This PR keeps the public `SourceFilter` API and compiles first. Only after `compileAutomaton` throws does a probe fall back to `Regex.simpleMatch` on the path and each ancestor prefix — the language of the compiled automaton plus its `("" | "." .*)` tail, restricted to leaf semantics. It does **not** implement object-descendant glob semantics: `isPathFiltered(path, true)` still throws the compile `IllegalArgumentException` (now 400). The vector-walk callers (`MappingLookup.syntheticVectorsLoader`, `ShardGetService.maybeExcludeVectorFields`) pass `false`. Callers that pass `true` (`IgnoredSourceFieldMapper`, `ObjectMapper.syntheticFieldLoader`, the inference path) keep today's failure, as a 400 instead of a 500.

`ShardGetService` is unchanged; the fallback inside `SourceFilter` covers its existing calls. `ObjectMapper.syntheticVectorsLoader` already moved to `MappingLookup` and iterates `syntheticVectorFields` only, so this PR does not prune that walk further.

### Limitation (per-document filtering)

After the loader is built, ES|QL filters each document's bytes through `SourceFilter.filterBytes`, which uses the x-content `FilterPath` / `Glob` matcher **as long as `canFilterBytes` is true** (no `*` in the excludes). If an exclude contains `*` (a vector field named with `*`), it falls back to `filterMap` → `compileAutomaton`, which can still throw. `_search` / GET `_source` with undeterminizable includes still 400 for the same reason.

### Reproduction (local `./gradlew run`, security off)

Index `t` with `exclude_source_vectors`, one `dense_vector`, and ten fields named `*m_0.v*` … `*m_9.v*`.

* `POST _query` `FROM t | KEEP \`*m_0.v*\`, … \`*m_9.v*\`` → **400** from field_caps (`The field names are too complex to process`), before `SourceFilter`. Field names that contain `*` are compiled as wildcards there; that path was already an `IllegalArgumentException`.
* `GET t/_search` with ten `*a*`…`*j*` includes → **200**. Single determinization at 50_000 lifts this set (it used to fail the 10_000 pass).
* `GET t/_search` with forty `*x*` includes → **400** `Unable to filter _source: [40] field patterns are too complex to compile into an automaton` (limitation above).

Unit tests cover the vector-walk fallback, including loading a document through `SourceLoader.leaf`.
