### PR TITLE
Fix DFA rolling-upgrade mixed-cluster setup 404

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/yamlRestTest/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/yamlRestTest/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -2,16 +2,19 @@ setup:
   # Rolling upgrades can leave analytics tasks in a failed state when nodes restart
   # mid-run. Force-stop clears failed tasks so subsequent tests can start/stop cleanly.
   - do:
+      catch: missing
       ml.stop_data_frame_analytics:
         id: "old_cluster_outlier_detection_job"
         force: true
         allow_no_match: true
   - do:
+      catch: missing
       ml.stop_data_frame_analytics:
         id: "old_cluster_regression_job"
         force: true
         allow_no_match: true
   - do:
+      catch: missing
       ml.stop_data_frame_analytics:
         id: "old_cluster_classification_job"
         force: true

--- a/x-pack/qa/rolling-upgrade/src/yamlRestTest/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/yamlRestTest/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -1,24 +1,14 @@
 setup:
   # Rolling upgrades can leave analytics tasks in a failed state when nodes restart
   # mid-run. Force-stop clears failed tasks so subsequent tests can start/stop cleanly.
+  # Wildcard + allow_no_match accepts both a successful stop (jobs exist) and no match
+  # (old_cluster phase skipped on smart-retry). catch: missing wrongly requires 404 when stop succeeds.
   - do:
-      catch: missing
       ml.stop_data_frame_analytics:
-        id: "old_cluster_outlier_detection_job"
+        id: "old_cluster_*"
         force: true
         allow_no_match: true
-  - do:
-      catch: missing
-      ml.stop_data_frame_analytics:
-        id: "old_cluster_regression_job"
-        force: true
-        allow_no_match: true
-  - do:
-      catch: missing
-      ml.stop_data_frame_analytics:
-        id: "old_cluster_classification_job"
-        force: true
-        allow_no_match: true
+  - match: { stopped: true }
 
 ---
 "Get old outlier_detection job":

--- a/x-pack/qa/rolling-upgrade/src/yamlRestTest/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/yamlRestTest/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -1,14 +1,12 @@
 setup:
   # Rolling upgrades can leave analytics tasks in a failed state when nodes restart
   # mid-run. Force-stop clears failed tasks so subsequent tests can start/stop cleanly.
-  # Wildcard + allow_no_match accepts both a successful stop (jobs exist) and no match
-  # (old_cluster phase skipped on smart-retry). catch: missing wrongly requires 404 when stop succeeds.
+  # Use a wildcard because allow_no_match does not suppress a missing exact ID.
   - do:
       ml.stop_data_frame_analytics:
         id: "old_cluster_*"
         force: true
         allow_no_match: true
-  - match: { stopped: true }
 
 ---
 "Get old outlier_detection job":


### PR DESCRIPTION
## Summary
- Use wildcard DFA cleanup with `allow_no_match` so mixed-cluster setup accepts present or absent old-cluster jobs.
- Keep main and supported-version backports aligned with the 8.19 retry fix in #158687.