### PR TITLE
fix: prevent inner result window overflow

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -1117,6 +1117,18 @@ public class TopHitsIT extends ESIntegTestCase {
             e.getCause().getMessage(),
             containsString("the top hits aggregator [hits]'s from + size must be less than or equal to: [100] but was [110]")
         );
+        e = expectThrows(
+            SearchPhaseExecutionException.class,
+            prepareSearch("idx").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(TERMS_AGGS_FIELD)
+                    .subAggregation(topHits("hits").from(Integer.MAX_VALUE).size(1))
+            )
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("the top hits aggregator [hits]'s from + size must be less than or equal to: [100] but was [2147483648]")
+        );
 
         updateIndexSettings(Settings.builder().put(IndexSettings.MAX_INNER_RESULT_WINDOW_SETTING.getKey(), 110), "idx");
         assertNoFailures(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
@@ -980,6 +980,18 @@ public class InnerHitsIT extends ESIntegTestCase {
             e.getCause().getMessage(),
             containsString("the inner hit definition's [_name]'s from + size must be less than or equal to: [100] but was [110]")
         );
+        e = expectThrows(
+            SearchPhaseExecutionException.class,
+            prepareSearch("index2").setQuery(
+                nestedQuery("nested", matchQuery("nested.field", "value1"), ScoreMode.Avg).innerHit(
+                    new InnerHitBuilder().setFrom(Integer.MAX_VALUE).setSize(1).setName("_name")
+                )
+            )
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("the inner hit definition's [_name]'s from + size must be less than or equal to: [100] but was [2147483648]")
+        );
 
         updateIndexSettings(Settings.builder().put(IndexSettings.MAX_INNER_RESULT_WINDOW_SETTING.getKey(), 110), "index2");
         assertNoFailures(

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
@@ -39,7 +39,7 @@ public abstract class InnerHitContextBuilder {
     }
 
     public final void build(SearchContext parentSearchContext, InnerHitsContext innerHitsContext) throws IOException {
-        long innerResultWindow = innerHitBuilder.getFrom() + innerHitBuilder.getSize();
+        long innerResultWindow = (long) innerHitBuilder.getFrom() + innerHitBuilder.getSize();
         int maxInnerResultWindow = parentSearchContext.getSearchExecutionContext().getIndexSettings().getMaxInnerResultWindow();
         if (innerResultWindow > maxInnerResultWindow) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -505,7 +505,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     @Override
     protected TopHitsAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subfactoriesBuilder)
         throws IOException {
-        long innerResultWindow = from() + size();
+        long innerResultWindow = (long) from() + size();
         int maxInnerResultWindow = context.getIndexSettings().getMaxInnerResultWindow();
         if (innerResultWindow > maxInnerResultWindow) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

The `top_hits` aggregation and `inner_hits` query validate `from + size` against `index.max_inner_result_window`
 
Both values are stored as non-negative `int`s, but the addition was also performed as an `int` before being assigned to a `long`. Consequently, sufficiently large values could overflow to a negative number and bypass
the result-window validation.

For example:

  ```text
  from = 2147483647
  size = 1

  Expected sum: 2147483648
  Previous int result: -2147483648

  The negative result passes a check such as:

  innerResultWindow > maxInnerResultWindow
```

This change widens from to a long before performing the addition in both validation paths. It also adds regression coverage for the overflow. In addition to that, i have added the required test cases. 
 


<!--
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->