### PR TITLE
ESQL: fix the columnar test oracle and drop six dataset exclusions

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
@@ -197,7 +197,6 @@ sample_data    | null           | null              | 172.21.3.15 | 172.21.3.15
 
 subqueryMetadataIndex
 required_capability: subquery_in_from_command
-skip_columnar: _index_mode metadata correctly reports "columnar" in columnar mode but the csv-spec oracle expects "standard"
 
 // tag::subquery_with_metadata[]
 FROM employees,
@@ -220,7 +219,6 @@ count:long | emp_no:integer | _index:keyword | _index_mode:keyword
 
 subqueryMetadataIndexInner
 required_capability: subquery_in_from_command
-skip_columnar: _index_mode metadata correctly reports "columnar" in columnar mode but the csv-spec oracle expects "standard"
 
 // tag::subquery_with_metadata_inner[]
 FROM employees,
@@ -242,7 +240,6 @@ count:long | emp_no:integer | _index:keyword | _index_mode:keyword
 
 subqueryMetadataIndexOuter
 required_capability: subquery_in_from_command
-skip_columnar: _index_mode metadata correctly reports "columnar" in columnar mode but the csv-spec oracle expects "standard"
 
 // tag::subquery_with_metadata_outer[]
 FROM employees,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
@@ -24,6 +24,7 @@ partiallyUnmappedSmallNumericFieldIsWidenedAndLoaded
 required_capability: optional_fields_v5
 required_capability: optional_fields_fix_partially_unmapped_small_numeric
 required_capability: optional_fields_fix_implicit_cast_on_small_numeric_punk
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM all_types, all_types_no_short METADATA _index
@@ -48,6 +49,7 @@ all_types_no_short | 50
 partiallyUnmappedSmallNumericFieldExplicitCast
 required_capability: optional_fields_v5
 required_capability: optional_fields_fix_partially_unmapped_small_numeric
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM all_types, all_types_no_short

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-type-conflicts.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-type-conflicts.csv-spec
@@ -558,6 +558,7 @@ sample_data            | 8268153.0
 typeConflictShortUnmappedCastToInteger
 required_capability: optional_fields_v5
 required_capability: optional_fields_fix_partially_unmapped_small_numeric
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM all_types, all_types_no_short METADATA _index
@@ -801,6 +802,7 @@ typeConflictPartiallyUnmappedTextFieldToText
 required_capability: optional_fields_v5
 required_capability: optional_fields_fix_load_partially_mapped
 required_capability: fn_to_text
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM employees_gender_text, employees_no_gender METADATA _index
@@ -825,6 +827,7 @@ required_capability: optional_fields_fix_load_partially_mapped
 required_capability: fn_to_text
 required_capability: fn_match_unmapped_fields_pushdown_fix
 required_capability: match_function
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM employees_gender_text, employees_no_gender METADATA _index
@@ -850,6 +853,7 @@ required_capability: optional_fields_fix_load_partially_mapped
 required_capability: fn_to_text
 required_capability: fn_match_phrase_runtime_filter
 required_capability: match_phrase_function
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM employees_gender_text, employees_no_gender METADATA _index
@@ -1466,6 +1470,7 @@ all_types_short_as_long | null
 typeConflictShortLongUnmappedCastToInteger
 required_capability: optional_fields_v5
 required_capability: optional_fields_fix_partially_unmapped_small_numeric
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM all_types, all_types_short_as_long, all_types_no_short METADATA _index
@@ -3525,6 +3530,7 @@ addresses_text           | North America
 // Cast city.country.continent.name (text, partially unmapped) to keyword via MultiTypeEsField.
 deeplyNestedNonKeywordSubfieldPartiallyUnmappedCastToKeyword
 required_capability: optional_fields_v5
+skip_columnar: dynamic:false unmapped fields are dropped at ingest in columnar mode (no _ignored_source), so unmapped_fields=load has nothing to read - lossy by design
 
 SET unmapped_fields="load"\;
 FROM addresses_text, addresses_no_continent METADATA _index

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -110,11 +110,12 @@ public class CsvColumnarIT extends CsvIT {
      * <p>Note: several entries in the generative-test catalogue
      * ({@code addresses_text}, {@code employees_gender_text}, {@code all_types},
      * {@code all_types_no_short}, {@code all_types_short_as_long}, {@code apps_short}) were
-     * artifacts of the ref_/cand_ side-by-side wildcard approach and do NOT apply here.
-     * They are still included because columnar auto-converts text→keyword and
-     * short→long, causing expected column-type headers in the csv-spec entries to mismatch.
-     * Revisit once the inventory (via {@code skip_columnar:} directives) is established and
-     * transformExpectedResults becomes worth implementing.
+     * artifacts of the ref_/cand_ side-by-side wildcard approach and do NOT apply here. They were
+     * also listed here on the assumption that columnar's text→keyword and short→long conversions
+     * would mismatch the csv-spec column-type headers. Running them proved otherwise: no test
+     * fails on column types. The only failures were the {@code unmapped_fields="load"} family
+     * described below, which now carry per-test {@code skip_columnar:} directives instead, so
+     * these datasets are no longer excluded.
      */
     private static final Set<String> COLUMNAR_INCOMPATIBLE_DATASETS = Set.of(
         // index:false / doc_values:false are no-ops in strict columnar mode — every field gets
@@ -132,19 +133,6 @@ public class CsvColumnarIT extends CsvIT {
         // data contains deliberate duplicates in boolean MV fields (e.g. [false,true,true]).
         // SortedSetDocValues deduplicates those in standard mode while columnar may preserve them.
         "employees_incompatible",
-        // Contains semantic_text and dense_vector fields that are absent from columnar field_caps,
-        // and has a short-typed field "short" that columnar normalises to long — both cause
-        // expected column-type header mismatches vs csv-spec declared types.
-        "all_types",
-        "all_types_no_short",
-        "all_types_short_as_long",
-        // id field overridden to short; columnar normalises short→long, causing a type conflict
-        // vs the base apps dataset (id: integer) and expected-type mismatches.
-        "apps_short",
-        // Keyword fields overridden to text; columnar auto-converts text→keyword, so expected
-        // column types in csv-spec entries (text) mismatch the actual columnar types (keyword).
-        "addresses_text",
-        "employees_gender_text",
         // Contains a plain txt:text field with no doc_values; fails index creation in columnar
         // mode because text without doc_values cannot be reconstructed from doc values.
         "text_state_mapped",

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -527,8 +527,18 @@ public class CsvColumnarIT extends CsvIT {
      * {@code CsvLogsdbColumnarIT}) may override to choose a different mode.
      */
     protected static Settings modeSettings() {
-        return Settings.builder().put("index.mode", "columnar").build();
+        return Settings.builder().put(INDEX_MODE_SETTING, "columnar").build();
     }
+
+    private static final String INDEX_MODE_SETTING = "index.mode";
+
+    /**
+     * The {@code _index_mode} metadata column, and the value the csv-spec corpus declares for it.
+     * The corpus is written against standard indices, so any dataset this strategy converts
+     * reports a different mode at query time.
+     */
+    private static final String INDEX_MODE_COLUMN = "_index_mode";
+    private static final String STANDARD_INDEX_MODE = "standard";
 
     /**
      * Installs the columnar index-load strategy.
@@ -673,13 +683,60 @@ public class CsvColumnarIT extends CsvIT {
             return new TransformedQuery(testCase.query, Settings.EMPTY);
         }
 
+        /**
+         * Rewrites expected {@code _index_mode} values from {@code standard} to the mode this
+         * strategy actually stamps on the datasets it converts.
+         *
+         * <p>Only the literal {@code standard} is rewritten. Lookup-mode datasets keep their
+         * original mode and the corpus already declares {@code lookup} for them, and a dataset
+         * that unexpectedly stayed standard (see {@link #FORCED_STANDARD_DATASETS}) still fails
+         * rather than being masked.
+         */
         @Override
         public CsvTestUtils.ExpectedResults transformExpectedResults(
             String testId,
             CsvTestCase testCase,
             CsvTestUtils.ExpectedResults expected
         ) {
-            return expected;
+            int modeIdx = expected.columnNames().indexOf(INDEX_MODE_COLUMN);
+            if (modeIdx < 0) {
+                return expected;
+            }
+            String actualMode = extraSettings.get(INDEX_MODE_SETTING);
+            if (actualMode == null) {
+                return expected;
+            }
+            boolean anyChanged = false;
+            List<List<Object>> newValues = new ArrayList<>(expected.values().size());
+            for (List<Object> row : expected.values()) {
+                Object rewritten = rewriteIndexMode(row.get(modeIdx), actualMode);
+                if (rewritten == row.get(modeIdx)) {
+                    newValues.add(row);
+                } else {
+                    List<Object> newRow = new ArrayList<>(row);
+                    newRow.set(modeIdx, rewritten);
+                    newValues.add(newRow);
+                    anyChanged = true;
+                }
+            }
+            if (anyChanged == false) {
+                return expected;
+            }
+            return new CsvTestUtils.ExpectedResults(expected.columnNames(), expected.columnTypes(), newValues);
+        }
+
+        /**
+         * Returns the cell with {@code standard} replaced by {@code actualMode}, or the original
+         * cell instance when nothing needs rewriting.
+         *
+         * <p>Only scalar cells are rewritten. Every row of a {@code _index_mode} column describes
+         * a single index, so no multi-value cell is expected here. If one ever appears it falls
+         * through unchanged and the comparison fails with a plain value mismatch, which is the
+         * intended outcome: this hook exists to retarget a known-good expectation, not to absorb
+         * shapes it was never verified against.
+         */
+        private static Object rewriteIndexMode(Object cell, String actualMode) {
+            return STANDARD_INDEX_MODE.equals(cell) ? actualMode : cell;
         }
 
         /**


### PR DESCRIPTION
Test-only.

`CsvColumnarIT` excluded six datasets and skipped three tests for reasons that don't hold. Both were test problems. 35 more csv-spec tests now run against columnar indices.

**`_index_mode`** - three subquery tests were skipped because the corpus declares `standard` while columnar correctly reports `columnar`. The values sit in docs `tag::` blocks, so they can't be edited without publishing wrong values for standard indices. Implemented the existing `transformExpectedResults` hook instead, rewriting only the literal `standard`. Lookup datasets already declare `lookup`, and a dataset that unexpectedly stayed standard still fails rather than being masked.

**Six datasets** - excluded on the theory that columnar's `text`→`keyword` and `short`→`long` conversions mismatch the declared column-type headers. Running them disproves it: nothing fails on column types. The only failures were eight tests using `SET unmapped_fields="load"`, which hit the documented lossy-by-design gap (columnar drops unmapped fields at ingest, no `_ignored_source`). Those eight now carry the same `skip_columnar` reason as their neighbours, so the six
exclusions are gone. Javadoc corrected so the type-header theory isn't re-derived later.