### PR TITLE
Harden DFA rolling-upgrade yaml setup against missing jobs

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -54,15 +54,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.ManyRequestsIT
   method: testManyRequests
   issue: https://github.com/elastic/elasticsearch/issues/151627
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
-  issue: https://github.com/elastic/elasticsearch/issues/157941
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old outlier_detection job}
-  issue: https://github.com/elastic/elasticsearch/issues/157942
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Explain data frame analytics}
-  issue: https://github.com/elastic/elasticsearch/issues/157943
 - class: org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT
   method: testSnapshotUpgrader {upgradedNodes=1}
   issue: https://github.com/elastic/elasticsearch/issues/158091
@@ -100,18 +91,9 @@ tests:
 - class: org.elasticsearch.upgrades.XpackSystemIndicesUpgradeIT
   method: testUpgradeSystemIndexAndDataStream {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/158123
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Put an outlier_detection job on the mixed cluster}
-  issue: https://github.com/elastic/elasticsearch/issues/158132
 - class: org.elasticsearch.upgrades.CcrRollingUpgradeIT
   method: testUniDirectionalIndexFollowing
   issue: https://github.com/elastic/elasticsearch/issues/153050
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=upgraded_cluster/90_ml_data_frame_analytics_crud/Get mixed cluster outlier_detection job stats}
-  issue: https://github.com/elastic/elasticsearch/issues/158136
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=upgraded_cluster/90_ml_data_frame_analytics_crud/Get mixed cluster outlier_detection job}
-  issue: https://github.com/elastic/elasticsearch/issues/158137
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/preview_datafeed/Test preview aggregation datafeed with doc_count}
   issue: https://github.com/elastic/elasticsearch/issues/158138

--- a/x-pack/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -2,16 +2,19 @@ setup:
   # Rolling upgrades can leave analytics tasks in a failed state when nodes restart
   # mid-run. Force-stop clears failed tasks so subsequent tests can start/stop cleanly.
   - do:
+      catch: missing
       ml.stop_data_frame_analytics:
         id: "old_cluster_outlier_detection_job"
         force: true
         allow_no_match: true
   - do:
+      catch: missing
       ml.stop_data_frame_analytics:
         id: "old_cluster_regression_job"
         force: true
         allow_no_match: true
   - do:
+      catch: missing
       ml.stop_data_frame_analytics:
         id: "old_cluster_classification_job"
         force: true


### PR DESCRIPTION
## Summary
- Wrap mixed-cluster `ml.stop_data_frame_analytics` setup steps in `catch: missing` so exact-id stops do not 404 when old-cluster jobs are absent during BWC upgrade (`allow_no_match` only relaxes wildcards).
- Unmute the six related `90_ml_data_frame_analytics_crud` yaml tests on 8.19.

Closes #158136
Closes #158137
Closes #158132
Closes #157941
Closes #157942
Closes #157943