### PR TITLE
[ESQL] ESQL:DS: Cap Parquet I/O at heap/8

### DIFF
--- a/docs/changelog/158689.yaml
+++ b/docs/changelog/158689.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158689
+summary: "ESQL:DS: Cap Parquet I/O at heap/8"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
@@ -115,6 +116,31 @@ final class CoalescedRangeReader {
         Executor executor,
         ActionListener<CoalescedRangeResult> listener
     ) {
+        return readCoalesced(storageObject, ranges, maxCoalesceGap, breaker, null, null, executor, listener);
+    }
+
+    static Releasable readCoalesced(
+        StorageObject storageObject,
+        List<ByteRange> ranges,
+        long maxCoalesceGap,
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark ioWatermark,
+        Executor executor,
+        ActionListener<CoalescedRangeResult> listener
+    ) {
+        return readCoalesced(storageObject, ranges, maxCoalesceGap, breaker, ioWatermark, null, executor, listener);
+    }
+
+    static Releasable readCoalesced(
+        StorageObject storageObject,
+        List<ByteRange> ranges,
+        long maxCoalesceGap,
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark ioWatermark,
+        @Nullable ParquetIoWatermark.AdmitHold admitHold,
+        Executor executor,
+        ActionListener<CoalescedRangeResult> listener
+    ) {
         if (ranges.isEmpty()) {
             listener.onResponse(new CoalescedRangeResult(Map.of(), () -> {}));
             return () -> {};
@@ -133,8 +159,9 @@ final class CoalescedRangeReader {
         AtomicReference<Exception> firstFailure = new AtomicReference<>();
 
         // Bridge the circuit breaker to the SPI's factory once, here at the boundary, so
-        // backends do not need to know about CircuitBreaker at all.
-        DirectBufferFactory factory = DirectBufferFactory.forBreaker(breaker);
+        // backends do not need to know about CircuitBreaker at all. The watermark wrapper
+        // charges actual allocated bytes beside REQUEST so footer estimates cannot drift.
+        DirectBufferFactory factory = ParquetIoWatermark.bufferFactory(breaker, ioWatermark, admitHold);
 
         for (MergedRange mr : merged) {
             inflight.add(storageObject.startReadBytesAsync(mr.offset, mr.length, factory, executor, new ActionListener<>() {
@@ -204,6 +231,16 @@ final class CoalescedRangeReader {
         long maxCoalesceGap,
         CircuitBreaker breaker
     ) throws IOException {
+        return readCoalescedSync(storageObject, ranges, maxCoalesceGap, breaker, null);
+    }
+
+    static CoalescedRangeResult readCoalescedSync(
+        StorageObject storageObject,
+        List<ByteRange> ranges,
+        long maxCoalesceGap,
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark ioWatermark
+    ) throws IOException {
         if (ranges.isEmpty()) {
             return new CoalescedRangeResult(Map.of(), () -> {});
         }
@@ -217,7 +254,7 @@ final class CoalescedRangeReader {
 
         Map<ByteRange, ByteBuffer> results = new HashMap<>(ranges.size());
         List<Releasable> buffers = new ArrayList<>(merged.size());
-        DirectBufferFactory factory = DirectBufferFactory.forBreaker(breaker);
+        DirectBufferFactory factory = ParquetIoWatermark.bufferFactory(breaker, ioWatermark);
         try {
             for (MergedRange mr : merged) {
                 int length = (int) mr.length();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -69,6 +69,16 @@ final class ColumnChunkPrefetcher {
         Set<String> projectedColumns,
         CircuitBreaker breaker
     ) {
+        return fetchSync(storageObject, block, projectedColumns, breaker, null);
+    }
+
+    static PrefetchedChunks fetchSync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark
+    ) {
         try {
             List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
             if (ranges.isEmpty()) {
@@ -82,7 +92,13 @@ final class ColumnChunkPrefetcher {
             );
             validateSyncRanges(block, projectedColumns, ranges);
             return buildPrefetched(
-                CoalescedRangeReader.readCoalescedSync(storageObject, ranges, CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP, breaker)
+                CoalescedRangeReader.readCoalescedSync(
+                    storageObject,
+                    ranges,
+                    CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
+                    breaker,
+                    ioWatermark
+                )
             );
         } catch (Exception e) {
             throw ParquetReadFailures.wrap(e, "Failed to fetch column chunks for row group at [" + block.getStartingPos() + "]");
@@ -99,6 +115,27 @@ final class ColumnChunkPrefetcher {
         Set<String> projectedColumns,
         CircuitBreaker breaker
     ) {
+        return prefetchAsync(storageObject, block, projectedColumns, breaker, null);
+    }
+
+    static CompletableFuture<PrefetchedChunks> prefetchAsync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark
+    ) {
+        return prefetchAsync(storageObject, block, projectedColumns, breaker, ioWatermark, null);
+    }
+
+    static CompletableFuture<PrefetchedChunks> prefetchAsync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark,
+        ParquetIoWatermark.AdmitHold admitHold
+    ) {
         List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
         if (ranges.isEmpty()) {
             return CompletableFuture.completedFuture(new PrefetchedChunks(new TreeMap<>(), () -> {}));
@@ -111,7 +148,7 @@ final class ColumnChunkPrefetcher {
             block.getTotalByteSize()
         );
 
-        return prefetchCoalesced(storageObject, ranges, breaker);
+        return prefetchCoalesced(storageObject, ranges, breaker, ioWatermark, admitHold);
     }
 
     /**
@@ -121,7 +158,13 @@ final class ColumnChunkPrefetcher {
      * what {@link CoalescedRangeReader#readCoalesced} will allocate.
      */
     static long computePrefetchBytes(BlockMetaData block, Set<String> projectedColumns) {
-        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
+        return computePrefetchBytes(computeColumnChunkRanges(block, projectedColumns));
+    }
+
+    /**
+     * Coalesced allocation size of {@code ranges}, matching {@link CoalescedRangeReader#readCoalesced}.
+     */
+    static long computePrefetchBytes(List<CoalescedRangeReader.ByteRange> ranges) {
         if (ranges.isEmpty()) {
             return 0;
         }
@@ -271,6 +314,20 @@ final class ColumnChunkPrefetcher {
         long rowGroupRowCount,
         CircuitBreaker breaker
     ) {
+        return fetchSync(storageObject, block, projectedColumns, rowRanges, metadata, rowGroupOrdinal, rowGroupRowCount, breaker, null);
+    }
+
+    static PrefetchedChunks fetchSync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        RowRanges rowRanges,
+        PreloadedRowGroupMetadata metadata,
+        int rowGroupOrdinal,
+        long rowGroupRowCount,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark
+    ) {
         try {
             List<CoalescedRangeReader.ByteRange> ranges = computeFilteredPageRanges(
                 block,
@@ -292,7 +349,13 @@ final class ColumnChunkPrefetcher {
             );
             validateSyncRanges(block, projectedColumns, ranges);
             return buildPrefetched(
-                CoalescedRangeReader.readCoalescedSync(storageObject, ranges, CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP, breaker)
+                CoalescedRangeReader.readCoalescedSync(
+                    storageObject,
+                    ranges,
+                    CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
+                    breaker,
+                    ioWatermark
+                )
             );
         } catch (Exception e) {
             throw ParquetReadFailures.wrap(e, "Failed to fetch column chunks for row group at [" + block.getStartingPos() + "]");
@@ -309,8 +372,48 @@ final class ColumnChunkPrefetcher {
         long rowGroupRowCount,
         CircuitBreaker breaker
     ) {
+        return prefetchAsync(storageObject, block, projectedColumns, rowRanges, metadata, rowGroupOrdinal, rowGroupRowCount, breaker, null);
+    }
+
+    static CompletableFuture<PrefetchedChunks> prefetchAsync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        RowRanges rowRanges,
+        PreloadedRowGroupMetadata metadata,
+        int rowGroupOrdinal,
+        long rowGroupRowCount,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark
+    ) {
+        return prefetchAsync(
+            storageObject,
+            block,
+            projectedColumns,
+            rowRanges,
+            metadata,
+            rowGroupOrdinal,
+            rowGroupRowCount,
+            breaker,
+            ioWatermark,
+            null
+        );
+    }
+
+    static CompletableFuture<PrefetchedChunks> prefetchAsync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        RowRanges rowRanges,
+        PreloadedRowGroupMetadata metadata,
+        int rowGroupOrdinal,
+        long rowGroupRowCount,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark,
+        ParquetIoWatermark.AdmitHold admitHold
+    ) {
         if (rowRanges == null || rowRanges.isAll()) {
-            return prefetchAsync(storageObject, block, projectedColumns, breaker);
+            return prefetchAsync(storageObject, block, projectedColumns, breaker, ioWatermark, admitHold);
         }
 
         List<CoalescedRangeReader.ByteRange> ranges = computeFilteredPageRanges(
@@ -327,7 +430,7 @@ final class ColumnChunkPrefetcher {
 
         logger.debug("Async prefetching [{}] filtered page ranges for row group at [{}]", ranges.size(), block.getStartingPos());
 
-        return prefetchCoalesced(storageObject, ranges, breaker);
+        return prefetchCoalesced(storageObject, ranges, breaker, ioWatermark, admitHold);
     }
 
     /**
@@ -336,7 +439,9 @@ final class ColumnChunkPrefetcher {
     private static CompletableFuture<PrefetchedChunks> prefetchCoalesced(
         StorageObject storageObject,
         List<CoalescedRangeReader.ByteRange> ranges,
-        CircuitBreaker breaker
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark,
+        ParquetIoWatermark.AdmitHold admitHold
     ) {
         CompletableFuture<PrefetchedChunks> result = new CompletableFuture<>();
         Releasable cancelIo = CoalescedRangeReader.readCoalesced(
@@ -344,6 +449,8 @@ final class ColumnChunkPrefetcher {
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
             breaker,
+            ioWatermark,
+            admitHold,
             Runnable::run,
             new ActionListener<>() {
                 @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -540,10 +540,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * would exceed {@code heap / 8}; an empty queue may take one node-wide overshoot so the
      * scan cannot stall. Stops early when no more surviving row groups remain. Breaker
      * accounting for the prefetched bytes happens inside {@code readBytesAsync}. Actual
-     * {@code DirectReadBuffer} sizes are charged to the watermark at alloc; the
-     * {@link ParquetIoWatermark.AdmitHold} estimate is dropped then (or when the future settles
-     * if I/O never allocated). If a prefetch trips the breaker it surfaces as a failed future
-     * and {@link #takePendingPrefetch} falls back to breaker-accounted sync I/O for that row group.
+     * {@code DirectReadBuffer} sizes are charged to the watermark at alloc; each alloc drops
+     * that many leftover {@link ParquetIoWatermark.AdmitHold} estimate bytes so sibling in-flight
+     * GETs stay charged. Leftover estimate is dropped when the future settles. If a prefetch
+     * trips the breaker it surfaces as a failed future and {@link #takePendingPrefetch} falls
+     * back to breaker-accounted sync I/O for that row group.
      */
     private void fillPrefetchQueue(int fromOrdinal) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -2194,8 +2194,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 if (head.ordinal() == expectedOrdinal) {
                     break;
                 }
-                assert head.ordinal() <= expectedOrdinal
-                    : "prefetch queue has ordinal " + head.ordinal() + " > expected " + expectedOrdinal;
+                if (head.ordinal() > expectedOrdinal) {
+                    // Current group was not queued (zero-byte filtered ranges). Keep later work.
+                    return selection;
+                }
                 selection.stage(dequeuePending());
             }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -103,9 +103,10 @@ import java.util.function.IntConsumer;
  * prefetch, the iterator drains speculative reservations and retries that row group through
  * the same breaker-accounted chunk machinery using synchronous I/O. The fallback can therefore
  * also be refused when the row group's chunks do not fit. {@link #fillPrefetchQueue} admits
- * unread queued groups under {@link #MAX_QUEUED_PREFETCH_BYTES}; {@link #prefetchDepth} is a
- * count wish, not the memory bound. An empty queue always starts the next group so the scan
- * cannot stall.
+ * unread queued groups under {@link #MAX_QUEUED_PREFETCH_BYTES} and the node-wide
+ * {@link ParquetIoWatermark}; {@link #prefetchDepth} is a count wish, not the memory bound.
+ * An empty queue may start the next group so the scan cannot stall, subject to one node-wide
+ * overshoot when that group exceeds the watermark.
  *
  * <p><b>Trivially-passes guard:</b> when late materialization is enabled and row-group
  * statistics prove every row satisfies the pushed filter ({@link TriviallyPassesChecker}),
@@ -534,13 +535,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     /**
      * Fills the prefetch queue starting from ordinal {@code fromOrdinal}. Admission requires
      * both {@code size < prefetchDepth} (count wish) and, when the queue is non-empty,
-     * {@code queuedPrefetchBytes + next <= prefetchByteBudget}. An empty queue always
-     * dispatches the next surviving group, even when that group exceeds the byte cap, so the
+     * {@code queuedPrefetchBytes + next <= prefetchByteBudget}. The node-wide
+     * {@link ParquetIoWatermark} is a second gate: look-ahead is refused when {@code used + next}
+     * would exceed {@code heap / 8}; an empty queue may take one node-wide overshoot so the
      * scan cannot stall. Stops early when no more surviving row groups remain. Breaker
-     * accounting for the prefetched bytes happens inside {@code readBytesAsync} via
-     * {@code DirectBufferFactory.forBreaker}; if a prefetch trips the breaker it surfaces as
-     * a failed future and {@link #takePendingPrefetch} falls back to breaker-accounted sync I/O
-     * for that row group.
+     * accounting for the prefetched bytes happens inside {@code readBytesAsync}. Actual
+     * {@code DirectReadBuffer} sizes are charged to the watermark at alloc; the
+     * {@link ParquetIoWatermark.AdmitHold} estimate is dropped then (or when the future settles
+     * if I/O never allocated). If a prefetch trips the breaker it surfaces as a failed future
+     * and {@link #takePendingPrefetch} falls back to breaker-accounted sync I/O for that row group.
      */
     private void fillPrefetchQueue(int fromOrdinal) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
@@ -565,18 +568,6 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
                 continue;
             }
-            long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, phaseColumns);
-            if (prefetchBytes <= 0) {
-                nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
-                continue;
-            }
-            // Remaining capacity, not a sum: a huge footer length cannot wrap a long add and
-            // admit a group we already know cannot fit. When queued already exceeds the cap
-            // (empty-queue overrun), the right-hand side is negative and any positive
-            // prefetchBytes fails the check.
-            if (pendingPrefetches.isEmpty() == false && prefetchBytes > prefetchByteBudget - queuedPrefetchBytes) {
-                break;
-            }
             try {
                 RowRanges nextRowRanges = allRowRanges != null && nextOrdinal < allRowRanges.length ? allRowRanges[nextOrdinal] : null;
                 RowRanges thresholdRanges = thresholdRowRanges(nextOrdinal, nextBlock);
@@ -600,23 +591,72 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 if (nextRowRanges != null && canSynchronizeListRows(nextOrdinal) == false) {
                     nextRowRanges = null;
                 }
-                CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future;
+                long prefetchBytes;
                 if (nextRowRanges != null) {
-                    future = ColumnChunkPrefetcher.prefetchAsync(
-                        storageObject,
-                        nextBlock,
-                        phaseColumns,
-                        nextRowRanges,
-                        preloadedMetadata,
-                        nextOrdinal,
-                        nextBlock.getRowCount(),
-                        breaker
+                    prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(
+                        ColumnChunkPrefetcher.computeFilteredPageRanges(
+                            nextBlock,
+                            nextRowRanges,
+                            preloadedMetadata,
+                            nextOrdinal,
+                            phaseColumns,
+                            nextBlock.getRowCount()
+                        )
                     );
                 } else {
-                    future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, phaseColumns, breaker);
+                    prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, phaseColumns);
                 }
-                pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future, prefetchBytes));
-                queuedPrefetchBytes += prefetchBytes;
+                if (prefetchBytes <= 0) {
+                    nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
+                    continue;
+                }
+                // Remaining capacity, not a sum: a huge footer length cannot wrap a long add and
+                // admit a group we already know cannot fit. When queued already exceeds the cap
+                // (empty-queue overrun), the right-hand side is negative and any positive
+                // prefetchBytes fails the check.
+                if (pendingPrefetches.isEmpty() == false && prefetchBytes > prefetchByteBudget - queuedPrefetchBytes) {
+                    break;
+                }
+                boolean lookahead = pendingPrefetches.isEmpty() == false;
+                ParquetIoWatermark.AdmitHold admitHold = formatReader.ioWatermark().tryAdmit(prefetchBytes, lookahead);
+                if (admitHold == null) {
+                    break;
+                }
+                boolean reserved = true;
+                try {
+                    CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future;
+                    if (nextRowRanges != null) {
+                        future = ColumnChunkPrefetcher.prefetchAsync(
+                            storageObject,
+                            nextBlock,
+                            phaseColumns,
+                            nextRowRanges,
+                            preloadedMetadata,
+                            nextOrdinal,
+                            nextBlock.getRowCount(),
+                            breaker,
+                            formatReader.ioWatermark(),
+                            admitHold
+                        );
+                    } else {
+                        future = ColumnChunkPrefetcher.prefetchAsync(
+                            storageObject,
+                            nextBlock,
+                            phaseColumns,
+                            breaker,
+                            formatReader.ioWatermark(),
+                            admitHold
+                        );
+                    }
+                    future.whenComplete((ignored, error) -> admitHold.drop());
+                    reserved = false;
+                    pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future, prefetchBytes));
+                    queuedPrefetchBytes += prefetchBytes;
+                } finally {
+                    if (reserved) {
+                        admitHold.drop();
+                    }
+                }
             } catch (Exception e) {
                 logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextOrdinal, fileLocation, e.getMessage());
                 break;
@@ -1339,7 +1379,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                             storageObjectForFallback(),
                             block,
                             predicateColumnPaths,
-                            breaker
+                            breaker,
+                            formatReader.ioWatermark()
                         );
                         currentChunksReleasable = fetched.release();
                         chunks = fetched.chunks();
@@ -1399,7 +1440,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                             preloadedMetadata,
                             rowGroupOrdinal,
                             block.getRowCount(),
-                            breaker
+                            breaker,
+                            formatReader.ioWatermark()
                         );
                         currentChunksReleasable = fetched.release();
                         chunks = fetched.chunks();
@@ -1906,7 +1948,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = null;
         try {
             future = rowRanges == null
-                ? ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projectionOnlyColumnPaths, breaker)
+                ? ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projectionOnlyColumnPaths, breaker, formatReader.ioWatermark())
                 : ColumnChunkPrefetcher.prefetchAsync(
                     storageObject,
                     block,
@@ -1915,7 +1957,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     preloadedMetadata,
                     rowGroupOrdinal,
                     block.getRowCount(),
-                    breaker
+                    breaker,
+                    formatReader.ioWatermark()
                 );
             return StorageRetryCancellation.getWithCancellationChecks(future);
         } catch (TaskCancelledException cancelled) {
@@ -1944,7 +1987,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 // currentChunksReleasable, so the trivially-passes path can keep Phase 1 live.
                 drainPendingPrefetches(detachPendingPrefetches());
                 return rowRanges == null
-                    ? ColumnChunkPrefetcher.fetchSync(storageObjectForFallback(), block, projectionOnlyColumnPaths, breaker)
+                    ? ColumnChunkPrefetcher.fetchSync(
+                        storageObjectForFallback(),
+                        block,
+                        projectionOnlyColumnPaths,
+                        breaker,
+                        formatReader.ioWatermark()
+                    )
                     : ColumnChunkPrefetcher.fetchSync(
                         storageObjectForFallback(),
                         block,
@@ -1953,7 +2002,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                         preloadedMetadata,
                         rowGroupOrdinal,
                         block.getRowCount(),
-                        breaker
+                        breaker,
+                        formatReader.ioWatermark()
                     );
             } catch (Throwable retryFailure) {
                 if (retryFailure != asyncFailure) {
@@ -2292,6 +2342,17 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     void refillPrefetchQueue() {
         cancelPendingPrefetch();
         fillPrefetchQueue(nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1));
+    }
+
+    /**
+     * Test-only: attempt more look-ahead without cancelling in-flight groups. Used to assert the
+     * node watermark refuses extra groups while the current overshoot is still held.
+     */
+    void fillLookaheadPrefetches() {
+        int fromOrdinal = pendingPrefetches.isEmpty()
+            ? nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1)
+            : nextSurvivingRowGroupOrdinal(pendingPrefetches.peekLast().ordinal() + 1);
+        fillPrefetchQueue(fromOrdinal);
     }
 
     private PendingPrefetch dequeuePending() {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -290,7 +290,13 @@ final class ParquetColumnExtractor implements ColumnExtractor {
             ColumnChunkPrefetcher.PrefetchedChunks>[]) new CompletableFuture<?>[buckets.size()];
         for (int i = 0; i < buckets.size(); i++) {
             BlockMetaData block = blocks.get(buckets.get(i).rowGroupIndex);
-            futures[i] = ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projection, blockFactory.breaker());
+            futures[i] = ColumnChunkPrefetcher.prefetchAsync(
+                storageObject,
+                block,
+                projection,
+                blockFactory.breaker(),
+                reader.ioWatermark()
+            );
         }
 
         // result[c][b] = block for column c in bucket b (bucket-visit order). We populate this

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -62,16 +62,19 @@ import java.util.function.Consumer;
  *       bucket, and per-bucket sorting on a handful of positions is essentially free. Row groups
  *       with no surviving position are never opened. The bucket structure is column-agnostic, so
  *       it is reused across every requested column.</li>
- *   <li><b>Per-row-group async prefetch, dispatched in parallel.</b> One
+ *   <li><b>Per-row-group async prefetch, admitted then dispatched in parallel.</b> One
  *       {@link ColumnChunkPrefetcher#prefetchAsync} call per visited row group, each carrying the
  *       full multi-column projection. {@link CoalescedRangeReader} merges adjacent column-chunk
  *       ranges <em>within</em> the row group (column chunks in one row group are written
  *       contiguously, so the multi-column projection coalesces naturally) and dispatches the
- *       merged ranges to {@link StorageObject#readBytesAsync}. All buckets fan out at once: the
- *       extractor never blocks on row group {@code k}'s bytes before issuing row group
- *       {@code k+1}'s GET. Per-request RTT/TTFB cost goes from {@code O(row groups × columns)}
- *       down to roughly {@code O(row groups)}, and the wall-clock cost of the slowest GET is no
- *       longer additive across row groups.</li>
+ *       merged ranges to {@link StorageObject#readBytesAsync}. Each bucket takes a
+ *       {@link ParquetIoWatermark} hold so TopN extraction competes with scan look-ahead for
+ *       {@code heap / 8}; later buckets are look-ahead and wait for a live group to decode when
+ *       the cap would be exceeded. Within that cap, buckets still fan out before decode: the
+ *       extractor does not wait on row group {@code k}'s bytes before issuing {@code k+1}'s GET.
+ *       Per-request RTT/TTFB cost goes from {@code O(row groups × columns)} down to roughly
+ *       {@code O(admitted row groups)}, and the wall-clock cost of the slowest in-flight GET is
+ *       no longer additive across those groups.</li>
  *   <li><b>Pipelined decode in arrival order.</b> A small bounded queue receives each
  *       per-bucket prefetch as it completes. The decode loop drains buckets in arrival order,
  *       running flat ({@link PageColumnReader#readBatchSparse}) or list (skip/read driven by a
@@ -279,25 +282,15 @@ final class ParquetColumnExtractor implements ColumnExtractor {
             projection.add(String.join(".", info.descriptor().getPath()));
         }
 
-        // Per-bucket async prefetch dispatch. We do NOT block on any one fetch before kicking
-        // off the next: every bucket's GET is in flight before we touch the first byte. This is
-        // the parallelism win — for N visited row groups end-to-end latency drops from
+        // Per-bucket async prefetch is admitted against the node watermark then dispatched.
+        // Within the cap we do NOT block on any one fetch before kicking off the next: every
+        // admitted bucket's GET is in flight before we touch the first byte. This is the
+        // parallelism win — for N admitted row groups end-to-end latency drops from
         // (slowest GET) + (sum of decodes) towards max(slowest GET, fastest GET + sum of decodes),
-        // bounded by the per-query concurrency budget which sits inside readBytesAsync.
-        List<BlockMetaData> blocks = ownedFooter.getBlocks();
+        // bounded by heap/8 and the per-query concurrency budget inside readBytesAsync.
         @SuppressWarnings("unchecked")
         CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks>[] futures = (CompletableFuture<
             ColumnChunkPrefetcher.PrefetchedChunks>[]) new CompletableFuture<?>[buckets.size()];
-        for (int i = 0; i < buckets.size(); i++) {
-            BlockMetaData block = blocks.get(buckets.get(i).rowGroupIndex);
-            futures[i] = ColumnChunkPrefetcher.prefetchAsync(
-                storageObject,
-                block,
-                projection,
-                blockFactory.breaker(),
-                reader.ioWatermark()
-            );
-        }
 
         // result[c][b] = block for column c in bucket b (bucket-visit order). We populate this
         // out of order as buckets' prefetches arrive; the per-column concat happens once every
@@ -343,10 +336,12 @@ final class ParquetColumnExtractor implements ColumnExtractor {
     }
 
     /**
-     * Drains the per-bucket prefetch futures in arrival order, decoding every requested column
-     * for each bucket as soon as its bytes land. Decode of bucket {@code i} therefore overlaps
-     * with the still in-flight S3 reads for the slower buckets — the wall-clock cost of the
-     * slowest GET is no longer additive with decode time.
+     * Admits and dispatches per-bucket prefetches against {@link ParquetIoWatermark}, then drains
+     * them in arrival order, decoding every requested column for each bucket as soon as its bytes
+     * land. Later buckets are look-ahead: if the cap would be exceeded, dispatch waits until a
+     * live group is decoded and its buffers released. Decode of bucket {@code i} still overlaps
+     * with slower in-flight GETs that already admitted — the wall-clock cost of those GETs is no
+     * longer additive with decode time.
      *
      * <p>If any prefetch fails, every other in-flight prefetch is cancelled (or its result
      * discarded once it lands) and the original failure is rethrown.
@@ -381,10 +376,26 @@ final class ParquetColumnExtractor implements ColumnExtractor {
 
         // Use CompletableFuture.anyOf in a draining loop so we always pick the next-completed
         // future. Track which slots are still pending via a mutable view over the futures array
-        // — completed slots get nulled out and skipped on subsequent iterations.
+        // — completed slots get nulled out and skipped on subsequent iterations. Dispatch is
+        // interleaved so a rejected look-ahead can retry after decode releases watermark bytes.
+        int dispatched = 0;
         int pending = futures.length;
         try {
             while (pending > 0) {
+                dispatched = dispatchAdmittedPrefetches(buckets, blocks, projection, blockFactory, futures, dispatched);
+                if (inFlightCount(futures) == 0) {
+                    if (dispatched >= buckets.size()) {
+                        throw new IllegalStateException("no in-flight prefetch but buckets remain");
+                    }
+                    futures[dispatched] = startBucketPrefetch(
+                        blocks.get(buckets.get(dispatched).rowGroupIndex),
+                        projection,
+                        blockFactory,
+                        false,
+                        false
+                    );
+                    dispatched++;
+                }
                 int bucketIdx = waitForNextCompleted(futures);
                 ColumnChunkPrefetcher.PrefetchedChunks prefetchedResult;
                 try {
@@ -467,6 +478,92 @@ final class ParquetColumnExtractor implements ColumnExtractor {
             }
             throw t;
         }
+    }
+
+    /**
+     * Dispatches later buckets as look-ahead until {@link ParquetIoWatermark#tryAdmit} refuses.
+     * The first in-flight group is current work and may take the node-wide overshoot.
+     */
+    private int dispatchAdmittedPrefetches(
+        List<Bucket> buckets,
+        List<BlockMetaData> blocks,
+        Set<String> projection,
+        BlockFactory blockFactory,
+        CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks>[] futures,
+        int dispatched
+    ) {
+        while (dispatched < buckets.size()) {
+            boolean lookahead = inFlightCount(futures) > 0;
+            CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = startBucketPrefetch(
+                blocks.get(buckets.get(dispatched).rowGroupIndex),
+                projection,
+                blockFactory,
+                lookahead,
+                true
+            );
+            if (future == null) {
+                break;
+            }
+            futures[dispatched] = future;
+            dispatched++;
+        }
+        return dispatched;
+    }
+
+    /**
+     * Starts one bucket GET. When {@code requireHold} is true, a refused look-ahead returns
+     * {@code null} so the caller can decode and retry. When false, a refused admit still
+     * dispatches so extraction cannot stall if another query holds the overshoot slot.
+     */
+    @Nullable
+    private CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> startBucketPrefetch(
+        BlockMetaData block,
+        Set<String> projection,
+        BlockFactory blockFactory,
+        boolean lookahead,
+        boolean requireHold
+    ) {
+        long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(block, projection);
+        ParquetIoWatermark watermark = reader.ioWatermark();
+        final ParquetIoWatermark.AdmitHold hold;
+        if (prefetchBytes > 0L) {
+            hold = watermark.tryAdmit(prefetchBytes, lookahead);
+            if (hold == null && requireHold) {
+                return null;
+            }
+        } else {
+            hold = null;
+        }
+        boolean reserved = hold != null;
+        try {
+            CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = ColumnChunkPrefetcher.prefetchAsync(
+                storageObject,
+                block,
+                projection,
+                blockFactory.breaker(),
+                watermark,
+                hold
+            );
+            if (hold != null) {
+                future.whenComplete((ignored, error) -> hold.drop());
+                reserved = false;
+            }
+            return future;
+        } finally {
+            if (reserved) {
+                hold.drop();
+            }
+        }
+    }
+
+    private static int inFlightCount(CompletableFuture<?>[] futures) {
+        int count = 0;
+        for (CompletableFuture<?> future : futures) {
+            if (future != null) {
+                count++;
+            }
+        }
+        return count;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -144,6 +144,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
      */
     private final FooterByteCache footerBytes;
 
+    /**
+     * Node-wide cap on retained Parquet I/O bytes ({@code heap / 8}). Shared by every derived
+     * reader the same way as the footer caches, so concurrent queries compete for one budget.
+     */
+    private final ParquetIoWatermark ioWatermark;
+
     private final BlockFactory blockFactory;
     private final FilterCompat.Filter pushedFilter;
     private final ParquetPushedExpressions pushedExpressions;
@@ -358,7 +364,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             Map.of(),
             Set.of(),
             FooterByteCache.fromSettings(settings),
-            ParsedFooterCache.fromSettings(settings, ParquetFormatReader::estimateFooterWeightBytes)
+            ParsedFooterCache.fromSettings(settings, ParquetFormatReader::estimateFooterWeightBytes),
+            ParquetIoWatermark.forHeap()
         );
     }
 
@@ -379,7 +386,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             Map.of(),
             Set.of(),
             FooterByteCache.fromSettings(Settings.EMPTY),
-            ParsedFooterCache.fromSettings(Settings.EMPTY, ParquetFormatReader::estimateFooterWeightBytes)
+            ParsedFooterCache.fromSettings(Settings.EMPTY, ParquetFormatReader::estimateFooterWeightBytes),
+            ParquetIoWatermark.forHeap()
         );
     }
 
@@ -393,7 +401,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         Map<String, String> declaredDateFormats,
         Set<String> declaredTypeColumns,
         FooterByteCache footerBytes,
-        ParsedFooterCache<ParquetMetadata> parsedFooters
+        ParsedFooterCache<ParquetMetadata> parsedFooters,
+        ParquetIoWatermark ioWatermark
     ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
@@ -405,6 +414,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         this.declaredTypeColumns = declaredTypeColumns;
         this.footerBytes = footerBytes;
         this.parsedFooters = parsedFooters;
+        if (ioWatermark == null) {
+            throw new IllegalArgumentException("ioWatermark");
+        }
+        this.ioWatermark = ioWatermark;
     }
 
     /**
@@ -424,7 +437,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredDateFormats,
             declaredTypeColumns,
             footerBytes,
-            parsedFooters
+            parsedFooters,
+            ioWatermark
         );
     }
 
@@ -444,7 +458,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredDateFormats,
             declaredTypeColumns,
             footerBytes,
-            parsedFooters
+            parsedFooters,
+            ioWatermark
         );
     }
 
@@ -464,7 +479,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 declaredDateFormats,
                 declaredTypeColumns,
                 footerBytes,
-                parsedFooters
+                parsedFooters,
+                ioWatermark
             );
         }
         if (pushedFilter instanceof FilterCompat.Filter filter) {
@@ -478,7 +494,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 declaredDateFormats,
                 declaredTypeColumns,
                 footerBytes,
-                parsedFooters
+                parsedFooters,
+                ioWatermark
             );
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
@@ -492,7 +509,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 declaredDateFormats,
                 declaredTypeColumns,
                 footerBytes,
-                parsedFooters
+                parsedFooters,
+                ioWatermark
             );
         }
         return this;
@@ -510,7 +528,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredDateFormats,
             declaredTypeColumns,
             footerBytes,
-            parsedFooters
+            parsedFooters,
+            ioWatermark
         );
     }
 
@@ -536,7 +555,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             Map.copyOf(physicalNameToPattern),
             declaredTypeColumns,
             footerBytes,
-            parsedFooters
+            parsedFooters,
+            ioWatermark
         );
     }
 
@@ -563,8 +583,33 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredDateFormats,
             Set.copyOf(physicalDeclaredColumns),
             footerBytes,
-            parsedFooters
+            parsedFooters,
+            ioWatermark
         );
+    }
+
+    /**
+     * Test-only: share a watermark across readers so node-wide admission can be asserted with a
+     * tiny limit. Production readers keep the heap-derived instance from the root constructor.
+     */
+    ParquetFormatReader withIoWatermark(ParquetIoWatermark watermark) {
+        return new ParquetFormatReader(
+            blockFactory,
+            pushedFilter,
+            pushedExpressions,
+            forceBaselinePath,
+            optimizedReader,
+            dynamicThreshold,
+            declaredDateFormats,
+            declaredTypeColumns,
+            footerBytes,
+            parsedFooters,
+            watermark
+        );
+    }
+
+    ParquetIoWatermark ioWatermark() {
+        return ioWatermark;
     }
 
     @Override
@@ -821,7 +866,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
 
     @Override
     public SourceMetadata metadata(StorageObject object) throws IOException {
-        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, footerBytes, blockFactory.breaker());
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(
+            object,
+            footerBytes,
+            blockFactory.breaker(),
+            ioWatermark
+        );
         ParquetReadOptions options = readOptionsBuilder().build();
 
         try (ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, options)) {
@@ -1482,7 +1532,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             // it emits any other column. Pushed filters, late materialization, page skipping, and
             // row-group skipping all stay on — each surviving row carries its identity, and the
             // matching extractor binds those identities back to the file's full footer.
-            ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, footerBytes, blockFactory.breaker());
+            ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(
+                object,
+                footerBytes,
+                blockFactory.breaker(),
+                ioWatermark
+            );
             long footerStartNanos = System.nanoTime();
             ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, readOptionsBuilder().build());
             counters.addFooterRead(System.nanoTime() - footerStartNanos, sizeOrZero(object), reader.getFooter().getBlocks().size());
@@ -1559,7 +1614,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
 
     @Override
     public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
-        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, footerBytes, blockFactory.breaker());
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(
+            object,
+            footerBytes,
+            blockFactory.breaker(),
+            ioWatermark
+        );
         // Take the parsed footer straight from the cache rather than opening a ParquetFileReader.
         // This method reads no data bytes at all (only row-group metadata and the schema), but
         // ParquetFileReader.open would allocate the adapter's sliding window and reserve it on the
@@ -1861,7 +1921,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 object,
                 rangeEnd - rangeStart,
                 footerBytes,
-                blockFactory.breaker()
+                blockFactory.breaker(),
+                ioWatermark
             );
             ParquetReadOptions rangeOptions = readOptionsBuilder().withRange(rangeStart, rangeEnd).build();
             // Footer resolution order:
@@ -2161,7 +2222,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             indexColumnPaths.columnIndexPaths(),
             indexColumnPaths.offsetIndexPaths(),
             offsetIndexRowGroupLimit,
-            blockFactory.breaker()
+            blockFactory.breaker(),
+            ioWatermark
         );
         boolean metadataHandedOff = false;
         try {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermark.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermark.java
@@ -80,9 +80,9 @@ final class ParquetIoWatermark {
     }
 
     /**
-     * {@link #tryReserve} plus a one-shot {@link AdmitHold} so the footer estimate is dropped
-     * when the first real buffer is allocated (or when the prefetch future settles if I/O never
-     * allocated). Returns {@code null} when admission refuses.
+     * {@link #tryReserve} plus an {@link AdmitHold} so the footer estimate is swapped for
+     * actual buffer sizes as they allocate, and leftover estimate is dropped when the prefetch
+     * future settles. Returns {@code null} when admission refuses.
      */
     @Nullable
     AdmitHold tryAdmit(long bytes, boolean lookahead) {
@@ -96,8 +96,8 @@ final class ParquetIoWatermark {
      * Unconditional charge used for buffers that must exist (sliding window at open, actual
      * coalesced {@code DirectReadBuffer} size). Admission of look-ahead happens in
      * {@link #tryReserve}. When a prefetch already {@link #tryAdmit}ted a footer estimate,
-     * {@link #accountingFactory(CircuitBreaker, AdmitHold)} drops that hold on the first alloc so
-     * {@code used} tracks retained arrays rather than estimate plus actual.
+     * {@link #accountingFactory(CircuitBreaker, AdmitHold)} drops that many estimate bytes on
+     * each alloc so in-flight sibling GETs keep their hold until they allocate.
      */
     void forceAdd(long bytes) {
         if (bytes < 0L) {
@@ -137,8 +137,9 @@ final class ParquetIoWatermark {
     /**
      * Factory that charges this watermark with the actual allocated length beside the REQUEST
      * breaker, and releases both on {@link DirectReadBuffer#close()}. {@code admitHold} is a
-     * {@link #tryAdmit} estimate dropped on the first successful alloc so in-flight GETs are
-     * not counted twice. A later {@link AdmitHold#drop()} is a no-op once that happened.
+     * {@link #tryAdmit} estimate; each alloc drops that many leftover estimate bytes so a
+     * coalesced group of many GETs does not open a look-ahead hole after the first buffer.
+     * {@link AdmitHold#drop()} clears any remainder when the prefetch future settles.
      */
     DirectBufferFactory accountingFactory(CircuitBreaker breaker, @Nullable AdmitHold admitHold) {
         DirectBufferFactory inner = DirectBufferFactory.forBreaker(breaker);
@@ -148,7 +149,7 @@ final class ParquetIoWatermark {
             try {
                 wrapped = account(allocated, len);
                 if (admitHold != null) {
-                    admitHold.drop();
+                    admitHold.drop(len);
                 }
                 return wrapped;
             } catch (Throwable t) {
@@ -194,24 +195,41 @@ final class ParquetIoWatermark {
     }
 
     /**
-     * Footer-estimate reservation that is released exactly once: on first buffer alloc, or when
-     * the prefetch future completes if I/O never allocated.
+     * Footer-estimate reservation released as real buffers allocate ({@link #drop(long)}) and
+     * cleared when the prefetch future settles ({@link #drop()}).
      */
     static final class AdmitHold {
         private final ParquetIoWatermark watermark;
-        private final long bytes;
-        private final AtomicBoolean dropped;
+        private final AtomicLong remaining;
 
         private AdmitHold(ParquetIoWatermark watermark, long bytes) {
             this.watermark = watermark;
-            this.bytes = bytes;
-            this.dropped = new AtomicBoolean(bytes <= 0L);
+            this.remaining = new AtomicLong(Math.max(0L, bytes));
+        }
+
+        /**
+         * Drops up to {@code bytes} of leftover estimate, swapping that slice for a retained
+         * array charged by {@link #forceAdd}. Sibling in-flight ranges keep their estimate.
+         */
+        void drop(long bytes) {
+            if (bytes <= 0L) {
+                return;
+            }
+            while (true) {
+                long current = remaining.get();
+                if (current <= 0L) {
+                    return;
+                }
+                long release = Math.min(current, bytes);
+                if (remaining.compareAndSet(current, current - release)) {
+                    watermark.release(release);
+                    return;
+                }
+            }
         }
 
         void drop() {
-            if (dropped.compareAndSet(false, true)) {
-                watermark.release(bytes);
-            }
+            drop(Long.MAX_VALUE);
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermark.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermark.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Node-scoped admission limit on retained Parquet I/O bytes (prefetch buffers and sliding
+ * windows). Copied from the ClickHouse parquet high-watermark shape: cap at {@code heap / 8},
+ * shared by every query on the node. Crossing the limit does not fail the query; the REQUEST
+ * circuit breaker remains the hard stop. Look-ahead is refused once {@code used + next} would
+ * exceed the cap. One in-flight group may overshoot when it is larger than the remaining budget,
+ * so a scan cannot stall; that overshoot is node-wide, not per iterator.
+ */
+final class ParquetIoWatermark {
+
+    static final int HEAP_DIVISOR = 8;
+
+    private final long limit;
+    private final AtomicLong used = new AtomicLong();
+
+    static ParquetIoWatermark forHeap() {
+        long heapBytes = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes();
+        return new ParquetIoWatermark(Math.max(1L, heapBytes / HEAP_DIVISOR));
+    }
+
+    ParquetIoWatermark(long limit) {
+        if (limit < 1L) {
+            throw new IllegalArgumentException("limit must be at least 1, got: " + limit);
+        }
+        this.limit = limit;
+    }
+
+    /**
+     * Attempts to reserve {@code bytes} of retained I/O. {@code lookahead} is true when the
+     * caller already has a live or queued group (DuckDB-style: no extra job once over budget).
+     * Returns {@code false} without throwing; never a query failure.
+     */
+    boolean tryReserve(long bytes, boolean lookahead) {
+        if (bytes < 0L) {
+            throw new IllegalArgumentException("bytes must be non-negative, got: " + bytes);
+        }
+        if (bytes == 0L) {
+            return true;
+        }
+        while (true) {
+            long current = used.get();
+            long next = current + bytes;
+            if (next < 0L) {
+                return false;
+            }
+            if (next <= limit) {
+                if (used.compareAndSet(current, next)) {
+                    return true;
+                }
+                continue;
+            }
+            if (lookahead || current > limit) {
+                if (used.get() != current) {
+                    continue;
+                }
+                return false;
+            }
+            if (used.compareAndSet(current, next)) {
+                return true;
+            }
+        }
+    }
+
+    /**
+     * {@link #tryReserve} plus a one-shot {@link AdmitHold} so the footer estimate is dropped
+     * when the first real buffer is allocated (or when the prefetch future settles if I/O never
+     * allocated). Returns {@code null} when admission refuses.
+     */
+    @Nullable
+    AdmitHold tryAdmit(long bytes, boolean lookahead) {
+        if (tryReserve(bytes, lookahead) == false) {
+            return null;
+        }
+        return new AdmitHold(this, bytes);
+    }
+
+    /**
+     * Unconditional charge used for buffers that must exist (sliding window at open, actual
+     * coalesced {@code DirectReadBuffer} size). Admission of look-ahead happens in
+     * {@link #tryReserve}. When a prefetch already {@link #tryAdmit}ted a footer estimate,
+     * {@link #accountingFactory(CircuitBreaker, AdmitHold)} drops that hold on the first alloc so
+     * {@code used} tracks retained arrays rather than estimate plus actual.
+     */
+    void forceAdd(long bytes) {
+        if (bytes < 0L) {
+            throw new IllegalArgumentException("bytes must be non-negative, got: " + bytes);
+        }
+        if (bytes == 0L) {
+            return;
+        }
+        used.addAndGet(bytes);
+    }
+
+    void release(long bytes) {
+        if (bytes < 0L) {
+            throw new IllegalArgumentException("bytes must be non-negative, got: " + bytes);
+        }
+        if (bytes == 0L) {
+            return;
+        }
+        used.updateAndGet(current -> {
+            long next = current - bytes;
+            return next < 0L ? 0L : next;
+        });
+    }
+
+    long used() {
+        return used.get();
+    }
+
+    long limit() {
+        return limit;
+    }
+
+    DirectBufferFactory accountingFactory(CircuitBreaker breaker) {
+        return accountingFactory(breaker, null);
+    }
+
+    /**
+     * Factory that charges this watermark with the actual allocated length beside the REQUEST
+     * breaker, and releases both on {@link DirectReadBuffer#close()}. {@code admitHold} is a
+     * {@link #tryAdmit} estimate dropped on the first successful alloc so in-flight GETs are
+     * not counted twice. A later {@link AdmitHold#drop()} is a no-op once that happened.
+     */
+    DirectBufferFactory accountingFactory(CircuitBreaker breaker, @Nullable AdmitHold admitHold) {
+        DirectBufferFactory inner = DirectBufferFactory.forBreaker(breaker);
+        return len -> {
+            DirectReadBuffer allocated = inner.allocate(len);
+            DirectReadBuffer wrapped = null;
+            try {
+                wrapped = account(allocated, len);
+                if (admitHold != null) {
+                    admitHold.drop();
+                }
+                return wrapped;
+            } catch (Throwable t) {
+                try {
+                    if (wrapped != null) {
+                        wrapped.close();
+                    } else {
+                        allocated.close();
+                    }
+                } catch (Throwable closeFailure) {
+                    t.addSuppressed(closeFailure);
+                }
+                throw t;
+            }
+        };
+    }
+
+    private DirectReadBuffer account(DirectReadBuffer inner, int length) {
+        AtomicBoolean released = new AtomicBoolean();
+        DirectReadBuffer wrapped = new DirectReadBuffer(inner.buffer(), () -> {
+            try {
+                inner.close();
+            } finally {
+                if (released.compareAndSet(false, true)) {
+                    release(length);
+                }
+            }
+        });
+        forceAdd(length);
+        return wrapped;
+    }
+
+    static DirectBufferFactory bufferFactory(CircuitBreaker breaker, @Nullable ParquetIoWatermark watermark) {
+        return bufferFactory(breaker, watermark, null);
+    }
+
+    static DirectBufferFactory bufferFactory(
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark watermark,
+        @Nullable AdmitHold admitHold
+    ) {
+        return watermark == null ? DirectBufferFactory.forBreaker(breaker) : watermark.accountingFactory(breaker, admitHold);
+    }
+
+    /**
+     * Footer-estimate reservation that is released exactly once: on first buffer alloc, or when
+     * the prefetch future completes if I/O never allocated.
+     */
+    static final class AdmitHold {
+        private final ParquetIoWatermark watermark;
+        private final long bytes;
+        private final AtomicBoolean dropped;
+
+        private AdmitHold(ParquetIoWatermark watermark, long bytes) {
+            this.watermark = watermark;
+            this.bytes = bytes;
+            this.dropped = new AtomicBoolean(bytes <= 0L);
+        }
+
+        void drop() {
+            if (dropped.compareAndSet(false, true)) {
+                watermark.release(bytes);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -11,6 +11,7 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.UninitializedArrays;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
@@ -49,6 +50,8 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
     private final FooterByteCache footerBytes;
     private final int windowSize;
     private final CircuitBreaker breaker;
+    @Nullable
+    private final ParquetIoWatermark ioWatermark;
 
     /**
      * Optional pre-warmed cache installed before {@code RowGroupFilter} runs. When set, reads
@@ -84,7 +87,16 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
      *                    splits, streams, and derived readers) share one cache
      */
     public ParquetStorageObjectAdapter(StorageObject storageObject, FooterByteCache footerBytes, CircuitBreaker breaker) {
-        this(storageObject, footerBytes, DEFAULT_WINDOW_SIZE, breaker);
+        this(storageObject, footerBytes, DEFAULT_WINDOW_SIZE, breaker, null);
+    }
+
+    ParquetStorageObjectAdapter(
+        StorageObject storageObject,
+        FooterByteCache footerBytes,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark
+    ) {
+        this(storageObject, footerBytes, DEFAULT_WINDOW_SIZE, breaker, ioWatermark);
     }
 
     /**
@@ -105,16 +117,34 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         CircuitBreaker breaker
     ) {
         int windowSize = (int) Math.min(Math.max(rangeBytes, DEFAULT_WINDOW_SIZE), MAX_WINDOW_SIZE);
-        return new ParquetStorageObjectAdapter(storageObject, footerBytes, windowSize, breaker);
+        return new ParquetStorageObjectAdapter(storageObject, footerBytes, windowSize, breaker, null);
     }
 
-    private ParquetStorageObjectAdapter(StorageObject storageObject, FooterByteCache footerBytes, int windowSize, CircuitBreaker breaker) {
+    static ParquetStorageObjectAdapter forRange(
+        StorageObject storageObject,
+        long rangeBytes,
+        FooterByteCache footerBytes,
+        CircuitBreaker breaker,
+        ParquetIoWatermark ioWatermark
+    ) {
+        int windowSize = (int) Math.min(Math.max(rangeBytes, DEFAULT_WINDOW_SIZE), MAX_WINDOW_SIZE);
+        return new ParquetStorageObjectAdapter(storageObject, footerBytes, windowSize, breaker, ioWatermark);
+    }
+
+    private ParquetStorageObjectAdapter(
+        StorageObject storageObject,
+        FooterByteCache footerBytes,
+        int windowSize,
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark ioWatermark
+    ) {
         if (storageObject == null) {
             throw new QlIllegalArgumentException("storageObject cannot be null");
         }
         this.storageObject = storageObject;
         this.footerBytes = footerBytes;
         this.breaker = breaker;
+        this.ioWatermark = ioWatermark;
         try {
             this.length = storageObject.length();
             this.cacheKey = FooterByteCache.Key.keyFor(storageObject);
@@ -165,6 +195,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             length,
             windowSize,
             breaker,
+            ioWatermark,
             this::currentPreWarmedChunks
         );
     }
@@ -214,6 +245,8 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         private final long length;
         private final int windowSize;
         private final CircuitBreaker breaker;
+        @Nullable
+        private final ParquetIoWatermark ioWatermark;
         private final byte[] window;
 
         /**
@@ -237,6 +270,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             long length,
             int windowSize,
             CircuitBreaker breaker,
+            @Nullable ParquetIoWatermark ioWatermark,
             Supplier<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> preWarmedChunksSupplier
         ) {
             this.storageObject = storageObject;
@@ -245,11 +279,18 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             this.length = length;
             this.windowSize = windowSize;
             this.breaker = LocalCircuitBreaker.forAsyncIo(breaker);
+            this.ioWatermark = ioWatermark;
             this.breaker.addEstimateBytesAndMaybeBreak(windowSize, WINDOW_BREAKER_LABEL);
+            if (this.ioWatermark != null) {
+                this.ioWatermark.forceAdd(windowSize);
+            }
             byte[] allocated;
             try {
                 allocated = UninitializedArrays.newByteArray(windowSize);
             } catch (Throwable t) {
+                if (this.ioWatermark != null) {
+                    this.ioWatermark.release(windowSize);
+                }
                 this.breaker.addWithoutBreaking(-windowSize);
                 throw t;
             }
@@ -568,6 +609,9 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 windowStart = -1;
                 windowLength = 0;
                 breaker.addWithoutBreaking(-windowSize);
+                if (ioWatermark != null) {
+                    ioWatermark.release(windowSize);
+                }
             }
         }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
@@ -19,6 +19,7 @@ import org.apache.parquet.schema.MessageType;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.UninitializedArrays;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
@@ -207,6 +208,28 @@ final class PreloadedRowGroupMetadata implements Releasable {
         int offsetIndexRowGroupLimit,
         CircuitBreaker breaker
     ) {
+        return preload(
+            reader,
+            storageObject,
+            predicateColumnPaths,
+            columnIndexPaths,
+            offsetIndexPaths,
+            offsetIndexRowGroupLimit,
+            breaker,
+            null
+        );
+    }
+
+    static PreloadedRowGroupMetadata preload(
+        ParquetFileReader reader,
+        StorageObject storageObject,
+        Set<String> predicateColumnPaths,
+        Set<String> columnIndexPaths,
+        Set<String> offsetIndexPaths,
+        int offsetIndexRowGroupLimit,
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark ioWatermark
+    ) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
         if (rowGroups.isEmpty()) {
             return empty();
@@ -222,7 +245,8 @@ final class PreloadedRowGroupMetadata implements Releasable {
                     columnIndexPaths,
                     offsetIndexPaths,
                     offsetIndexRowGroupLimit,
-                    breaker
+                    breaker,
+                    ioWatermark
                 );
             } catch (Exception e) {
                 logger.debug("Coalesced metadata preload failed, falling back to sequential: {}", e.getMessage());
@@ -255,7 +279,8 @@ final class PreloadedRowGroupMetadata implements Releasable {
         Set<String> columnIndexPaths,
         Set<String> offsetIndexPaths,
         int offsetIndexRowGroupLimit,
-        CircuitBreaker breaker
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark ioWatermark
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
         List<RangeMeta> rangeMetas = new ArrayList<>();
@@ -308,6 +333,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
             breaker,
+            ioWatermark,
             Runnable::run,
             future
         );
@@ -379,7 +405,8 @@ final class PreloadedRowGroupMetadata implements Releasable {
                     offsetIndexes,
                     preWarmedChunks,
                     storageObject,
-                    breaker
+                    breaker,
+                    ioWatermark
                 );
             } catch (Throwable e) {
                 try {
@@ -485,7 +512,8 @@ final class PreloadedRowGroupMetadata implements Releasable {
         Map<String, OffsetIndex> offsetIndexes,
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> preWarmedChunks,
         StorageObject storageObject,
-        CircuitBreaker breaker
+        CircuitBreaker breaker,
+        @Nullable ParquetIoWatermark ioWatermark
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = omittedDictionaryRanges(
             rowGroups,
@@ -503,6 +531,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
             breaker,
+            ioWatermark,
             Runnable::run,
             future
         );

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
@@ -200,10 +200,10 @@ public class OptimizedFilteredReaderTests extends ESTestCase {
 
         try (CloseableIterator<Page> iter = reader.read(storage, FormatReadContext.of(null, 1024))) {
             OptimizedParquetColumnIterator optimized = (OptimizedParquetColumnIterator) iter;
-            // The fixture's first projected row group exceeds SHALLOW_PREFETCH_BYTES, so
-            // computePrefetchDepth deliberately seeds both ordinals before the first hasNext().
-            assertTrue("fixture must queue the empty and matching row groups together", optimized.prefetchDepth() > 1);
-            assertEquals(List.of(0, 1), optimized.pendingPrefetchOrdinals());
+            // Empty page-index ranges admit no I/O, so fillPrefetchQueue skips ordinal 0 and
+            // seeds only the matching group. Later prefetch must still be intact.
+            assertTrue("fixture must queue ahead of the empty first group", optimized.prefetchDepth() > 1);
+            assertEquals(List.of(1), optimized.pendingPrefetchOrdinals());
             assertTrue("first row group must have empty page-index ranges", optimized.rowRanges(0).isEmpty());
             assertFalse("later row group must retain matching page-index ranges", optimized.rowRanges(1).isEmpty());
             assertEquals("matching row group must be prefetched once during queue seeding", 1, storage.largeAsyncReads.get());
@@ -774,7 +774,8 @@ public class OptimizedFilteredReaderTests extends ESTestCase {
         ) {
             for (int id : new int[] { 0, 1_000, 500, 500 }) {
                 // Two values form each row group; together they cross SHALLOW_PREFETCH_BYTES so
-                // both groups are queued before the empty first group's ranges are consumed.
+                // depth is >1 and the matching group is queued while the empty first group is
+                // skipped (zero filtered bytes).
                 byte[] payload = new byte[4_250_000];
                 payload[0] = (byte) id;
                 writer.write(groupFactory.newGroup().append("id", id).append("payload", Binary.fromConstantByteArray(payload)));

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
@@ -831,6 +831,30 @@ public class ParquetColumnExtractorTests extends ESTestCase {
     }
 
     /**
+     * Later buckets are look-ahead on {@link ParquetIoWatermark}. A 1-byte cap admits the first
+     * group as the node-wide overshoot and serialises the rest; extract must still finish.
+     */
+    public void testExtractWithTinyIoWatermark() throws IOException {
+        byte[] data = writeMultiRowGroupFile(2000);
+        StorageObject so = createStorageObject(data);
+        ParquetMetadata fullFooter = loadFooter(so);
+        assertTrue("expected multiple row groups", fullFooter.getBlocks().size() >= 3);
+        long rg0Rows = fullFooter.getBlocks().get(0).getRowCount();
+        long rg1Rows = fullFooter.getBlocks().get(1).getRowCount();
+        long[] survivors = new long[] { 0L, rg0Rows + 1, rg0Rows + rg1Rows + 1 };
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory).withIoWatermark(new ParquetIoWatermark(1));
+        try (ColumnExtractor extractor = new ParquetColumnExtractor(so, reader, fullFooter, ErrorPolicy.PERMISSIVE)) {
+            try (Block block = extractor.extract("v", survivors, blockFactory)) {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(survivors.length, ints.getPositionCount());
+                for (int i = 0; i < survivors.length; i++) {
+                    assertEquals((int) survivors[i], ints.getInt(i));
+                }
+            }
+        }
+    }
+
+    /**
      * Struct-leaf columns (e.g. {@code "event.action"}) must be extractable via the deferred
      * TopN path. The two bugs this exercises: (1) {@code resolveColumnInfo} previously returned
      * {@code null} for dotted names because it only checked top-level fields; (2)

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermarkTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermarkTests.java
@@ -94,6 +94,24 @@ public class ParquetIoWatermarkTests extends ESTestCase {
         assertEquals(0, breaker.getUsed());
     }
 
+    public void testAdmitHoldDropsPerAllocKeepsInFlightEstimate() throws Exception {
+        CircuitBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        ParquetIoWatermark watermark = new ParquetIoWatermark(1024);
+        ParquetIoWatermark.AdmitHold hold = watermark.tryAdmit(152, false);
+        assertNotNull(hold);
+        DirectBufferFactory factory = watermark.accountingFactory(breaker, hold);
+        DirectReadBuffer first = factory.allocate(10);
+        assertEquals("first alloc must not drop the rest of the in-flight group", 152, watermark.used());
+        DirectReadBuffer second = factory.allocate(10);
+        assertEquals(152, watermark.used());
+        hold.drop();
+        assertEquals("leftover estimate released; retained arrays remain", 20, watermark.used());
+        first.close();
+        second.close();
+        assertEquals(0, watermark.used());
+        assertEquals(0, breaker.getUsed());
+    }
+
     public void testTryReserveRetriesWhenReleaseLandsOverLimit() {
         ParquetIoWatermark watermark = new ParquetIoWatermark(10);
         assertTrue(watermark.tryReserve(50, false));

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermarkTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetIoWatermarkTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ParquetIoWatermarkTests extends ESTestCase {
+
+    public void testForHeapIsOneEighth() {
+        ParquetIoWatermark watermark = ParquetIoWatermark.forHeap();
+        long heapBytes = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes();
+        assertEquals(Math.max(1L, heapBytes / ParquetIoWatermark.HEAP_DIVISOR), watermark.limit());
+    }
+
+    public void testAdmitUntilLimitThenRejectLookahead() {
+        ParquetIoWatermark watermark = new ParquetIoWatermark(100);
+        assertTrue(watermark.tryReserve(40, false));
+        assertTrue(watermark.tryReserve(40, true));
+        assertEquals(80, watermark.used());
+        assertFalse("look-ahead must not cross the cap", watermark.tryReserve(30, true));
+        assertEquals(80, watermark.used());
+        assertTrue("current work may take the one overshoot", watermark.tryReserve(30, false));
+        assertEquals(110, watermark.used());
+        assertFalse("second overshoot is refused even for current work", watermark.tryReserve(1, false));
+        assertFalse(watermark.tryReserve(1, true));
+    }
+
+    public void testOneNodeWideOvershootForGroupLargerThanLimit() {
+        ParquetIoWatermark watermark = new ParquetIoWatermark(50);
+        assertTrue(watermark.tryReserve(80, false));
+        assertEquals(80, watermark.used());
+        assertFalse(watermark.tryReserve(80, false));
+        assertFalse(watermark.tryReserve(1, true));
+    }
+
+    public void testReleaseAllowsNextIterator() {
+        ParquetIoWatermark watermark = new ParquetIoWatermark(50);
+        assertTrue(watermark.tryReserve(80, false));
+        watermark.release(80);
+        assertEquals(0, watermark.used());
+        assertTrue("release returns the overshoot slot", watermark.tryReserve(80, false));
+        assertEquals(80, watermark.used());
+    }
+
+    public void testZeroReserveIsNoop() {
+        ParquetIoWatermark watermark = new ParquetIoWatermark(10);
+        assertTrue(watermark.tryReserve(0, true));
+        assertTrue(watermark.tryReserve(0, false));
+        assertEquals(0, watermark.used());
+        watermark.forceAdd(0);
+        watermark.release(0);
+        assertEquals(0, watermark.used());
+    }
+
+    public void testAccountingFactoryChargesAndReleasesBesideRequest() throws Exception {
+        CircuitBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        ParquetIoWatermark watermark = new ParquetIoWatermark(1024);
+        DirectBufferFactory factory = watermark.accountingFactory(breaker);
+        DirectReadBuffer buffer = factory.allocate(64);
+        assertEquals(64, watermark.used());
+        assertEquals(64, breaker.getUsed());
+        buffer.close();
+        assertEquals(0, watermark.used());
+        assertEquals(0, breaker.getUsed());
+    }
+
+    public void testAdmitHoldDroppedOnceOnAllocNotDoubleCounted() throws Exception {
+        CircuitBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        ParquetIoWatermark watermark = new ParquetIoWatermark(1024);
+        ParquetIoWatermark.AdmitHold hold = watermark.tryAdmit(64, false);
+        assertNotNull(hold);
+        assertEquals(64, watermark.used());
+        DirectBufferFactory factory = watermark.accountingFactory(breaker, hold);
+        DirectReadBuffer buffer = factory.allocate(64);
+        assertEquals("alloc swaps the estimate for the retained array", 64, watermark.used());
+        hold.drop();
+        assertEquals("second drop is a no-op", 64, watermark.used());
+        buffer.close();
+        assertEquals(0, watermark.used());
+        assertEquals(0, breaker.getUsed());
+    }
+
+    public void testTryReserveRetriesWhenReleaseLandsOverLimit() {
+        ParquetIoWatermark watermark = new ParquetIoWatermark(10);
+        assertTrue(watermark.tryReserve(50, false));
+        watermark.release(50);
+        assertTrue("stale over-limit snapshot must not refuse after a concurrent release", watermark.tryReserve(10, false));
+        assertEquals(10, watermark.used());
+    }
+
+    public void testTryAdmitNullWhenLookaheadWouldExceed() {
+        ParquetIoWatermark watermark = new ParquetIoWatermark(50);
+        ParquetIoWatermark.AdmitHold current = watermark.tryAdmit(40, false);
+        assertNotNull(current);
+        assertNull(watermark.tryAdmit(20, true));
+        assertEquals(40, watermark.used());
+        current.drop();
+        assertEquals(0, watermark.used());
+    }
+
+    public void testConcurrentCurrentWorkTakesOneOvershoot() throws Exception {
+        ParquetIoWatermark watermark = new ParquetIoWatermark(10);
+        AtomicInteger admitted = new AtomicInteger();
+        CountDownLatch start = new CountDownLatch(1);
+        Thread[] threads = new Thread[8];
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    start.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                if (watermark.tryReserve(50, false)) {
+                    admitted.incrementAndGet();
+                }
+            });
+            threads[i].start();
+        }
+        start.countDown();
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        assertEquals("overshoot is node-wide", 1, admitted.get());
+        assertEquals(50, watermark.used());
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -106,6 +106,29 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         }
     }
 
+    public void testWindowChargesAndReleasesWatermarkBesideRequest() throws IOException {
+        byte[] data = new byte[2048];
+        randomBytes(data);
+        ParquetIoWatermark watermark = new ParquetIoWatermark(64 * 1024 * 1024);
+        CircuitBreaker limited = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(
+            createRangeReadStorageObject(data),
+            footerByteCache,
+            limited,
+            watermark
+        );
+        assertEquals(0, watermark.used());
+        try (SeekableInputStream stream = adapter.newStream()) {
+            assertEquals("window is charged at open, not lazily per miss", data.length, watermark.used());
+            assertEquals(data.length, limited.getUsed());
+            byte[] buf = new byte[64];
+            stream.readFully(buf);
+            assertEquals("fill reuses the ctor array; D (lazy/per-miss alloc) is not in this change", data.length, watermark.used());
+        }
+        assertEquals(0, watermark.used());
+        assertEquals(0, limited.getUsed());
+    }
+
     /**
      * Incomplete window fill (cancel / exception mid-GET) must {@code abortStream} the range
      * rather than {@code close()}, which on S3 would drain the remaining 4–16 MiB.

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchLatencySimulationTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchLatencySimulationTests.java
@@ -445,6 +445,54 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
     }
 
     /**
+     * Empty-queue overrun of a group larger than the node watermark is one slot for the process,
+     * not one per iterator. {@link OptimizedParquetColumnIterator#MAX_QUEUED_PREFETCH_BYTES} stays
+     * the local anti-runaway and is not retuned to the 10 MiB GET size.
+     */
+    public void testWatermarkEmptyQueueOverrunIsNodeWide() throws Exception {
+        byte[] parquetData = smallInt64MultiRowGroupFile();
+        FormatReadContext ctx = FormatReadContext.of(null, 1024);
+        ParquetIoWatermark probe = new ParquetIoWatermark(Long.MAX_VALUE / 8);
+        long oneIteratorUsed;
+        try (
+            CloseableIterator<Page> measured = new ParquetFormatReader(blockFactory, true).withIoWatermark(probe)
+                .read(new CountingStorageObject(parquetData, asyncIoExecutor), ctx)
+        ) {
+            OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) measured;
+            oneIteratorUsed = probe.used();
+            assertTrue("probe iterator must queue the current group", opi.pendingPrefetchCount() >= 1);
+            assertTrue(oneIteratorUsed > 0);
+        }
+        // Cap at what one iterator already retains (window + metadata + one group). A second
+        // iterator may forceAdd its window past the cap; empty-queue prefetch must not take a
+        // second overshoot.
+        ParquetIoWatermark watermark = new ParquetIoWatermark(oneIteratorUsed);
+        try (
+            CloseableIterator<Page> first = new ParquetFormatReader(blockFactory, true).withIoWatermark(watermark)
+                .read(new CountingStorageObject(parquetData, asyncIoExecutor), ctx);
+            CloseableIterator<Page> second = new ParquetFormatReader(blockFactory, true).withIoWatermark(watermark)
+                .read(new CountingStorageObject(parquetData, asyncIoExecutor), ctx)
+        ) {
+            OptimizedParquetColumnIterator opi1 = (OptimizedParquetColumnIterator) first;
+            OptimizedParquetColumnIterator opi2 = (OptimizedParquetColumnIterator) second;
+            growPrefetchDepth(opi1, 3);
+            growPrefetchDepth(opi2, 3);
+            opi1.fillLookaheadPrefetches();
+            opi2.fillLookaheadPrefetches();
+            int combined = opi1.pendingPrefetchCount() + opi2.pendingPrefetchCount();
+            assertEquals("empty-queue overrun stays one node, not one per iterator: " + combined, 1, combined);
+            assertEquals(32_000_000L, OptimizedParquetColumnIterator.MAX_QUEUED_PREFETCH_BYTES);
+        }
+        try (
+            CloseableIterator<Page> next = new ParquetFormatReader(blockFactory, true).withIoWatermark(watermark)
+                .read(new CountingStorageObject(parquetData, asyncIoExecutor), ctx)
+        ) {
+            OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) next;
+            assertEquals("release on close allows the next iterator", 1, opi.pendingPrefetchCount());
+        }
+    }
+
+    /**
      * Consume and cancel must keep queued-byte accounting in sync: a tiny budget scan returns
      * the same rows as an unconstrained read and drains the queue at exhaustion.
      */


### PR DESCRIPTION
Prefetch and sliding windows fit the REQUEST breaker but still OOM G1 on 512 MiB with 3 clients. Admit retained Parquet I/O against a node watermark. Look-ahead stops at the cap; one group may overshoot so the scan cannot stall.