### PR TITLE
Stabilize MultiSearchTemplateIT testLargeMsearchTemplateDoesNotOom

### DIFF
--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -72,6 +72,8 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(SearchService.CCS_VERSION_CHECK_SETTING.getKey(), "true")
+            // The render-breaker test requires accounting on every coordinator; randomized no-op breakers ignore the limit.
+            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.getKey(), "memory")
             .build();
     }
 
@@ -211,7 +213,7 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
      * <p>
      * Render estimate = {@code 512 + source.length() + 2 × serialised(SearchSourceBuilder)}.
      * The ~16 KB template body produces a serialised builder of comparable size, so the total
-     * estimate is well above the 10 KB breaker limit. The first render therefore trips; every
+     * estimate is well above the 1 byte breaker limit. The first render therefore trips; every
      * subsequent slot is filled via the {@code renderCbe} fast-path without issuing any searches.
      */
     public void testLargeMsearchTemplateDoesNotOom() throws Exception {
@@ -246,18 +248,24 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
                 multiRequest.add(req);
             }
 
-            assertResponse(client().execute(MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION, multiRequest), response -> {
-                assertThat(response.getResponses().length, equalTo(numRequests));
-                // Once the first render trips the breaker, fillRemainingWithCbe fills every
-                // subsequent slot via the renderCbe fast-path. All slots must be CBE failures —
-                // a weaker "cbeCount > 0" check would miss a regression where only the first
-                // slot is a CBE and the rest execute as real searches.
-                for (Item item : response.getResponses()) {
-                    assertNotNull("every slot must be populated", item);
-                    assertTrue("every slot must be a CBE failure", item.isFailure());
-                    assertThat(item.getFailure(), instanceOf(CircuitBreakingException.class));
-                }
-            });
+            // Exercise every possible coordinator so a node with an ineffective breaker cannot escape coverage.
+            for (String node : internalCluster().getNodeNames()) {
+                assertResponse(
+                    internalCluster().client(node).execute(MustachePlugin.MULTI_SEARCH_TEMPLATE_ACTION, multiRequest),
+                    response -> {
+                        assertThat(response.getResponses().length, equalTo(numRequests));
+                        // Once the first render trips the breaker, fillRemainingWithCbe fills every
+                        // subsequent slot via the renderCbe fast-path. All slots must be CBE failures —
+                        // a weaker "cbeCount > 0" check would miss a regression where only the first
+                        // slot is a CBE and the rest execute as real searches.
+                        for (Item item : response.getResponses()) {
+                            assertNotNull("every slot must be populated", item);
+                            assertTrue("every slot must be a CBE failure on " + node, item.isFailure());
+                            assertThat(item.getFailure(), instanceOf(CircuitBreakingException.class));
+                        }
+                    }
+                );
+            }
         } finally {
             updateClusterSettings(
                 Settings.builder().putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey())


### PR DESCRIPTION
## Summary

Fixes #158428.

Pinned memory request breakers and extended the regression to every coordinator. The change is contained in a single integration-test file.

## Root cause

The test assumes a 1-byte limit guarantees early rejection, but a randomized no-op breaker lets rendering and searches proceed. The 8.19 setup precharges real breakers by 1 GB, so a shard node rejects the inbound query at its parent breaker. Search wraps that rejection in a phase exception, causing the direct-CircuitBreakingException assertion to fail.

## Correctness invariant

Every possible coordinator must reject the first render reservation before dispatching inner searches, populating every response slot with a direct CircuitBreakingException.

## Validation

- `GRADLE_USER_HOME="$PWD/.gradle/investigation-158428-cache" ./gradlew :modules:lang-mustache:internalClusterTest --tests org.elasticsearch.script.mustache.MultiSearchTemplateIT.testLargeMsearchTemplateDoesNotOom -Dtests.seed=3BE6555CE289A5D3 -Dtests.locale=hsb -Dtests.timezone=Africa/Malabo -Druntime.java=26 -Dtests.mutes.enabled=false --no-scan --console=plain > build/investigation-158428/implementation-targeted.log 2>&1`
- `GRADLE_USER_HOME="$PWD/.gradle/investigation-158428-cache" ./gradlew :modules:lang-mustache:internalClusterTest --tests org.elasticsearch.script.mustache.MultiSearchTemplateIT :modules:lang-mustache:precommit -Duser.home="$PWD/build/investigation-158428" -Dtests.seed=3BE6555CE289A5D3 -Dtests.locale=hsb -Dtests.timezone=Africa/Malabo -Druntime.java=26 -Dtests.mutes.enabled=false --no-daemon --no-scan --console=plain > build/investigation-158428/implementation-final.log 2>&1`
- `git diff --check`

## Contribution policies reviewed

- AGENTS.md
- CLAUDE.md
- CONTRIBUTING.md, including CLA, AI, style and testing requirements
- BUILDING.md
- TESTING.asciidoc
- .github/PULL_REQUEST_TEMPLATE.md
- [Elastic Contributor Agreement](https://www.elastic.co/contributor-agreement/)

## Adversarial review

No material blocker found in the complete one-file patch at 3903c2bff09f. The breaker override fixes the demonstrated setup defect without weakening assertions.

## AI-assisted contribution

This contribution was prepared with substantial assistance from OpenAI Codex through an automated engineering workflow. The contributor is responsible for the submission and will respond to maintainer review.