### PR TITLE
Fix RolesBackwardsCompatibilityIT BWC failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -69,8 +69,6 @@ tests:
 - class: org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT
   method: testSnapshotUpgrader {upgradedNodes=2}
   issue: https://github.com/elastic/elasticsearch/issues/158092
-- class: org.elasticsearch.upgrades.RolesBackwardsCompatibilityIT
-  issue: https://github.com/elastic/elasticsearch/issues/158093
 - class: org.elasticsearch.upgrades.SemanticTextUpgradeIT
   issue: https://github.com/elastic/elasticsearch/issues/158094
 - class: org.elasticsearch.upgrades.MlAssignmentPlannerUpgradeIT

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/RolesBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/RolesBackwardsCompatibilityIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.Request;
@@ -299,17 +298,15 @@ public class RolesBackwardsCompatibilityIT extends AbstractXpackRollingUpgradeWi
 
     private boolean nodeSupportTransportVersion(NodeInfo testNodeInfo, TransportVersion transportVersion) {
         if (testNodeInfo.transportVersion().equals(TransportVersion.zero())) {
-            // In cases where we were not able to find a TransportVersion, a pre-8.8.0 node answered about a newer (upgraded) node.
-            // In that case, the node will be current (upgraded), and remote indices are supported for sure.
-            var nodeIsCurrent = testNodeInfo.version().equals(Build.current().version());
-            assertTrue(nodeIsCurrent);
-            return true;
+            return testNodeInfo.isUpgradedVersionCluster();
         }
         return testNodeInfo.transportVersion().supports(transportVersion);
     }
 
     private static RoleDescriptor randomRoleDescriptor(boolean includeDescription, boolean includeManageRoles) {
         final Set<String> excludedPrivileges = Set.of(
+            "read_failure_store",
+            "manage_failure_store",
             "cross_cluster_replication",
             "cross_cluster_replication_internal",
             "manage_data_stream_lifecycle"


### PR DESCRIPTION
Fixes two bugs in the rolling-upgrade `RolesBackwardsCompatibilityIT` (migrated in #155112) that make it fail against 8.19 BWC bases:

* `nodeSupportTransportVersion` assumed that a missing `transport_version` in the nodes-info response implies the node is an upgraded node, and asserted that the node is on the current build. However, pre-8.8.0 nodes do not report a transport version for themselves either, so the assertion trips on any BWC base older than 8.8.0. Classify such nodes by release version instead.

* `randomRoleDescriptor` drew index privileges from the current privilege name pool, which includes `read_failure_store` and `manage_failure_store`; nodes older than 8.19 reject roles containing them with `unknown index privilege`. Exclude both, mirroring `ApiKeyBackwardsCompatibilityIT`.

Also unmutes the suite.

Verified locally with the CI-reported seeds: `v8.3.3#bwcTest` (seed `773A7ECB35A07C14`, previously failed the node-classification assertion) and `v8.9.2#bwcTest` (seed `7096B7E6942F74D8`, previously failed on `read_failure_store`) both pass the full suite.

Closes #158093
Closes #158095
Closes #158096
Closes #158097
Closes #158098