### PR TITLE
[9.5] Auto calibration error model should honour precondition (#158569)

### DIFF
--- a/docs/changelog/158569.yaml
+++ b/docs/changelog/158569.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 158569
+summary: Auto calibration error model should honour precondition
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModel.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModel.java
@@ -104,6 +104,7 @@ public final class ErrorModel {
         float[] residualScratch = scratch.residualScratch;
         float[] normScratch = scratch.normScratch;
         int[] quantizeScratch = scratch.quantizeScratch;
+        float[] preconditionScratch = scratch.preconditionScratch;
 
         float[] docLower = scratch.docLower;
         float[] docUpper = scratch.docUpper;
@@ -116,6 +117,10 @@ public final class ErrorModel {
             float[] doc = source.vectors().vectorValue(source.corpusOrdinals()[i]);
             if (cosine) {
                 doc = CalibrationUtils.copyAndNormalize(doc, normScratch);
+            }
+            if (usePreconditioned && source.preconditioner() != null) {
+                source.preconditioner().applyTransform(doc, preconditionScratch);
+                doc = preconditionScratch;
             }
             int qc = docCentroidAssignments[docAssignments[i]];
             corpusDotCentroid[i] = ESVectorUtil.dotProduct(queryCentroids[qc], doc);
@@ -139,7 +144,6 @@ public final class ErrorModel {
         byte[][] queryQuantized = new byte[actualQueryClusters][dim];
 
         float[] queryScratch = scratch.queryScratch;
-        float[] preconditionScratch = scratch.preconditionScratch;
 
         double[] queryDotCentroid = new double[nDocClusters];
         double[] simOsq = scratch.simOsq;
@@ -251,6 +255,10 @@ public final class ErrorModel {
                 if (cosine) {
                     doc = CalibrationUtils.copyAndNormalize(doc, normScratch);
                 }
+                if (usePreconditioned && source.preconditioner() != null) {
+                    source.preconditioner().applyTransform(doc, preconditionScratch);
+                    doc = preconditionScratch;
+                }
                 double exact;
                 if (sim == VectorSimilarityFunction.EUCLIDEAN) {
                     assert docDotDoc != null;
@@ -289,6 +297,17 @@ public final class ErrorModel {
         int[] flatAssignments = docClusters.assignments();
         if (docCentroids.length == 0) {
             return new QuantizedErrorComputeResult(1.0, docCentroids, warmStartQueryCentroids);
+        }
+
+        // K-means distances are preserved under orthogonal rotation, so assignments are the same in both spaces.
+        // Rotating each centroid gives the exact centroid of the preconditioned cluster, so we can cluster in
+        // original space and then rotate the resulting centroids rather than re-clustering preconditioned vectors.
+        if (usePreconditioned && source.preconditioner() != null) {
+            float[][] preconditionedCentroids = new float[docCentroids.length][source.workingDim()];
+            for (int i = 0; i < docCentroids.length; i++) {
+                source.preconditioner().applyTransform(docCentroids[i], preconditionedCentroids[i]);
+            }
+            docCentroids = preconditionedCentroids;
         }
 
         QuantizedQueryErrorResult queryError = quantizedRepErrorStd(

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModelTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModelTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.elasticsearch.index.codec.vectors.cluster.CentroidOps;
 import org.elasticsearch.index.codec.vectors.cluster.HierarchicalKMeans;
 import org.elasticsearch.index.codec.vectors.cluster.KMeansFloatVectorValues;
+import org.elasticsearch.index.codec.vectors.diskbbq.Preconditioner;
 import org.elasticsearch.simdvec.ESVectorUtil;
 import org.elasticsearch.test.ESTestCase;
 
@@ -389,6 +390,177 @@ public class ErrorModelTests extends ESTestCase {
         // Self-consistency: the ratio must match the model's slope exactly
         assertEquals("errorStd must scale as (sample/N)^modelSlope", Math.pow(0.1, modelSlope), ratio, 1e-3);
         assertTrue("estimate must depend on corpus size (slope must not cancel)", Math.abs(ratio - 1.0) > 1e-3);
+    }
+
+    /**
+     * Regression guard for the preconditioning fix. For spherically symmetric (isotropic) data the
+     * expected quantization error is the same whether or not a random orthogonal preconditioner is
+     * applied, because the distribution is already rotation-invariant.
+     */
+    public void testPreconditioningDoesNotInflateErrorStdForIsotropicData() throws IOException {
+        int dim = 64;
+        float[][] rows = randomNormalizedRows(2500, dim, 123L);
+        FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
+        // Single-block rotation maximally mixes all dimensions.
+        Preconditioner preconditioner = Preconditioner.createPreconditioner(dim, dim);
+
+        int[] queryOrdinals = range(0, 64);
+        int[] corpusOrdinals = range(64, 2436);
+        CalibrationSource source = new CalibrationSource(
+            VectorSimilarityFunction.DOT_PRODUCT,
+            dim,
+            fvv,
+            queryOrdinals,
+            dim,
+            false,
+            false,
+            preconditioner,
+            corpusOrdinals,
+            10,
+            fvv.size()
+        );
+
+        HierarchicalKMeans<float[]> kmeans = HierarchicalKMeans.ofSerial(CentroidOps.FLOAT, dim);
+        ErrorModel.QuantizedErrorScratch scratch = new ErrorModel.QuantizedErrorScratch(corpusOrdinals.length, dim, false, false, true);
+
+        ErrorModel.QuantizedErrorComputeResult withoutPrecondition = ErrorModel.quantizedRepErrorStdWithCentroids(
+            source,
+            false,
+            corpusOrdinals.length,
+            128,
+            4,
+            1,
+            kmeans,
+            null,
+            null,
+            scratch
+        );
+        ErrorModel.QuantizedErrorComputeResult withPrecondition = ErrorModel.quantizedRepErrorStdWithCentroids(
+            source,
+            true,
+            corpusOrdinals.length,
+            128,
+            4,
+            1,
+            kmeans,
+            null,
+            null,
+            scratch
+        );
+
+        // For isotropic data the two error stds must be within 30% of each other.
+        double ratio = withPrecondition.std() / withoutPrecondition.std();
+        assertThat(
+            "preconditioning must not inflate error std for isotropic data "
+                + "(ratio="
+                + ratio
+                + ", no-precondition std="
+                + withoutPrecondition.std()
+                + ", preconditioned std="
+                + withPrecondition.std()
+                + ")",
+            ratio,
+            lessThan(1.3)
+        );
+    }
+
+    /**
+     * Regression guard for the preconditioning fix in {@link ErrorModel#quantizedRepErrorStd}.
+     * For data whose within-cluster residuals have non-uniform component distribution (high variance
+     * concentrated in the first quarter of dimensions, tiny elsewhere), preconditioning via a random
+     * orthogonal rotation spreads the variance uniformly, reducing OSQ quantization error.
+     * The preconditioned error std must be strictly lower than the non-preconditioned one.
+     */
+    public void testPreconditioningLowersErrorStdForSkewedResiduals() throws IOException {
+        int dim = 64;
+        float[][] rows = skewedClusteredRows(2500, dim, 8);
+        FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
+        // Single-block rotation spreads the skewed variance across all dimensions.
+        Preconditioner preconditioner = Preconditioner.createPreconditioner(dim, dim);
+
+        int[] queryOrdinals = range(0, 64);
+        int[] corpusOrdinals = range(64, 2436);
+        CalibrationSource source = new CalibrationSource(
+            VectorSimilarityFunction.DOT_PRODUCT,
+            dim,
+            fvv,
+            queryOrdinals,
+            dim,
+            false,
+            false,
+            preconditioner,
+            corpusOrdinals,
+            10,
+            fvv.size()
+        );
+
+        HierarchicalKMeans<float[]> kmeans = HierarchicalKMeans.ofSerial(CentroidOps.FLOAT, dim);
+        ErrorModel.QuantizedErrorScratch scratch = new ErrorModel.QuantizedErrorScratch(corpusOrdinals.length, dim, false, false, true);
+
+        ErrorModel.QuantizedErrorComputeResult withoutPrecondition = ErrorModel.quantizedRepErrorStdWithCentroids(
+            source,
+            false,
+            corpusOrdinals.length,
+            128,
+            4,
+            1,
+            kmeans,
+            null,
+            null,
+            scratch
+        );
+        // Warm-start from the original-space centroids so both runs use the same clustering.
+        ErrorModel.QuantizedErrorComputeResult withPrecondition = ErrorModel.quantizedRepErrorStdWithCentroids(
+            source,
+            true,
+            corpusOrdinals.length,
+            128,
+            4,
+            1,
+            kmeans,
+            withoutPrecondition.docCentroids(),
+            withoutPrecondition.queryCentroids(),
+            scratch
+        );
+
+        assertThat(
+            "preconditioned error std must be lower for skewed-residual data "
+                + "(no-precondition std="
+                + withoutPrecondition.std()
+                + ", preconditioned std="
+                + withPrecondition.std()
+                + ")",
+            withPrecondition.std(),
+            lessThan(withoutPrecondition.std())
+        );
+    }
+
+    /**
+     * Creates clustered rows whose within-cluster residuals have non-uniform component distribution:
+     * the first quarter of dimensions carry 50× more noise than the remainder. This skew makes
+     * preconditioning (random orthogonal rotation) clearly beneficial for OSQ quantization.
+     */
+    private static float[][] skewedClusteredRows(int count, int dim, int numClusters) {
+        Random rng = new Random(77L);
+        float[][] centroids = new float[numClusters][dim];
+        for (int c = 0; c < numClusters; c++) {
+            for (int d = 0; d < dim; d++) {
+                centroids[c][d] = (float) rng.nextGaussian();
+            }
+            l2normalize(centroids[c]);
+        }
+        float[][] rows = new float[count][dim];
+        for (int i = 0; i < count; i++) {
+            int c = i % numClusters;
+            System.arraycopy(centroids[c], 0, rows[i], 0, dim);
+            for (int d = 0; d < dim / 4; d++) {
+                rows[i][d] += (float) rng.nextGaussian() * 0.5f;
+            }
+            for (int d = dim / 4; d < dim; d++) {
+                rows[i][d] += (float) rng.nextGaussian() * 0.01f;
+            }
+        }
+        return rows;
     }
 
     /** Real-residual error-std for encoding (4q,2d) at a given query set / corpus, extrapolated to the corpus size. */


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Auto calibration error model should honour precondition (#158569)