### PR TITLE
Change the XContent serialization order to match 9.1

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -2312,11 +2312,11 @@ public class DenseVectorFieldMapper extends FieldMapper {
         @Override
         public void toXContentFragment(XContentBuilder builder, Params params) throws IOException {
             builder.field("type", type);
-            if (rescoreVector != null) {
-                rescoreVector.toXContent(builder, params);
-            }
             if (confidenceInterval != null) {
                 builder.field("confidence_interval", confidenceInterval);
+            }
+            if (rescoreVector != null) {
+                rescoreVector.toXContent(builder, params);
             }
         }
 
@@ -2524,11 +2524,11 @@ public class DenseVectorFieldMapper extends FieldMapper {
         @Override
         public void toXContentFragment(XContentBuilder builder, Params params) throws IOException {
             builder.field("type", type);
-            if (rescoreVector != null) {
-                rescoreVector.toXContent(builder, params);
-            }
             if (confidenceInterval != null) {
                 builder.field("confidence_interval", confidenceInterval);
+            }
+            if (rescoreVector != null) {
+                rescoreVector.toXContent(builder, params);
             }
         }
 


### PR DESCRIPTION
Partially fixes #158358

#157459 pre-empted the assertions change in https://github.com/elastic/elasticsearch/pull/146946, causing breakages. This reverts the serialization order change in #141882 to match 9.1, so the assert doesn't trigger