### PR TITLE
Test fix: BlobStoreIncrementalityIT.testForceMergeCausesFullSnapshot

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -691,9 +691,6 @@ tests:
 - class: org.elasticsearch.action.bulk.ShardBatchIndexerCanUseBatchTests
   method: testDynamicSettingUpdate
   issue: https://github.com/elastic/elasticsearch/issues/157947
-- class: org.elasticsearch.snapshots.BlobStoreIncrementalityIT
-  method: testForceMergeCausesFullSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/157970
 - class: org.elasticsearch.xpack.esql.evaluator.command.TestCompoundOutputEvaluatorTests
   method: testSimpleCircuitBreaking
   issue: https://github.com/elastic/elasticsearch/issues/154059

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -152,6 +152,12 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
                 // retention leases protect recent deletes from being merged away; sync them
                 // frequently so the merges below can reclaim the deletes promptly
                 .put(IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING.getKey(), "100ms")
+                // Retention releases the two tombstones one sequence number at a time, so an expunge merge can reclaim one of them
+                // and fold the other into a larger segment. At the default of 10% that leftover tombstone is too small a fraction
+                // of the merged segment for findForcedDeletesMerges to ever select it again, and the assertBysy loop below would
+                // then spin forever on a single deleted doc.
+                // Zero makes any segment with a reclaimable delete eligible, so the loop always converges.
+                .put(MergePolicyConfig.INDEX_MERGE_POLICY_EXPUNGE_DELETES_ALLOWED_SETTING.getKey(), 0.0d)
                 .build()
         );
         ensureGreen(indexName);


### PR DESCRIPTION
The `index.merge.policy.expunge_deletes_allowed` equal to 10% may cause one doc to remain there if it has been the only one not reclaimed in the first `assertBusy` run. This state is permanent, so I think it's best to rule this parameter out from this test and always remove tombstones.

Closes: https://github.com/elastic/elasticsearch/issues/157970