### PR TITLE
Fix DimensionValuesByteRefGroupingAggregatorFunctionTests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
@@ -130,7 +130,7 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
                 int group = groups.getInt(p);
                 int valueCount = valuesBlock.getValueCount(p);
                 if (valueCount == 0) {
-                    actualValues.put(group, List.of());
+                    actualValues.putIfAbsent(group, List.of());
                 } else {
                     int firstValueIndex = valuesBlock.getFirstValueIndex(p);
                     List<BytesRef> values = new ArrayList<>(valueCount);
@@ -138,7 +138,7 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
                         BytesRef dv = valuesBlock.getBytesRef(firstValueIndex + v, new BytesRef());
                         values.add(BytesRef.deepCopyOf(dv));
                     }
-                    actualValues.put(group, values);
+                    actualValues.putIfAbsent(group, values);
                 }
             }
             out.close();


### PR DESCRIPTION
In INITIAL mode, partial emissions can return the same group on multiple pages. The test expects the group’s first input value, but collected results using put, which overwrites earlier values. Because repeated groups receive different random values, this occasionally fails.

Changed both result-collection branches to putIfAbsent, preserving the first value, including nulls.

Closes #155069