### PR TITLE
[ESQL] Seed newObject from listing size

### DIFF
--- a/docs/changelog/158666.yaml
+++ b/docs/changelog/158666.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158666
+summary: Seed `newObject` from listing size
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -2081,7 +2082,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     // Cache per file path to avoid redundant metadata fetches across splits of the same file.
                     List<Attribute> cachedSchema = fileSplit.path().equals(state.lastSchemaPath) ? state.lastBoundSchema : null;
                     if (cachedSchema == null) {
-                        SourceMetadata meta = fileReader.metadata(storageProvider.newObject(fileSplit.path()));
+                        SourceMetadata meta = fileReader.metadata(FileSplitProvider.newObjectForFile(storageProvider, fileSplit));
                         if (meta != null && meta.schema() != null && meta.schema().isEmpty() == false) {
                             cachedSchema = meta.schema();
                         }
@@ -2294,14 +2295,19 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
 
         CloseableIterator<Page> pages = null;
         try {
-            StorageObject obj = storageProvider.newObject(files.path(fileIndex));
+            StoragePath filePath = files.path(fileIndex);
+            long size = files.size(fileIndex);
+            long mtime = files.lastModifiedMillis(fileIndex);
+            StorageObject obj = mtime > 0
+                ? storageProvider.newObject(filePath, size, Instant.ofEpochMilli(mtime))
+                : storageProvider.newObject(filePath, size);
             attachStorageMetrics(obj); // before any read — see note at the single-object dispatch above
             // Pull this file's coordinator-inferred schema from schemaInfo when available, so the
             // reader is pinned to the same inference the per-file ColumnMapping was built against.
             ColumnMapping mapping = null;
             List<Attribute> perFileReadSchema = null;
             if (state.schemaInfo != null) {
-                SchemaReconciliation.FileSchemaInfo info = state.schemaInfo.get(files.path(fileIndex));
+                SchemaReconciliation.FileSchemaInfo info = state.schemaInfo.get(filePath);
                 if (info != null) {
                     mapping = info.mapping();
                     perFileReadSchema = info.fileSchema().attributes();
@@ -2362,7 +2368,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             CloseableIterator<Page> withEncoder = wrapWithEncoderIfNeeded(adapted, perFileCols, state.driverContext);
             // Per-file virtual-column iterator (built with FileMetadataColumns.extractValues for
             // this file) so {@code _file.*} columns carry the right values for the current file.
-            state.pages = wrapWithVirtualColumns(withEncoder, perFileValues, state.driverContext, files.path(fileIndex));
+            state.pages = wrapWithVirtualColumns(withEncoder, perFileValues, state.driverContext, filePath);
             state.currentObject = obj;
             state.currentObjectBytesSnapshot = readBytesOrZero(obj);
             return true;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -64,7 +64,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -2028,10 +2027,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             FormatReader fileReader = readerForFile(fileSplit);
             boolean isRangeSplit = "true".equals(fileSplit.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
             if (isRangeSplit && fileReader instanceof RangeAwareFormatReader rangeReader) {
-                String fileLengthStr = (String) fileSplit.config().get(FileSplitProvider.FILE_LENGTH_KEY);
-                StorageObject fullObj = fileLengthStr != null
-                    ? storageProvider.newObject(fileSplit.path(), Long.parseLong(fileLengthStr))
-                    : storageProvider.newObject(fileSplit.path());
+                StorageObject fullObj = FileSplitProvider.newObjectForFile(storageProvider, fileSplit);
                 attachStorageMetrics(fullObj); // before any read — see note at the single-object dispatch above
                 long rangeEnd = fileSplit.offset() + fileSplit.length();
                 Object fileContext = fileSplit.path().equals(state.lastRangeFilePath) ? state.lastFileContext : null;
@@ -2227,10 +2223,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         for (ExternalSplit claim : claims) {
             for (ExternalSplit leaf : flattenToLeaves(claim)) {
                 if (leaf instanceof FileSplit fs) {
-                    String fileLengthStr = (String) fs.config().get(FileSplitProvider.FILE_LENGTH_KEY);
-                    StorageObject obj = fileLengthStr != null
-                        ? storageProvider.newObject(fs.path(), Long.parseLong(fileLengthStr))
-                        : storageProvider.newObject(fs.path());
+                    StorageObject obj = FileSplitProvider.newObjectForFile(storageProvider, fs);
                     // Batch path reads several objects together — attach each before readAll() opens them.
                     attachStorageMetrics(obj);
                     splitRefs.add(new RangeAwareFormatReader.SplitRef(obj, fs.offset(), fs.length()));
@@ -2298,9 +2291,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             StoragePath filePath = files.path(fileIndex);
             long size = files.size(fileIndex);
             long mtime = files.lastModifiedMillis(fileIndex);
-            StorageObject obj = mtime > 0
-                ? storageProvider.newObject(filePath, size, Instant.ofEpochMilli(mtime))
-                : storageProvider.newObject(filePath, size);
+            StorageObject obj = FileSplitProvider.newObject(storageProvider, filePath, size, mtime);
             attachStorageMetrics(obj); // before any read — see note at the single-object dispatch above
             // Pull this file's coordinator-inferred schema from schemaInfo when available, so the
             // reader is pinned to the same inference the per-file ColumnMapping was built against.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -1257,21 +1257,26 @@ public class FileSplitProvider implements SplitProvider {
 
     /**
      * Full-file {@link StorageObject} for {@code fileSplit}, seeded with listing length (and mtime
-     * when known) so {@code length()} does not probe the object store. Size {@code 0} is a real
-     * empty object; missing length falls back to the path-only constructor.
+     * when known) so {@code length()} / {@code lastModified()} do not probe the object store. Size
+     * {@code 0} is a real empty object; missing length falls back to the path-only constructor.
      * <p>
-     * Used by {@link #storageObjectForSplit} (which then range-wraps the view span) and by COUNT(*)
-     * schema bind, which must see file-leading bytes rather than the split window.
+     * Used by {@link #storageObjectForSplit} (which then range-wraps the view span), COUNT(*) schema
+     * bind (file-leading bytes, not the split window), and range-leaf / batch reads.
      */
     static StorageObject newObjectForFile(StorageProvider storageProvider, FileSplit fileSplit) {
-        StoragePath path = fileSplit.path();
-        Long length = fileLengthHint(fileSplit);
+        return newObject(storageProvider, fileSplit.path(), fileLengthHint(fileSplit), fileMtimeHint(fileSplit));
+    }
+
+    /**
+     * Picks the {@link StorageProvider#newObject} overload. Missing {@code length} is path-only;
+     * size {@code 0} is a known empty object; mtime {@code 0} is unknown.
+     */
+    static StorageObject newObject(StorageProvider storageProvider, StoragePath path, @Nullable Long length, long mtimeMillis) {
         if (length == null) {
             return storageProvider.newObject(path);
         }
-        Long mtime = fileMtimeHint(fileSplit);
-        return mtime != null
-            ? storageProvider.newObject(path, length, Instant.ofEpochMilli(mtime))
+        return mtimeMillis > 0
+            ? storageProvider.newObject(path, length, Instant.ofEpochMilli(mtimeMillis))
             : storageProvider.newObject(path, length);
     }
 
@@ -1296,16 +1301,9 @@ public class FileSplitProvider implements SplitProvider {
         return listed instanceof Number n ? n.longValue() : null;
     }
 
-    @Nullable
-    private static Long fileMtimeHint(FileSplit fileSplit) {
+    private static long fileMtimeHint(FileSplit fileSplit) {
         Object modified = fileSplit.partitionValues().get(FileMetadataColumns.MODIFIED);
-        if (modified instanceof Number n) {
-            long millis = n.longValue();
-            if (millis > 0) {
-                return millis;
-            }
-        }
-        return null;
+        return modified instanceof Number n ? n.longValue() : 0L;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -58,6 +58,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Les
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1255,12 +1256,56 @@ public class FileSplitProvider implements SplitProvider {
     }
 
     /**
+     * Full-file {@link StorageObject} for {@code fileSplit}, seeded with listing length (and mtime
+     * when known) so {@code length()} does not probe the object store. Size {@code 0} is a real
+     * empty object; missing length falls back to the path-only constructor.
+     * <p>
+     * Used by {@link #storageObjectForSplit} (which then range-wraps the view span) and by COUNT(*)
+     * schema bind, which must see file-leading bytes rather than the split window.
+     */
+    static StorageObject newObjectForFile(StorageProvider storageProvider, FileSplit fileSplit) {
+        StoragePath path = fileSplit.path();
+        Long length = fileLengthHint(fileSplit);
+        if (length == null) {
+            return storageProvider.newObject(path);
+        }
+        Long mtime = fileMtimeHint(fileSplit);
+        return mtime != null
+            ? storageProvider.newObject(path, length, Instant.ofEpochMilli(mtime))
+            : storageProvider.newObject(path, length);
+    }
+
+    /**
      * Builds a {@link StorageObject} that exposes only the bytes for the given {@link FileSplit}.
      * Always wraps the provider's base object in {@link RangeStorageObject} so format readers and
      * splittable decompressors only see the split's compressed byte span (including offset {@code 0}).
+     * The inner object is the full file, seeded from listing metadata when present — never from
+     * {@link FileSplit#length()}, which is the view span.
      */
     public static StorageObject storageObjectForSplit(StorageProvider storageProvider, FileSplit fileSplit) {
-        return new RangeStorageObject(storageProvider.newObject(fileSplit.path()), fileSplit.offset(), fileSplit.length());
+        return new RangeStorageObject(newObjectForFile(storageProvider, fileSplit), fileSplit.offset(), fileSplit.length());
+    }
+
+    @Nullable
+    private static Long fileLengthHint(FileSplit fileSplit) {
+        Object configured = fileSplit.config().get(FILE_LENGTH_KEY);
+        if (configured instanceof String s) {
+            return Long.parseLong(s);
+        }
+        Object listed = fileSplit.partitionValues().get(FileMetadataColumns.SIZE);
+        return listed instanceof Number n ? n.longValue() : null;
+    }
+
+    @Nullable
+    private static Long fileMtimeHint(FileSplit fileSplit) {
+        Object modified = fileSplit.partitionValues().get(FileMetadataColumns.MODIFIED);
+        if (modified instanceof Number n) {
+            long millis = n.longValue();
+            if (millis > 0) {
+                return millis;
+            }
+        }
+        return null;
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -498,6 +498,37 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
     }
 
     /**
+     * {@code openNextMultiFile} must call the length overload, including listed size {@code 0}.
+     * A row-count-only assertion would pass on the path-only constructor.
+     */
+    public void testOpenNextMultiFileSeedsListedSizeIncludingEmpty() throws Exception {
+        StoragePath sized = StoragePath.of("s3://bucket/data/f1.parquet");
+        StoragePath empty = StoragePath.of("s3://bucket/data/empty.parquet");
+        FileList fileList = GlobExpander.fileListOf(
+            List.of(new StorageEntry(sized, 100, Instant.EPOCH), new StorageEntry(empty, 0, Instant.EPOCH)),
+            "s3://bucket/data/*.parquet"
+        );
+        RecordingMultiFileStorageProvider storageProvider = new RecordingMultiFileStorageProvider();
+        drainMultiFileOperator(storageProvider, fileList, sized);
+        assertEquals(
+            List.of(
+                new RecordingMultiFileStorageProvider.Call(sized, 100L, null),
+                new RecordingMultiFileStorageProvider.Call(empty, 0L, null)
+            ),
+            storageProvider.calls
+        );
+    }
+
+    public void testOpenNextMultiFileSeedsMtimeWhenKnown() throws Exception {
+        StoragePath path = StoragePath.of("s3://bucket/data/f1.parquet");
+        Instant mtime = Instant.ofEpochMilli(1_700_000_000_000L);
+        FileList fileList = GlobExpander.fileListOf(List.of(new StorageEntry(path, 100, mtime)), "s3://bucket/data/*.parquet");
+        RecordingMultiFileStorageProvider storageProvider = new RecordingMultiFileStorageProvider();
+        drainMultiFileOperator(storageProvider, fileList, path);
+        assertEquals(List.of(new RecordingMultiFileStorageProvider.Call(path, 100L, mtime)), storageProvider.calls);
+    }
+
+    /**
      * Collision regression (the {@code date=<one-day>} shape). A Hive partition key {@code year}
      * shadows a same-named physical column, so the unified attributes are [id, value, year] with
      * {@code year} the appended partition column, while the file-backed {@link ColumnMapping} is
@@ -3594,6 +3625,42 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
 
     // ===== Helpers =====
 
+    private static void drainMultiFileOperator(StorageProvider storageProvider, FileList fileList, StoragePath path) {
+        FormatReader formatReader = new PageCountingFormatReader(new AtomicInteger());
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(mock(BlockFactory.class));
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).fileList(fileList).build();
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                pages.add(page);
+            }
+        }
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+        operator.close();
+    }
+
     private static CloseableIterator<Page> emptyIterator() {
         return new CloseableIterator<>() {
             @Override
@@ -3793,6 +3860,30 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
 
         @Override
         public void close() {}
+    }
+
+    private static class RecordingMultiFileStorageProvider extends StubMultiFileStorageProvider {
+        record Call(StoragePath path, Long length, Instant lastModified) {}
+
+        final List<Call> calls = new ArrayList<>();
+
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            calls.add(new Call(path, null, null));
+            return super.newObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            calls.add(new Call(path, length, null));
+            return super.newObject(path, length);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            calls.add(new Call(path, length, lastModified));
+            return super.newObject(path, length, lastModified);
+        }
     }
 
     private static class StubMultiFileStorageProvider implements StorageProvider {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -4369,6 +4369,29 @@ public class FileSplitProviderTests extends ESTestCase {
         verify(storage, never()).newObject(eq(path), eq(512L));
     }
 
+    public void testNewObjectForFile_fileLengthKeyAndMtimeUsesThreeArg() {
+        StoragePath path = StoragePath.of("file:///tmp/x.parquet");
+        StorageObject delegate = mock(StorageObject.class);
+        StorageProvider storage = mock(StorageProvider.class);
+        long mtime = 1_700_000_000_000L;
+        Instant modified = Instant.ofEpochMilli(mtime);
+        when(storage.newObject(path, 2000L, modified)).thenReturn(delegate);
+        FileSplit split = new FileSplit(
+            "file",
+            path,
+            0,
+            512L,
+            ".parquet",
+            Map.of(FileSplitProvider.FILE_LENGTH_KEY, Long.toString(2000L)),
+            Map.of(FileMetadataColumns.MODIFIED, mtime)
+        );
+        StorageObject got = FileSplitProvider.newObjectForFile(storage, split);
+        assertSame(delegate, got);
+        verify(storage).newObject(path, 2000L, modified);
+        verify(storage, never()).newObject(eq(path), eq(2000L));
+        verify(storage, never()).newObject(path);
+    }
+
     /**
      * Multi-group grouping must place each boundary into exactly one macro-split, and groups must
      * cover all boundaries in order without gaps.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -4291,6 +4291,84 @@ public class FileSplitProviderTests extends ESTestCase {
         verify(storage).newObject(path);
     }
 
+    public void testStorageObjectForSplit_partitionSizeAndMtimeSeedsFullFileObject() {
+        StoragePath path = StoragePath.of("file:///tmp/x.ndjson");
+        StorageObject delegate = mock(StorageObject.class);
+        StorageProvider storage = mock(StorageProvider.class);
+        long mtime = 1_700_000_000_000L;
+        Instant modified = Instant.ofEpochMilli(mtime);
+        when(storage.newObject(path, 2000L, modified)).thenReturn(delegate);
+        FileSplit split = new FileSplit(
+            "file",
+            path,
+            0,
+            512L,
+            ".ndjson",
+            Map.of(),
+            Map.of(FileMetadataColumns.SIZE, 2000L, FileMetadataColumns.MODIFIED, mtime)
+        );
+        StorageObject got = FileSplitProvider.storageObjectForSplit(storage, split);
+        assertThat(got, instanceOf(RangeStorageObject.class));
+        verify(storage).newObject(path, 2000L, modified);
+        verify(storage, never()).newObject(path, 512L, modified);
+        verify(storage, never()).newObject(eq(path), eq(512L));
+        verify(storage, never()).newObject(eq(path), eq(2000L));
+        verify(storage, never()).newObject(path);
+    }
+
+    public void testStorageObjectForSplit_partitionSizeIsFullFileNotSpan() {
+        StoragePath path = StoragePath.of("file:///tmp/x.ndjson");
+        StorageObject delegate = mock(StorageObject.class);
+        StorageProvider storage = mock(StorageProvider.class);
+        when(storage.newObject(path, 2000L)).thenReturn(delegate);
+        FileSplit split = new FileSplit("file", path, 10, 10L, ".ndjson", Map.of(), Map.of(FileMetadataColumns.SIZE, 2000L));
+        StorageObject got = FileSplitProvider.storageObjectForSplit(storage, split);
+        assertThat(got, instanceOf(RangeStorageObject.class));
+        RangeStorageObject range = (RangeStorageObject) got;
+        assertEquals(10, range.offset());
+        assertEquals(10L, range.length());
+        verify(storage).newObject(path, 2000L);
+        verify(storage, never()).newObject(eq(path), eq(10L));
+        verify(storage, never()).newObject(path);
+    }
+
+    public void testStorageObjectForSplit_zeroListedSizeIsKnownEmpty() {
+        StoragePath path = StoragePath.of("file:///tmp/empty.ndjson");
+        StorageObject delegate = mock(StorageObject.class);
+        StorageProvider storage = mock(StorageProvider.class);
+        when(storage.newObject(path, 0L)).thenReturn(delegate);
+        FileSplit split = new FileSplit("file", path, 0, 0L, ".ndjson", Map.of(), Map.of(FileMetadataColumns.SIZE, 0L));
+        FileSplitProvider.storageObjectForSplit(storage, split);
+        verify(storage).newObject(path, 0L);
+        verify(storage, never()).newObject(path);
+    }
+
+    public void testNewObjectForFile_returnsFullFileNotRangeWrapper() {
+        StoragePath path = StoragePath.of("file:///tmp/x.csv");
+        StorageObject delegate = mock(StorageObject.class);
+        StorageProvider storage = mock(StorageProvider.class);
+        when(storage.newObject(path, 2000L)).thenReturn(delegate);
+        FileSplit split = new FileSplit("file", path, 10, 10L, ".csv", Map.of(), Map.of(FileMetadataColumns.SIZE, 2000L));
+        StorageObject got = FileSplitProvider.newObjectForFile(storage, split);
+        assertSame(delegate, got);
+        verify(storage).newObject(path, 2000L);
+        verify(storage, never()).newObject(eq(path), eq(10L));
+        verify(storage, never()).newObject(path);
+    }
+
+    public void testStorageObjectForSplit_fileLengthKeySeedsWithoutPartitionSize() {
+        StoragePath path = StoragePath.of("file:///tmp/x.parquet");
+        StorageObject delegate = mock(StorageObject.class);
+        StorageProvider storage = mock(StorageProvider.class);
+        when(storage.newObject(path, 2000L)).thenReturn(delegate);
+        Map<String, Object> cfg = Map.of(FileSplitProvider.FILE_LENGTH_KEY, Long.toString(2000L));
+        FileSplit split = new FileSplit("file", path, 0, 512L, ".parquet", cfg, Map.of());
+        FileSplitProvider.storageObjectForSplit(storage, split);
+        verify(storage).newObject(path, 2000L);
+        verify(storage, never()).newObject(path);
+        verify(storage, never()).newObject(eq(path), eq(512L));
+    }
+
     /**
      * Multi-group grouping must place each boundary into exactly one macro-split, and groups must
      * cover all boundaries in order without gaps.


### PR DESCRIPTION
Path-only construction dropped listing length, so the first
length() probed the object store. Pass _file.size or
FILE_LENGTH_KEY (and mtime when known) into newObject. Size 0
is a real empty object, not unknown.