### PR TITLE
Answer keyword doc-values filters from the column

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/StringFormat.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/StringFormat.java
@@ -42,6 +42,7 @@ import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.columnar.ColumNARDocValuesFormat;
 import org.elasticsearch.columnar.ColumnarFieldType;
 import org.elasticsearch.columnar.ColumnarStringTermQuery;
+import org.elasticsearch.columnar.ScanBudget;
 import org.elasticsearch.columnar.string.ColumnarStringBinaryDocValues;
 import org.elasticsearch.columnar.string.DictionaryPolicy;
 import org.elasticsearch.columnar.string.DictionaryStringColumnReader;
@@ -396,7 +397,7 @@ public enum StringFormat {
 
         @Override
         public long queryTerm(BytesRef term) throws IOException {
-            return bulkCount(searcher, directoryReader.leaves().get(0), ColumnarStringTermQuery.term(FIELD, term));
+            return bulkCount(searcher, directoryReader.leaves().get(0), ColumnarStringTermQuery.term(FIELD, term, ScanBudget.UNLIMITED));
         }
 
         @Override
@@ -407,7 +408,11 @@ public enum StringFormat {
 
         @Override
         public long queryPrefix(BytesRef prefix) throws IOException {
-            return bulkCount(searcher, directoryReader.leaves().get(0), ColumnarStringTermQuery.prefix(FIELD, prefix));
+            return bulkCount(
+                searcher,
+                directoryReader.leaves().get(0),
+                ColumnarStringTermQuery.prefix(FIELD, prefix, ScanBudget.UNLIMITED)
+            );
         }
 
         private static long count(DocIdSetIterator matches) throws IOException {

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringAutomatonQuery.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringAutomatonQuery.java
@@ -11,6 +11,8 @@ package org.elasticsearch.columnar;
 
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
@@ -61,19 +63,28 @@ public final class ColumnarStringAutomatonQuery extends Query {
     private final String field;
     private final ByteRunAutomaton automaton;
     private final String description;
+    private final ScanBudget budget;
 
     /**
      * Documents whose value {@code automaton} accepts.
      *
-     * <p>{@code automaton} must be deterministic, as {@link ByteRunAutomaton} requires. {@code description}
-     * stands in for it in {@link #equals}, since an automaton has no equality worth caching on: it has to be
-     * derived from whatever produced the automaton, and two queries carrying the same description have to be
-     * the same query.
+     * <p>{@code automaton} must be deterministic, as {@link ByteRunAutomaton} requires. {@code description} names
+     * what the automaton was built from, for {@link #toString}; what the query is compared and cached on is the
+     * automaton itself, so a caller that spells its parameters differently cannot make two queries collide.
      */
-    public ColumnarStringAutomatonQuery(String field, Automaton automaton, String description) {
+    public ColumnarStringAutomatonQuery(String field, Automaton automaton, String description, ScanBudget budget) {
+        this(field, new ByteRunAutomaton(Objects.requireNonNull(automaton)), description, budget);
+    }
+
+    /**
+     * As above, for a caller that already compiled the automaton - a fuzzy query, whose {@link ByteRunAutomaton} is built
+     * by the query that defines the edit distance rather than by this one.
+     */
+    public ColumnarStringAutomatonQuery(String field, ByteRunAutomaton automaton, String description, ScanBudget budget) {
         this.field = Objects.requireNonNull(field);
-        this.automaton = new ByteRunAutomaton(Objects.requireNonNull(automaton));
+        this.automaton = Objects.requireNonNull(automaton);
         this.description = Objects.requireNonNull(description);
+        this.budget = Objects.requireNonNull(budget);
     }
 
     /**
@@ -82,18 +93,18 @@ public final class ColumnarStringAutomatonQuery extends Query {
      * <p>{@code foo} is a term, {@code foo*} a prefix and {@code *foo*} a value carrying a run of bytes, and
      * a column answers each of those without an automaton. Anything else is one.
      */
-    public static Query forWildcard(String field, String pattern) {
+    public static Query forWildcard(String field, String pattern, ScanBudget budget) {
         final String whole = literal(pattern);
         if (whole != null) {
-            return ColumnarStringTermQuery.term(field, new BytesRef(whole));
+            return ColumnarStringTermQuery.term(field, new BytesRef(whole), budget);
         }
         final String start = prefix(pattern);
         if (start != null) {
-            return ColumnarStringTermQuery.prefix(field, new BytesRef(start));
+            return ColumnarStringTermQuery.prefix(field, new BytesRef(start), budget);
         }
         final String inside = contained(pattern);
         if (inside != null) {
-            return ColumnarStringTermQuery.contains(field, new BytesRef(inside));
+            return ColumnarStringTermQuery.contains(field, new BytesRef(inside), budget);
         }
         return new ColumnarStringAutomatonQuery(
             field,
@@ -101,7 +112,8 @@ public final class ColumnarStringAutomatonQuery extends Query {
                 WildcardQuery.toAutomaton(new Term(field, pattern), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT),
                 Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
             ),
-            "pattern=" + pattern
+            "pattern=" + pattern,
+            budget
         );
     }
 
@@ -147,49 +159,59 @@ public final class ColumnarStringAutomatonQuery extends Query {
             @Override
             public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
                 final LeafReader reader = context.reader();
-                final BinaryDocValues values = reader.getBinaryDocValues(field);
-                if (values == null) {
+                final FieldInfo info = reader.getFieldInfos().fieldInfo(field);
+                if (info == null || info.getDocValuesType() != DocValuesType.BINARY) {
                     // No value for the field in this segment, so nothing here matches.
                     return null;
                 }
-                if (values instanceof StringColumnSource columnar) {
-                    final StringColumnReader column = columnar.reader();
-                    final DocIdSetIterator matches = column.match(value -> automaton.run(value.bytes, value.offset, value.length));
-                    return ConstantScoreScorerSupplier.fromIterator(matches, score(), scoreMode, reader.maxDoc());
-                }
-
-                // An overlay rather than the column, as an updated field is: the values are read one
-                // document at a time and run through the automaton. The surface carries a document's slots as
-                // one payload, so each is run separately and any of them accepted accepts the document.
-                final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
-                final TwoPhaseIterator twoPhase = new TwoPhaseIterator(values) {
+                return new ConstantScoreScorerSupplier(score(), scoreMode, reader.maxDoc()) {
                     @Override
-                    public boolean matches() throws IOException {
-                        final int slots = decoder.reset(values.binaryValue());
-                        for (int slot = 0; slot < slots; slot++) {
-                            final BytesRef candidate = decoder.next();
-                            // A null has no bytes to run an automaton over, not even the empty ones.
-                            if (candidate == null) {
-                                continue;
-                            }
-                            if (automaton.run(candidate.bytes, candidate.offset, candidate.length)) {
-                                return true;
-                            }
-                        }
-                        return false;
+                    public long cost() {
+                        return reader.maxDoc();
                     }
 
                     @Override
-                    public float matchCost() {
-                        return 100f;
+                    public DocIdSetIterator iterator(long leadCost) throws IOException {
+                        // Checked here rather than where the supplier is built: everything below allocates, and
+                        // the answer is not wanted until Lucene asks for the iterator.
+                        budget.check(searcher);
+                        final BinaryDocValues values = reader.getBinaryDocValues(field);
+                        if (values == null) {
+                            return DocIdSetIterator.empty();
+                        }
+                        if (values instanceof StringColumnSource columnar) {
+                            final StringColumnReader column = columnar.reader();
+                            return column.match(value -> automaton.run(value.bytes, value.offset, value.length));
+                        }
+
+                        // An overlay rather than the column, as an updated field is: the values are read one
+                        // document at a time and run through the automaton. The surface carries a document's slots
+                        // as one payload, so each is run separately and any of them accepted accepts the document.
+                        final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
+                        return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
+                            @Override
+                            public boolean matches() throws IOException {
+                                final int slots = decoder.reset(values.binaryValue());
+                                for (int slot = 0; slot < slots; slot++) {
+                                    final BytesRef candidate = decoder.next();
+                                    // A null has no bytes to run an automaton over, not even the empty ones.
+                                    if (candidate == null) {
+                                        continue;
+                                    }
+                                    if (automaton.run(candidate.bytes, candidate.offset, candidate.length)) {
+                                        return true;
+                                    }
+                                }
+                                return false;
+                            }
+
+                            @Override
+                            public float matchCost() {
+                                return 100f;
+                            }
+                        });
                     }
                 };
-                return ConstantScoreScorerSupplier.fromIterator(
-                    TwoPhaseIterator.asDocIdSetIterator(twoPhase),
-                    score(),
-                    scoreMode,
-                    reader.maxDoc()
-                );
             }
 
             @Override
@@ -217,13 +239,13 @@ public final class ColumnarStringAutomatonQuery extends Query {
             return true;
         }
         if (other instanceof ColumnarStringAutomatonQuery q) {
-            return field.equals(q.field) && description.equals(q.description);
+            return field.equals(q.field) && automaton.equals(q.automaton) && description.equals(q.description);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, description);
+        return Objects.hash(field, automaton, description);
     }
 }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringMatchQuery.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringMatchQuery.java
@@ -37,11 +37,9 @@ import java.util.function.Predicate;
  * Documents whose keyword column holds a value {@code matcher} accepts, answered by the column rather than
  * by an inverted index.
  *
- * <p>For the shapes that are a test over values and nothing more: a set of terms, a range, a length. What
- * the column makes of that is its own business, and it is more than a scan — a dictionary column tests each
- * term once and lets every value naming it inherit the answer, so the cost follows the vocabulary rather
- * than the documents. A caller that knows its shape is a term or a prefix should say so through
- * {@link ColumnarStringTermQuery} instead, which can bisect; a caller holding an automaton should use
+ * <p>For the shapes that are a test over values and nothing more: a set of terms, a range, a length. What the
+ * column makes of that is its own business. A caller that knows its shape is a term or a prefix should say so
+ * through {@link ColumnarStringTermQuery} instead, which can bisect; a caller holding an automaton should use
  * {@link ColumnarStringAutomatonQuery}, which can also hand its terms to a {@link QueryVisitor}.
  *
  * <p>{@code identity} stands in for the predicate in {@link #equals}, since a predicate has no equality worth

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringMatchQuery.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringMatchQuery.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.columnar;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorerSupplier;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringColumnSource;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Documents whose keyword column holds a value {@code matcher} accepts, answered by the column rather than
+ * by an inverted index.
+ *
+ * <p>For the shapes that are a test over values and nothing more: a set of terms, a range, a length. What
+ * the column makes of that is its own business, and it is more than a scan — a dictionary column tests each
+ * term once and lets every value naming it inherit the answer, so the cost follows the vocabulary rather
+ * than the documents. A caller that knows its shape is a term or a prefix should say so through
+ * {@link ColumnarStringTermQuery} instead, which can bisect; a caller holding an automaton should use
+ * {@link ColumnarStringAutomatonQuery}, which can also hand its terms to a {@link QueryVisitor}.
+ *
+ * <p>{@code identity} stands in for the predicate in {@link #equals}, since a predicate has no equality worth
+ * caching on: two queries carrying equal identities must accept the same values. It is whatever the caller
+ * built the predicate from - a set of terms, the bounds of a range - so nothing has to be spelt into a string
+ * to be compared, and a query over many terms does not carry a rendering of all of them for its lifetime.
+ */
+public final class ColumnarStringMatchQuery extends Query {
+
+    private final String field;
+    private final Predicate<BytesRef> matcher;
+    private final Object identity;
+    private final ScanBudget budget;
+
+    public ColumnarStringMatchQuery(String field, Predicate<BytesRef> matcher, Object identity, ScanBudget budget) {
+        this.field = Objects.requireNonNull(field);
+        this.matcher = Objects.requireNonNull(matcher);
+        this.identity = Objects.requireNonNull(identity);
+        this.budget = Objects.requireNonNull(budget);
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                final LeafReader reader = context.reader();
+                final FieldInfo info = reader.getFieldInfos().fieldInfo(field);
+                if (info == null || info.getDocValuesType() != DocValuesType.BINARY) {
+                    // No value for the field in this segment, so nothing here matches.
+                    return null;
+                }
+                return new ConstantScoreScorerSupplier(score(), scoreMode, reader.maxDoc()) {
+                    @Override
+                    public long cost() {
+                        return reader.maxDoc();
+                    }
+
+                    @Override
+                    public DocIdSetIterator iterator(long leadCost) throws IOException {
+                        // Checked here rather than where the supplier is built: everything below allocates, and
+                        // the answer is not wanted until Lucene asks for the iterator.
+                        budget.check(searcher);
+                        final BinaryDocValues values = reader.getBinaryDocValues(field);
+                        if (values == null) {
+                            return DocIdSetIterator.empty();
+                        }
+                        if (values instanceof StringColumnSource columnar) {
+                            return columnar.reader().match(matcher);
+                        }
+
+                        // An overlay rather than the column, as an updated field is: the values are read one
+                        // document at a time and tested. The surface carries a document's slots as one payload, so
+                        // each is tested in turn and any of them accepted accepts the document, which is what the
+                        // column answers too.
+                        final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
+                        return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
+                            @Override
+                            public boolean matches() throws IOException {
+                                final int slots = decoder.reset(values.binaryValue());
+                                for (int slot = 0; slot < slots; slot++) {
+                                    final BytesRef candidate = decoder.next();
+                                    // A null is no value, so it is offered to no matcher — not even one that would
+                                    // accept the empty string, which is a value a document really holds.
+                                    if (candidate != null && matcher.test(candidate)) {
+                                        return true;
+                                    }
+                                }
+                                return false;
+                            }
+
+                            @Override
+                            public float matchCost() {
+                                return 100f;
+                            }
+                        });
+                    }
+                };
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return DocValues.isCacheable(ctx, field);
+            }
+        };
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(field)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    @Override
+    public String toString(String defaultField) {
+        return "ColumnarStringMatchQuery(field=" + field + "," + identity + ")";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (sameClassAs(other) == false) {
+            return false;
+        }
+        final ColumnarStringMatchQuery that = (ColumnarStringMatchQuery) other;
+        return field.equals(that.field) && identity.equals(that.identity);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), field, identity);
+    }
+}

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringTermQuery.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumnarStringTermQuery.java
@@ -11,6 +11,8 @@ package org.elasticsearch.columnar;
 
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreScorerSupplier;
@@ -56,26 +58,28 @@ public final class ColumnarStringTermQuery extends Query {
     private final String field;
     private final BytesRef term;
     private final Where where;
+    private final ScanBudget budget;
 
     /** Documents whose value is exactly {@code term}. */
-    public static ColumnarStringTermQuery term(String field, BytesRef term) {
-        return new ColumnarStringTermQuery(field, term, Where.WHOLE);
+    public static ColumnarStringTermQuery term(String field, BytesRef term, ScanBudget budget) {
+        return new ColumnarStringTermQuery(field, term, Where.WHOLE, budget);
     }
 
     /** Documents holding a value that starts with {@code prefix}. */
-    public static ColumnarStringTermQuery prefix(String field, BytesRef prefix) {
-        return new ColumnarStringTermQuery(field, prefix, Where.START);
+    public static ColumnarStringTermQuery prefix(String field, BytesRef prefix, ScanBudget budget) {
+        return new ColumnarStringTermQuery(field, prefix, Where.START, budget);
     }
 
     /** Documents holding a value that has {@code term} somewhere inside it. */
-    public static ColumnarStringTermQuery contains(String field, BytesRef term) {
-        return new ColumnarStringTermQuery(field, term, Where.ANYWHERE);
+    public static ColumnarStringTermQuery contains(String field, BytesRef term, ScanBudget budget) {
+        return new ColumnarStringTermQuery(field, term, Where.ANYWHERE, budget);
     }
 
-    private ColumnarStringTermQuery(String field, BytesRef term, Where where) {
+    private ColumnarStringTermQuery(String field, BytesRef term, Where where, ScanBudget budget) {
         this.field = Objects.requireNonNull(field);
         this.term = BytesRef.deepCopyOf(Objects.requireNonNull(term));
         this.where = where;
+        this.budget = Objects.requireNonNull(budget);
     }
 
     @Override
@@ -84,75 +88,85 @@ public final class ColumnarStringTermQuery extends Query {
             @Override
             public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
                 final LeafReader reader = context.reader();
-                final BinaryDocValues values = reader.getBinaryDocValues(field);
-                if (values == null) {
+                final FieldInfo info = reader.getFieldInfos().fieldInfo(field);
+                if (info == null || info.getDocValuesType() != DocValuesType.BINARY) {
                     // No value for the field in this segment, so nothing here matches.
                     return null;
                 }
-                if (values instanceof StringColumnSource columnar) {
-                    final StringColumnReader column = columnar.reader();
-                    final DocIdSetIterator matches = switch (where) {
-                        case WHOLE -> column.matchTerm(term);
-                        case START -> column.matchPrefix(term);
-                        case ANYWHERE -> column.matchContains(term);
-                    };
-                    return ConstantScoreScorerSupplier.fromIterator(matches, score(), scoreMode, reader.maxDoc());
-                }
-
-                // An overlay rather than the column, as an updated field is: the values are read one
-                // document at a time and compared. The surface carries a document's slots as one payload, so
-                // each is decoded and tested in turn and any of them matching matches the document, which is
-                // what the column answers too.
-                final BytesRef value = new BytesRef();
-                final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
-                final TwoPhaseIterator twoPhase = new TwoPhaseIterator(values) {
+                return new ConstantScoreScorerSupplier(score(), scoreMode, reader.maxDoc()) {
                     @Override
-                    public boolean matches() throws IOException {
-                        final int slots = decoder.reset(values.binaryValue());
-                        for (int slot = 0; slot < slots; slot++) {
-                            final BytesRef candidate = decoder.next();
-                            // A null is no term, starts with no prefix, and holds nothing.
-                            if (candidate == null) {
-                                continue;
-                            }
-                            final boolean matched = switch (where) {
-                                case WHOLE -> candidate.bytesEquals(term);
-                                case START -> {
-                                    if (candidate.length < term.length) {
-                                        yield false;
-                                    }
-                                    value.bytes = candidate.bytes;
-                                    value.offset = candidate.offset;
-                                    value.length = term.length;
-                                    yield value.bytesEquals(term);
-                                }
-                                case ANYWHERE -> ESVectorUtil.contains(
-                                    candidate.bytes,
-                                    candidate.offset,
-                                    candidate.length,
-                                    term.bytes,
-                                    term.offset,
-                                    term.length
-                                );
-                            };
-                            if (matched) {
-                                return true;
-                            }
-                        }
-                        return false;
+                    public long cost() {
+                        return reader.maxDoc();
                     }
 
                     @Override
-                    public float matchCost() {
-                        return 10f;
+                    public DocIdSetIterator iterator(long leadCost) throws IOException {
+                        // Checked here rather than where the supplier is built: everything below allocates, and
+                        // the answer is not wanted until Lucene asks for the iterator.
+                        budget.check(searcher);
+                        final BinaryDocValues values = reader.getBinaryDocValues(field);
+                        if (values == null) {
+                            return DocIdSetIterator.empty();
+                        }
+                        if (values instanceof StringColumnSource columnar) {
+                            final StringColumnReader column = columnar.reader();
+                            return switch (where) {
+                                case WHOLE -> column.matchTerm(term);
+                                case START -> column.matchPrefix(term);
+                                case ANYWHERE -> column.matchContains(term);
+                            };
+                        }
+
+                        // An overlay rather than the column, as an updated field is: the values are read one
+                        // document at a time and compared. The surface carries a document's slots as one payload,
+                        // so each is decoded and tested in turn and any of them matching matches the document,
+                        // which is what the column answers too.
+                        final BytesRef value = new BytesRef();
+                        final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
+                        return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
+                            @Override
+                            public boolean matches() throws IOException {
+                                final int slots = decoder.reset(values.binaryValue());
+                                for (int slot = 0; slot < slots; slot++) {
+                                    final BytesRef candidate = decoder.next();
+                                    // A null is no term, starts with no prefix, and holds nothing.
+                                    if (candidate == null) {
+                                        continue;
+                                    }
+                                    final boolean matched = switch (where) {
+                                        case WHOLE -> candidate.bytesEquals(term);
+                                        case START -> {
+                                            if (candidate.length < term.length) {
+                                                yield false;
+                                            }
+                                            value.bytes = candidate.bytes;
+                                            value.offset = candidate.offset;
+                                            value.length = term.length;
+                                            yield value.bytesEquals(term);
+                                        }
+                                        case ANYWHERE -> ESVectorUtil.contains(
+                                            candidate.bytes,
+                                            candidate.offset,
+                                            candidate.length,
+                                            term.bytes,
+                                            term.offset,
+                                            term.length
+                                        );
+                                    };
+                                    if (matched) {
+                                        return true;
+                                    }
+                                }
+                                return false;
+                            }
+
+                            @Override
+                            public float matchCost() {
+                                return 10f;
+                            }
+                        });
                     }
                 };
-                return ConstantScoreScorerSupplier.fromIterator(
-                    TwoPhaseIterator.asDocIdSetIterator(twoPhase),
-                    score(),
-                    scoreMode,
-                    reader.maxDoc()
-                );
             }
 
             @Override

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/ScanBudget.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/ScanBudget.java
@@ -15,10 +15,10 @@ import org.apache.lucene.search.IndexSearcher;
  * Consulted once per segment before a columnar query starts reading it, so a caller that keeps a budget for
  * that work can refuse it before anything is allocated.
  *
- * <p>These queries scan: matching a term against a dictionary reads every term, and a segment handed over as
- * an overlay rather than as a column is decoded a document at a time. Whether there is room for that is not
- * a question this library can answer — it knows nothing of heap accounting — so the search layer supplies
- * the answer and this is the whole of the seam.
+ * <p>Not every shape scans, but the ones that cannot bisect do: a predicate or an automaton is tested against
+ * every term, and a segment handed over as an overlay rather than as a column is decoded a document at a time.
+ * Whether there is room for that is not a question this library can answer — it knows nothing of heap
+ * accounting — so the search layer supplies the answer and this is the whole of the seam.
  *
  * <p>An implementation is expected to throw when the budget is spent, and to be cheap enough to call for
  * every segment of every query.

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/ScanBudget.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/ScanBudget.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.columnar;
+
+import org.apache.lucene.search.IndexSearcher;
+
+/**
+ * Consulted once per segment before a columnar query starts reading it, so a caller that keeps a budget for
+ * that work can refuse it before anything is allocated.
+ *
+ * <p>These queries scan: matching a term against a dictionary reads every term, and a segment handed over as
+ * an overlay rather than as a column is decoded a document at a time. Whether there is room for that is not
+ * a question this library can answer — it knows nothing of heap accounting — so the search layer supplies
+ * the answer and this is the whole of the seam.
+ *
+ * <p>An implementation is expected to throw when the budget is spent, and to be cheap enough to call for
+ * every segment of every query.
+ */
+@FunctionalInterface
+public interface ScanBudget {
+
+    /** Permits every scan, for a caller that keeps no budget. */
+    ScanBudget UNLIMITED = searcher -> {};
+
+    /** Throws when {@code searcher} has no room to read a segment of this column. */
+    void check(IndexSearcher searcher);
+}

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/ColumnarStringAutomatonQueryTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/ColumnarStringAutomatonQueryTests.java
@@ -100,13 +100,22 @@ public class ColumnarStringAutomatonQueryTests extends ESTestCase {
      * bisects or searches for bytes rather than running an automaton over every distinct value.
      */
     public void testForWildcardNarrowsToTheCheapestQuery() {
-        assertEquals(ColumnarStringTermQuery.term(FIELD, new BytesRef("alpha")), ColumnarStringAutomatonQuery.forWildcard(FIELD, "alpha"));
-        assertEquals(ColumnarStringTermQuery.prefix(FIELD, new BytesRef("al")), ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*"));
-        // Every value, which is a prefix of no bytes rather than an automaton.
-        assertEquals(ColumnarStringTermQuery.prefix(FIELD, new BytesRef("")), ColumnarStringAutomatonQuery.forWildcard(FIELD, "*"));
         assertEquals(
-            ColumnarStringTermQuery.contains(FIELD, new BytesRef("lph")),
-            ColumnarStringAutomatonQuery.forWildcard(FIELD, "*lph*")
+            ColumnarStringTermQuery.term(FIELD, new BytesRef("alpha"), ScanBudget.UNLIMITED),
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "alpha", ScanBudget.UNLIMITED)
+        );
+        assertEquals(
+            ColumnarStringTermQuery.prefix(FIELD, new BytesRef("al"), ScanBudget.UNLIMITED),
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*", ScanBudget.UNLIMITED)
+        );
+        // Every value, which is a prefix of no bytes rather than an automaton.
+        assertEquals(
+            ColumnarStringTermQuery.prefix(FIELD, new BytesRef(""), ScanBudget.UNLIMITED),
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "*", ScanBudget.UNLIMITED)
+        );
+        assertEquals(
+            ColumnarStringTermQuery.contains(FIELD, new BytesRef("lph"), ScanBudget.UNLIMITED),
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "*lph*", ScanBudget.UNLIMITED)
         );
     }
 
@@ -116,7 +125,7 @@ public class ColumnarStringAutomatonQueryTests extends ESTestCase {
         for (String pattern : new String[] { "*pha", "al*a", "alph?", "**", "a*b*c", "al\\*pha", "*a?c*", "" }) {
             assertThat(
                 "pattern [" + pattern + "]",
-                ColumnarStringAutomatonQuery.forWildcard(FIELD, pattern),
+                ColumnarStringAutomatonQuery.forWildcard(FIELD, pattern, ScanBudget.UNLIMITED),
                 instanceOf(ColumnarStringAutomatonQuery.class)
             );
         }
@@ -128,13 +137,22 @@ public class ColumnarStringAutomatonQueryTests extends ESTestCase {
      * cached filter would be handed to the wrong one.
      */
     public void testCacheIdentityFollowsThePattern() {
-        assertEquals(ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a"), ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a"));
         assertEquals(
-            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a").hashCode(),
-            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a").hashCode()
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a", ScanBudget.UNLIMITED),
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a", ScanBudget.UNLIMITED)
         );
-        assertNotEquals(ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a"), ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*b"));
-        assertNotEquals(ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a"), ColumnarStringAutomatonQuery.forWildcard("other", "al*a"));
+        assertEquals(
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a", ScanBudget.UNLIMITED).hashCode(),
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a", ScanBudget.UNLIMITED).hashCode()
+        );
+        assertNotEquals(
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a", ScanBudget.UNLIMITED),
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*b", ScanBudget.UNLIMITED)
+        );
+        assertNotEquals(
+            ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a", ScanBudget.UNLIMITED),
+            ColumnarStringAutomatonQuery.forWildcard("other", "al*a", ScanBudget.UNLIMITED)
+        );
     }
 
     /**
@@ -162,7 +180,7 @@ public class ColumnarStringAutomatonQueryTests extends ESTestCase {
                     assertEquals(
                         "pattern [" + pattern + "] through an overlay",
                         accepted(values, pattern),
-                        found(searcher, ColumnarStringAutomatonQuery.forWildcard(FIELD, pattern))
+                        found(searcher, ColumnarStringAutomatonQuery.forWildcard(FIELD, pattern, ScanBudget.UNLIMITED))
                     );
                     // The narrowed shapes go through the overlay too, since forWildcard picks them first.
                     assertEquals(
@@ -197,7 +215,7 @@ public class ColumnarStringAutomatonQueryTests extends ESTestCase {
                     assertEquals(
                         "pattern [" + pattern + "]",
                         accepted(values, pattern),
-                        found(searcher, ColumnarStringAutomatonQuery.forWildcard(FIELD, pattern))
+                        found(searcher, ColumnarStringAutomatonQuery.forWildcard(FIELD, pattern, ScanBudget.UNLIMITED))
                     );
                     // The automaton is what the narrowed queries have to agree with, so it is asked too.
                     assertEquals(
@@ -218,7 +236,8 @@ public class ColumnarStringAutomatonQueryTests extends ESTestCase {
                 WildcardQuery.toAutomaton(new Term(FIELD, pattern), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT),
                 Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
             ),
-            "pattern=" + pattern
+            "pattern=" + pattern,
+            ScanBudget.UNLIMITED
         );
     }
 

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/ColumnarStringMatchQueryTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/ColumnarStringMatchQueryTests.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.columnar;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LogDocMergePolicy;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringColumnSource;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.columnar.ColumnarTestUtils.columnarBinaryFieldType;
+import static org.elasticsearch.columnar.ColumnarTestUtils.columnarCodec;
+import static org.elasticsearch.columnar.ColumnarTestUtils.hideTheColumn;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * The filter shapes that are a test over values and nothing more - a set of terms, a range, a length - answered by the
+ * column. Every one is checked against the documents the same test run over the values by hand would find, and against
+ * what the same query finds with the column hidden, since a field read as an overlay has to answer the same.
+ */
+public class ColumnarStringMatchQueryTests extends ESTestCase {
+
+    private static final String FIELD = "kw";
+
+    /** The predicates worth telling apart, each with the description the query is compared by. */
+    private record Shape(String description, Predicate<BytesRef> matcher) {}
+
+    private static List<Shape> shapes() {
+        return List.of(
+            new Shape("terms", in("alpha", "charlie")),
+            new Shape("terms-absent", in("nothing-holds-this")),
+            new Shape("terms-with-empty", in("", "alpha")),
+            new Shape("range[alpha,charlie)", between("alpha", true, "charlie", false)),
+            new Shape("range(alpha,charlie]", between("alpha", false, "charlie", true)),
+            new Shape("range-open-below", between(null, false, "bravo", true)),
+            new Shape("range-open-above", between("bravo", true, null, false)),
+            new Shape("length==5", value -> value.length == 5),
+            new Shape("length>=6", value -> value.length >= 6),
+            new Shape("length==0", value -> value.length == 0),
+            // Accepts anything it is offered, which is what pins down what a null slot is: no value, so it is
+            // offered to nothing and a document holding only nulls matches nothing.
+            new Shape("everything", value -> true),
+            new Shape("nothing", value -> false)
+        );
+    }
+
+    private static Predicate<BytesRef> in(String... terms) {
+        final Set<BytesRef> set = new java.util.HashSet<>();
+        for (String term : terms) {
+            set.add(new BytesRef(term));
+        }
+        return set::contains;
+    }
+
+    private static Predicate<BytesRef> between(String lower, boolean lowerInclusive, String upper, boolean upperInclusive) {
+        final BytesRef low = lower == null ? null : new BytesRef(lower);
+        final BytesRef high = upper == null ? null : new BytesRef(upper);
+        return value -> {
+            if (low != null) {
+                final int cmp = value.compareTo(low);
+                if (cmp < 0 || (cmp == 0 && lowerInclusive == false)) {
+                    return false;
+                }
+            }
+            if (high != null) {
+                final int cmp = value.compareTo(high);
+                if (cmp > 0 || (cmp == 0 && upperInclusive == false)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+
+    /** Few terms over many documents, which is the shape that earns a dictionary. */
+    public void testDictionaryColumn() throws IOException {
+        final String[] terms = { "alpha", "bravo", "charlie", "delta", "" };
+        final List<List<String>> docs = new ArrayList<>();
+        for (int d = 0; d < between(400, 1200); d++) {
+            docs.add(List.of(terms[d % terms.length]));
+        }
+        assertShapes(docs);
+    }
+
+    /** Values distinct enough that the column keeps no dictionary, so every value is tested on its own. */
+    public void testPlainColumn() throws IOException {
+        final List<List<String>> docs = new ArrayList<>();
+        for (int d = 0; d < between(400, 1200); d++) {
+            docs.add(List.of("value-" + d));
+        }
+        assertShapes(docs);
+    }
+
+    /**
+     * A dictionary with values escaping it. An escaped value is named by nothing but its bytes, so it cannot inherit a
+     * term's answer and has to be tested itself - which is the arm a column-wide test would otherwise miss.
+     */
+    public void testColumnWithEscapes() throws IOException {
+        final String[] terms = { "alpha", "bravo", "charlie" };
+        final List<List<String>> docs = new ArrayList<>();
+        for (int d = 0; d < between(400, 1200); d++) {
+            docs.add(List.of(d % 25 == 3 ? "escaped-" + d : terms[d % terms.length]));
+        }
+        assertShapes(docs);
+    }
+
+    /** A document matches when any slot it holds does, so the shapes are checked over documents holding several. */
+    public void testMultiValuedDocuments() throws IOException {
+        final String[] terms = { "alpha", "bravo", "charlie", "delta" };
+        final List<List<String>> docs = new ArrayList<>();
+        for (int d = 0; d < between(400, 1200); d++) {
+            docs.add(switch (d % 4) {
+                case 0 -> List.of(terms[d % terms.length]);
+                case 1 -> List.of(terms[d % terms.length], terms[(d + 1) % terms.length]);
+                case 2 -> List.of("alpha", "alpha");
+                default -> List.of(terms[d % terms.length], "escaped-" + d, "");
+            });
+        }
+        assertShapes(docs);
+    }
+
+    /**
+     * Null slots, empty arrays and absent fields. A null is no value: it is offered to no matcher, not even one that
+     * accepts everything, so a document holding only nulls matches nothing - while a document holding the empty string
+     * holds a value a matcher may well accept.
+     */
+    public void testNullsEmptyArraysAndAbsentFields() throws IOException {
+        final String[] terms = { "alpha", "bravo", "" };
+        final List<List<String>> docs = new ArrayList<>();
+        for (int d = 0; d < between(400, 1200); d++) {
+            docs.add(switch (d % 6) {
+                case 0 -> List.of(terms[d % terms.length]);
+                // A lone null slot.
+                case 1 -> java.util.Collections.singletonList(null);
+                // A null beside a value.
+                case 2 -> java.util.Arrays.asList(null, terms[d % terms.length]);
+                // An empty array.
+                case 3 -> List.<String>of();
+                // The field absent altogether.
+                case 4 -> null;
+                default -> java.util.Arrays.asList(terms[d % terms.length], null);
+            });
+        }
+        assertShapes(docs);
+    }
+
+    /**
+     * The budget the search layer keeps for reading a column. It is consulted when the scorer's iterator is asked
+     * for rather than when the supplier is built, since everything that allocates happens behind it and a supplier
+     * Lucene decides not to use should cost nothing.
+     */
+    public void testTheBudgetIsSpentWhenTheColumnIsRead() throws IOException {
+        final List<List<String>> docs = new ArrayList<>();
+        for (int d = 0; d < 200; d++) {
+            docs.add(List.of("term-" + (d % 4)));
+        }
+        final ScanBudget refuses = searcher -> { throw new IllegalStateException("no room to read a column"); };
+        try (Directory dir = newDirectory()) {
+            index(dir, docs);
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final IndexSearcher searcher = new IndexSearcher(reader);
+                final Query query = new ColumnarStringMatchQuery(FIELD, value -> true, "everything", refuses);
+                final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1f);
+                final ScorerSupplier supplier = weight.scorerSupplier(reader.leaves().get(0));
+                assertNotNull("a supplier costs nothing to hand out", supplier);
+                expectThrows(IllegalStateException.class, () -> supplier.get(Long.MAX_VALUE));
+                expectThrows(IllegalStateException.class, () -> searcher.search(query, 1));
+            }
+        }
+    }
+
+    /**
+     * Every shape, against the documents the same predicate applied to the values by hand would find - through the
+     * column, and again with the column hidden so the query has to read a document at a time.
+     */
+    private void assertShapes(List<List<String>> docs) throws IOException {
+        try (Directory dir = newDirectory()) {
+            index(dir, docs);
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                // The two searchers have to be reading the field two different ways, or the comparison below holds
+                // for the wrong reason: one of them answering everything a document at a time and agreeing with
+                // itself. So each is asked what it sees before either is asked a question.
+                assertThat(
+                    "the field is a column",
+                    reader.leaves().get(0).reader().getBinaryDocValues(FIELD),
+                    instanceOf(StringColumnSource.class)
+                );
+                final DirectoryReader hidden = hideTheColumn(reader);
+                assertThat(
+                    "the column is hidden",
+                    hidden.leaves().get(0).reader().getBinaryDocValues(FIELD),
+                    not(instanceOf(StringColumnSource.class))
+                );
+                final IndexSearcher onTheColumn = new IndexSearcher(reader);
+                final IndexSearcher onAnOverlay = new IndexSearcher(hidden);
+                for (Shape shape : shapes()) {
+                    final List<Integer> expected = matching(docs, shape.matcher());
+                    assertEquals("[" + shape.description() + "] through the column", expected, found(onTheColumn, queryFor(shape)));
+                    assertEquals("[" + shape.description() + "] through an overlay", expected, found(onAnOverlay, queryFor(shape)));
+                }
+            }
+        }
+    }
+
+    private static void index(Directory dir, List<List<String>> docs) throws IOException {
+        final IndexWriterConfig iwc = new IndexWriterConfig().setCodec(columnarCodec(ColumnarFieldType.STRING))
+            .setMergePolicy(new LogDocMergePolicy());
+        final FieldType type = columnarBinaryFieldType();
+        try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+            for (List<String> slots : docs) {
+                final Document doc = new Document();
+                if (slots != null) {
+                    doc.add(new Field(FIELD, payload(slots), type));
+                }
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1);
+        }
+    }
+
+    private static Query queryFor(Shape shape) {
+        return new ColumnarStringMatchQuery(FIELD, shape.matcher(), shape.description(), ScanBudget.UNLIMITED);
+    }
+
+    /** The documents holding a slot the predicate accepts, worked out from the values themselves. */
+    private static List<Integer> matching(List<List<String>> docs, Predicate<BytesRef> matcher) {
+        final List<Integer> matched = new ArrayList<>();
+        for (int d = 0; d < docs.size(); d++) {
+            final List<String> slots = docs.get(d);
+            if (slots == null) {
+                continue;
+            }
+            for (String slot : slots) {
+                // A null slot is no value, so it is never offered.
+                if (slot != null && matcher.test(new BytesRef(slot))) {
+                    matched.add(d);
+                    break;
+                }
+            }
+        }
+        return matched;
+    }
+
+    private static BytesRef payload(List<String> slots) {
+        final List<BytesRef> encoded = new ArrayList<>(slots.size());
+        for (String slot : slots) {
+            encoded.add(slot == null ? null : new BytesRef(slot));
+        }
+        return BytesRef.deepCopyOf(new StringBinaryPayload.Builder().encode(encoded));
+    }
+
+    private static List<Integer> found(IndexSearcher searcher, Query query) throws IOException {
+        final TopDocs hits = searcher.search(query, Integer.MAX_VALUE);
+        final List<Integer> docs = new ArrayList<>();
+        for (ScoreDoc hit : hits.scoreDocs) {
+            docs.add(hit.doc);
+        }
+        java.util.Collections.sort(docs);
+        return docs;
+    }
+}

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/ColumnarStringTermQueryTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/ColumnarStringTermQueryTests.java
@@ -123,7 +123,7 @@ public class ColumnarStringTermQueryTests extends ESTestCase {
                     assertEquals(
                         "term [" + probe + "]",
                         expected(ordered, probe, true),
-                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
             }
@@ -191,7 +191,7 @@ public class ColumnarStringTermQueryTests extends ESTestCase {
                     assertEquals(
                         "term [" + probe + "] after merging past segments without the field",
                         expected(values, probe, true),
-                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
             }
@@ -256,7 +256,7 @@ public class ColumnarStringTermQueryTests extends ESTestCase {
                         assertEquals(
                             shape.name() + " term [" + probe + "]",
                             expected(values, probe, true),
-                            found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe)))
+                            found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                         );
                     }
                 }
@@ -312,14 +312,14 @@ public class ColumnarStringTermQueryTests extends ESTestCase {
                     assertEquals(
                         "term [" + probe + "] on an index-sorted column",
                         expected(inDocOrder, probe, true),
-                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
                 for (String probe : Arrays.asList("al", "alp", "b", "d", "az", "zzz", "")) {
                     assertEquals(
                         "prefix [" + probe + "] on an index-sorted column",
                         expected(inDocOrder, probe, false),
-                        found(searcher, ColumnarStringTermQuery.prefix(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.prefix(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
             }
@@ -350,19 +350,19 @@ public class ColumnarStringTermQueryTests extends ESTestCase {
                     assertEquals(
                         "term [" + probe + "] through an overlay",
                         expected(values, probe, true),
-                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                     assertEquals(
                         "prefix [" + probe + "] through an overlay",
                         expected(values, probe, false),
-                        found(searcher, ColumnarStringTermQuery.prefix(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.prefix(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
                 for (String probe : Arrays.asList("lph", "alpha", "a", "", "zzz")) {
                     assertEquals(
                         "contains [" + probe + "] through an overlay",
                         containing(values, probe),
-                        found(searcher, ColumnarStringTermQuery.contains(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.contains(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
             }
@@ -385,8 +385,8 @@ public class ColumnarStringTermQueryTests extends ESTestCase {
             }
             try (DirectoryReader reader = DirectoryReader.open(dir)) {
                 final IndexSearcher searcher = new IndexSearcher(reader);
-                assertEquals(List.of(), found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef("alpha"))));
-                assertEquals(List.of(), found(searcher, ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a")));
+                assertEquals(List.of(), found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef("alpha"), ScanBudget.UNLIMITED)));
+                assertEquals(List.of(), found(searcher, ColumnarStringAutomatonQuery.forWildcard(FIELD, "al*a", ScanBudget.UNLIMITED)));
             }
         }
     }
@@ -443,14 +443,14 @@ public class ColumnarStringTermQueryTests extends ESTestCase {
                     assertEquals(
                         "term [" + probe + "]",
                         expected(values, probe, true),
-                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.term(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
                 for (String probe : Arrays.asList("al", "alp", "b", "id-", "zzz")) {
                     assertEquals(
                         "prefix [" + probe + "]",
                         expected(values, probe, false),
-                        found(searcher, ColumnarStringTermQuery.prefix(FIELD, new BytesRef(probe)))
+                        found(searcher, ColumnarStringTermQuery.prefix(FIELD, new BytesRef(probe), ScanBudget.UNLIMITED))
                     );
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -906,8 +906,8 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         /**
-         * The queries this field answers from its doc values, chosen by how those doc values are framed. Held rather
-         * than decided per query, so the eight query methods below each delegate instead of branching on the format.
+         * The queries this field answers from its doc values, chosen by how those doc values are framed, so the query
+         * methods below each delegate instead of branching on the format.
          */
         private BinaryDocValuesQueries binaryQueries() {
             return BinaryDocValuesQueries.forFormat(binaryFormat());

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -88,12 +88,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.fn.Utf8CodePointsFro
 import org.elasticsearch.index.query.AutomatonQueryWithDescription;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
+import org.elasticsearch.lucene.queries.BinaryDocValuesQueries;
 import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
@@ -910,6 +905,14 @@ public final class KeywordFieldMapper extends FieldMapper {
             return usesBinaryDocValuesForIgnoredFields;
         }
 
+        /**
+         * The queries this field answers from its doc values, chosen by how those doc values are framed. Held rather
+         * than decided per query, so the eight query methods below each delegate instead of branching on the format.
+         */
+        private BinaryDocValuesQueries binaryQueries() {
+            return BinaryDocValuesQueries.forFormat(binaryFormat());
+        }
+
         @Override
         public boolean isSearchable() {
             return indexType.hasTerms() || hasDocValues();
@@ -921,7 +924,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.termQuery(value, context);
             } else if (usesBinaryDocValues()) {
-                return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), binaryFormat());
+                return binaryQueries().term(name(), indexedValueForSearch(value));
             } else {
                 return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
@@ -933,8 +936,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.termsQuery(values, context);
             } else if (usesBinaryDocValues()) {
-                List<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
-                return new ScanningBinaryDocValuesTermInSetQuery(name(), bytesRefs, binaryFormat());
+                return binaryQueries().terms(name(), values.stream().map(this::indexedValueForSearch).toList());
             } else {
                 Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
                 return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);
@@ -953,13 +955,12 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, context);
             } else if (usesBinaryDocValues()) {
-                return new ScanningBinaryDocValuesRangeQuery(
+                return binaryQueries().range(
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm),
                     includeLower,
-                    includeUpper,
-                    binaryFormat()
+                    includeUpper
                 );
             } else {
                 return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(
@@ -986,13 +987,12 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions, context, rewriteMethod);
             } else if (usesBinaryDocValues()) {
-                return ScanningBinaryDocValuesAutomatonQuery.forFuzzy(
+                return binaryQueries().fuzzy(
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     fuzziness.asDistance(BytesRefs.toString(value)),
                     prefixLength,
-                    transpositions,
-                    binaryFormat()
+                    transpositions
                 );
             } else {
                 return FuzzyQueries.create(
@@ -1019,12 +1019,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.prefixQuery(value, method, caseInsensitive, context);
             } else if (usesBinaryDocValues()) {
-                return new ScanningBinaryDocValuesPrefixQuery(
-                    name(),
-                    indexedValueForSearch(value).utf8ToString(),
-                    caseInsensitive,
-                    binaryFormat()
-                );
+                return binaryQueries().prefix(name(), indexedValueForSearch(value).utf8ToString(), caseInsensitive);
             } else {
                 if (caseInsensitive == false) {
                     Term prefix = new Term(name(), indexedValueForSearch(value));
@@ -1046,11 +1041,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.termQueryCaseInsensitive(value, context);
             } else if (usesBinaryDocValues()) {
-                return ScanningBinaryDocValuesAutomatonQuery.forCaseInsensitiveTerm(
-                    name(),
-                    indexedValueForSearch(value).utf8ToString(),
-                    binaryFormat()
-                );
+                return binaryQueries().caseInsensitiveTerm(name(), indexedValueForSearch(value).utf8ToString());
             } else {
                 return new StringScriptFieldTermQuery(
                     new Script(""),
@@ -1389,7 +1380,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
 
                 if (usesBinaryDocValues()) {
-                    return ScanningBinaryDocValuesAutomatonQuery.forWildcard(name(), value, caseInsensitive, binaryFormat());
+                    return binaryQueries().wildcard(name(), value, caseInsensitive);
                 }
 
                 if (caseInsensitive == false) {
@@ -1419,7 +1410,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
 
                 if (usesBinaryDocValues()) {
-                    return ScanningBinaryDocValuesAutomatonQuery.forWildcard(name(), value, false, binaryFormat());
+                    return binaryQueries().wildcard(name(), value, false);
                 } else {
                     Term term = new Term(name(), value);
                     if (context.getCircuitBreaker() != null) {
@@ -1446,13 +1437,12 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else {
                 value = AutomatonQueries.collapseConsecutiveQuantifiers(value);
                 if (usesBinaryDocValues()) {
-                    return new ScanningBinaryDocValuesRegexpQuery(
+                    return binaryQueries().regexp(
                         name(),
                         indexedValueForSearch(value).utf8ToString(),
                         syntaxFlags,
                         matchFlags,
                         maxDeterminizedStates,
-                        binaryFormat(),
                         context.getCircuitBreaker()
                     );
                 } else {
@@ -1521,7 +1511,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return new AutomatonQueryWithDescription(new Term(name()), automatonSupplier.get(), description);
             } else if (usesBinaryDocValues()) {
-                return new ScanningBinaryDocValuesAutomatonQuery(name(), automatonSupplier.get(), binaryFormat(), description);
+                return binaryQueries().automaton(name(), automatonSupplier.get(), description);
             } else {
                 return new AutomatonQueryWithDescription(
                     new Term(name()),

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -29,7 +29,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueArrayOrderInlineNullBinaryDocValuesReader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueColumnarPayloadBinaryDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueSeparateCountBinaryDocValuesReader;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 
@@ -48,7 +47,19 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
     AbstractBinaryDocValuesQuery(String fieldName, Predicate<BytesRef> matcher, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = Objects.requireNonNull(fieldName);
         this.matcher = Objects.requireNonNull(matcher);
-        this.binaryFormat = Objects.requireNonNull(binaryFormat);
+        this.binaryFormat = rejectColumnar(binaryFormat, fieldName);
+    }
+
+    /**
+     * A columnar field is answered by its column, through the queries in the columnar library, so one reaching a
+     * scanning query is a caller that routed it wrongly - see BinaryDocValuesQueries, which is what chooses between
+     * the two. Refused here rather than where the scan would run, so it fails when the query is built.
+     */
+    static BinaryDocValuesFormat rejectColumnar(BinaryDocValuesFormat binaryFormat, String fieldName) {
+        if (Objects.requireNonNull(binaryFormat) == BinaryDocValuesFormat.COLUMNAR_PAYLOAD) {
+            throw new IllegalArgumentException("field [" + fieldName + "] is a column and is not answered by scanning");
+        }
+        return binaryFormat;
     }
 
     @Override
@@ -98,9 +109,11 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
             return null;
         }
         return switch (binaryFormat) {
-            // The payload carries its own count and writes no .counts companion, so the binary column drives iteration on its own and
-            // there is nothing to look up.
-            case COLUMNAR_PAYLOAD -> columnarPayloadIterator(values, matcher, matchCost);
+            // A field framed this way is answered by its column, through the queries in the columnar library, and never
+            // arrives here - see BinaryDocValuesQueries, which is what chooses between the two.
+            case COLUMNAR_PAYLOAD -> throw new IllegalStateException(
+                "a columnar field is answered by its column, not by scanning [" + fieldName + "]"
+            );
             case ARRAY_ORDER_INLINE_NULL -> {
                 // ArrayOrderInlineNull always writes the .counts field (even for an all-null or empty array, which writes no blob), so
                 // the counts column drives iteration and count==1 is handled inside the inline-null reader as the raw case.
@@ -124,26 +137,6 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
         if (visitor.acceptField(fieldName)) {
             visitor.visitLeaf(this);
         }
-    }
-
-    /**
-     * Iterator for the columnar codec's payload. The blob is written for every present document and carries its own slot count, so it is
-     * both the approximation and the source of the values; a document whose slots are all null simply matches nothing.
-     */
-    static DocIdSetIterator columnarPayloadIterator(BinaryDocValues values, Predicate<BytesRef> predicate, float cost) {
-        return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
-            final MultiValueColumnarPayloadBinaryDocValuesReader reader = new MultiValueColumnarPayloadBinaryDocValuesReader();
-
-            @Override
-            public boolean matches() throws IOException {
-                return reader.match(values.binaryValue(), predicate);
-            }
-
-            @Override
-            public float matchCost() {
-                return cost;
-            }
-        });
     }
 
     static DocIdSetIterator multiValuedIterator(

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -109,11 +109,8 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
             return null;
         }
         return switch (binaryFormat) {
-            // A field framed this way is answered by its column, through the queries in the columnar library, and never
-            // arrives here - see BinaryDocValuesQueries, which is what chooses between the two.
-            case COLUMNAR_PAYLOAD -> throw new IllegalStateException(
-                "a columnar field is answered by its column, not by scanning [" + fieldName + "]"
-            );
+            // Refused by the constructor, so a query holding this format does not exist.
+            case COLUMNAR_PAYLOAD -> throw new AssertionError("columnar field [" + fieldName + "]");
             case ARRAY_ORDER_INLINE_NULL -> {
                 // ArrayOrderInlineNull always writes the .counts field (even for an all-null or empty array, which writes no blob), so
                 // the counts column drives iteration and count==1 is handled inside the inline-null reader as the raw case.

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
@@ -42,18 +42,13 @@ public final class BinaryDocValuesContainsTermQuery extends AbstractBinaryDocVal
         if (values == null) {
             return null;
         }
-        // A payload blob is never a bare value, so the whole-blob scan below can never apply to one — and there is no
-        // .counts companion to look up on the way to finding that out. super decodes the payload instead.
-        if (binaryFormat != BinaryDocValuesFormat.COLUMNAR_PAYLOAD) {
-            // tryContainsIterator scans the whole doc blob including the multi-valued length-prefix framing, so it is only
-            // correct for single-valued fields where no length prefixes exist.
-            final DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(fieldName + COUNT_FIELD_SUFFIX);
-            if ((countsSkipper == null || countsSkipper.maxValue() == 1)
-                && values instanceof BlockLoader.OptionalColumnAtATimeReader direct) {
-                final DocIdSetIterator containsIter = direct.tryContainsIterator(containsTerm);
-                if (containsIter != null) {
-                    return containsIter;
-                }
+        // tryContainsIterator scans the whole doc blob including the multi-valued length-prefix framing, so it is only
+        // correct for single-valued fields where no length prefixes exist.
+        final DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(fieldName + COUNT_FIELD_SUFFIX);
+        if ((countsSkipper == null || countsSkipper.maxValue() == 1) && values instanceof BlockLoader.OptionalColumnAtATimeReader direct) {
+            final DocIdSetIterator containsIter = direct.tryContainsIterator(containsTerm);
+            if (containsIter != null) {
+                return containsIter;
             }
         }
         return super.getDocIdSetIterator(context, matchCost);

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
@@ -83,11 +83,8 @@ final class BinaryDocValuesLengthQuery extends Query {
                         Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
                         String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
                         return switch (binaryFormat) {
-                            // Reached only by rewriting a term query for the empty term, and a columnar field's term
-                            // query is the column's own, which answers the empty term by bisecting like any other.
-                            case COLUMNAR_PAYLOAD -> throw new IllegalStateException(
-                                "a columnar field is answered by its column, not by scanning [" + fieldName + "]"
-                            );
+                            // Refused by the constructor, so a query holding this format does not exist.
+                            case COLUMNAR_PAYLOAD -> throw new AssertionError("columnar field [" + fieldName + "]");
                             case ARRAY_ORDER_INLINE_NULL, SEPARATE_COUNT -> {
                                 final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
                                 DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
@@ -47,7 +47,7 @@ final class BinaryDocValuesLengthQuery extends Query {
     BinaryDocValuesLengthQuery(String fieldName, int length, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = Objects.requireNonNull(fieldName);
         this.length = length;
-        this.binaryFormat = Objects.requireNonNull(binaryFormat);
+        this.binaryFormat = AbstractBinaryDocValuesQuery.rejectColumnar(binaryFormat, fieldName);
     }
 
     @Override
@@ -83,11 +83,10 @@ final class BinaryDocValuesLengthQuery extends Query {
                         Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
                         String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
                         return switch (binaryFormat) {
-                            // The payload carries its own count; its blob is never a bare value, so no fast path applies.
-                            case COLUMNAR_PAYLOAD -> AbstractBinaryDocValuesQuery.columnarPayloadIterator(
-                                values,
-                                lengthPredicate,
-                                matchCost
+                            // Reached only by rewriting a term query for the empty term, and a columnar field's term
+                            // query is the column's own, which answers the empty term by bisecting like any other.
+                            case COLUMNAR_PAYLOAD -> throw new IllegalStateException(
+                                "a columnar field is answered by its column, not by scanning [" + fieldName + "]"
                             );
                             case ARRAY_ORDER_INLINE_NULL, SEPARATE_COUNT -> {
                                 final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueries.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automaton;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
+
+import java.util.Collection;
+
+/**
+ * The queries a field answers from its binary doc values, for a field with no inverted index to answer them from.
+ *
+ * <p>How a document's values are framed on disk decides how a query over them is best answered, and the two are not the
+ * same question at every shape. A field whose doc values are a ColumNAR column can bisect an ordered column, match over
+ * a dictionary's ordinals, and test a term once for every value naming it; a field framed as a blob per document has to
+ * read every document and compare. Choosing between them once, here, keeps that decision out of the eight query methods
+ * on the field type, which would otherwise each grow a branch per format.
+ *
+ * <p>Implementations are stateless and chosen by {@link #forFormat}, so a field type holds one for the life of its
+ * mapping rather than deciding per query.
+ */
+public interface BinaryDocValuesQueries {
+
+    /** The implementation for {@code format}. */
+    static BinaryDocValuesQueries forFormat(BinaryDocValuesFormat format) {
+        return format == BinaryDocValuesFormat.COLUMNAR_PAYLOAD
+            ? ColumnarBinaryDocValuesQueries.INSTANCE
+            : new ScanningBinaryDocValuesQueries(format);
+    }
+
+    /** Documents holding exactly {@code term}. */
+    Query term(String field, BytesRef term);
+
+    /** Documents holding any of {@code terms}. */
+    Query terms(String field, Collection<BytesRef> terms);
+
+    /** Documents holding a value inside the bounds, either of which may be null for unbounded. */
+    Query range(String field, @Nullable BytesRef lower, @Nullable BytesRef upper, boolean includeLower, boolean includeUpper);
+
+    /** Documents holding a value that starts with {@code value}. */
+    Query prefix(String field, String value, boolean caseInsensitive);
+
+    /** Documents holding a value within {@code maxEdits} of {@code term}. */
+    Query fuzzy(String field, String term, int maxEdits, int prefixLength, boolean transpositions);
+
+    /** Documents holding {@code value}, compared without case. */
+    Query caseInsensitiveTerm(String field, String value);
+
+    /** Documents holding a value the wildcard pattern accepts. */
+    Query wildcard(String field, String pattern, boolean caseInsensitive);
+
+    /**
+     * Documents holding a value {@code automaton} accepts, for a caller that has already decided what its pattern means.
+     * {@code description} stands in for the automaton in equality, which is what lets two such queries share a cache entry.
+     */
+    Query automaton(String field, Automaton automaton, String description);
+
+    /** Documents holding a value the regular expression accepts. */
+    Query regexp(
+        String field,
+        String pattern,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        @Nullable CircuitBreaker breaker
+    );
+}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueries.java
@@ -24,19 +24,19 @@ import java.util.Collection;
  * <p>How a document's values are framed on disk decides how a query over them is best answered, and the two are not the
  * same question at every shape. A field whose doc values are a ColumNAR column can bisect an ordered column, match over
  * a dictionary's ordinals, and test a term once for every value naming it; a field framed as a blob per document has to
- * read every document and compare. Choosing between them once, here, keeps that decision out of the eight query methods
- * on the field type, which would otherwise each grow a branch per format.
+ * read every document and compare. Choosing between them once, here, keeps that decision out of the query methods on the
+ * field type, which would otherwise each grow a branch per format.
  *
- * <p>Implementations are stateless and chosen by {@link #forFormat}, so a field type holds one for the life of its
- * mapping rather than deciding per query.
+ * <p>Implementations are stateless, and {@link #forFormat} hands out one instance per format, so asking for them costs
+ * nothing and a field type need not hold its own.
  */
 public interface BinaryDocValuesQueries {
 
-    /** The implementation for {@code format}. */
+    /** The implementation for {@code format}, shared rather than built per call. */
     static BinaryDocValuesQueries forFormat(BinaryDocValuesFormat format) {
         return format == BinaryDocValuesFormat.COLUMNAR_PAYLOAD
             ? ColumnarBinaryDocValuesQueries.INSTANCE
-            : new ScanningBinaryDocValuesQueries(format);
+            : ScanningBinaryDocValuesQueries.forFormat(format);
     }
 
     /** Documents holding exactly {@code term}. */

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ColumnarBinaryDocValuesQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ColumnarBinaryDocValuesQueries.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.elasticsearch.columnar.ColumnarStringAutomatonQuery;
+import org.elasticsearch.columnar.ColumnarStringMatchQuery;
+import org.elasticsearch.columnar.ColumnarStringTermQuery;
+import org.elasticsearch.columnar.ScanBudget;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.search.internal.ContextIndexSearcher;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Queries answered by the ColumNAR string column itself rather than by reading a blob for every document.
+ *
+ * <p>What each costs is the column's own business and varies by what it is: a term or a prefix over a column whose
+ * values arrive in term order bisects to the run of matches, and a dictionary column runs a test over its terms and
+ * then answers documents by ordinal. What is shared is that a test is paid once per distinct value rather than once
+ * per document wherever the column can arrange it.
+ *
+ * <p>Automata are built here rather than in the column library, which has no dependency on the mapper's automaton
+ * helpers and no business deciding what a pattern means. The library runs whatever it is handed.
+ */
+final class ColumnarBinaryDocValuesQueries implements BinaryDocValuesQueries {
+
+    static final ColumnarBinaryDocValuesQueries INSTANCE = new ColumnarBinaryDocValuesQueries();
+
+    /**
+     * The column library keeps no notion of a heap budget, so it is handed one. Every columnar query consults this once
+     * per segment before it reads anything - matching a term against a dictionary reads every term, and a segment that
+     * arrives as an overlay rather than as a column is decoded a document at a time.
+     */
+    private static final ScanBudget BUDGET = ContextIndexSearcher::checkBinaryDvDecodeBreaker;
+
+    private ColumnarBinaryDocValuesQueries() {}
+
+    @Override
+    public Query term(String field, BytesRef term) {
+        return ColumnarStringTermQuery.term(field, term, BUDGET);
+    }
+
+    @Override
+    public Query terms(String field, Collection<BytesRef> terms) {
+        final Set<BytesRef> set = new HashSet<>(terms);
+        // What the query is compared by, so two of them cache as one however the caller ordered its terms. The terms
+        // themselves rather than a rendering of them: there may be tens of thousands.
+        return new ColumnarStringMatchQuery(field, set::contains, new TreeSet<>(terms), BUDGET);
+    }
+
+    @Override
+    public Query range(String field, @Nullable BytesRef lower, @Nullable BytesRef upper, boolean includeLower, boolean includeUpper) {
+        final BytesRef low = lower == null ? null : BytesRef.deepCopyOf(lower);
+        final BytesRef high = upper == null ? null : BytesRef.deepCopyOf(upper);
+        final String identity = "range=" + (includeLower ? "[" : "{") + low + "," + high + (includeUpper ? "]" : "}");
+        return new ColumnarStringMatchQuery(field, value -> {
+            if (low != null) {
+                final int cmp = value.compareTo(low);
+                if (cmp < 0 || (cmp == 0 && includeLower == false)) {
+                    return false;
+                }
+            }
+            if (high != null) {
+                final int cmp = value.compareTo(high);
+                return cmp < 0 || (cmp == 0 && includeUpper);
+            }
+            return true;
+        }, identity, BUDGET);
+    }
+
+    @Override
+    public Query prefix(String field, String value, boolean caseInsensitive) {
+        if (caseInsensitive == false) {
+            // The column bisects a prefix, so this never becomes an automaton.
+            return ColumnarStringTermQuery.prefix(field, new BytesRef(value), BUDGET);
+        }
+        return new ColumnarStringAutomatonQuery(
+            field,
+            AutomatonQueries.caseInsensitivePrefix(value),
+            "caseInsensitivePrefix=" + value,
+            BUDGET
+        );
+    }
+
+    @Override
+    public Query fuzzy(String field, String term, int maxEdits, int prefixLength, boolean transpositions) {
+        // The compiled automaton comes from the query that defines the edit distance, as the scanning path also does.
+        final FuzzyQuery delegate = FuzzyQueries.create(
+            new Term(field, term),
+            maxEdits,
+            prefixLength,
+            1,
+            transpositions,
+            null,
+            null,
+            field
+        );
+        return new ColumnarStringAutomatonQuery(
+            field,
+            delegate.getAutomata().runAutomaton,
+            "fuzzy,term=" + term + ",maxEdits=" + maxEdits + ",prefixLength=" + prefixLength + ",transpositions=" + transpositions,
+            BUDGET
+        );
+    }
+
+    @Override
+    public Query caseInsensitiveTerm(String field, String value) {
+        return new ColumnarStringAutomatonQuery(field, Automata.makeCaseInsensitiveString(value), "caseInsensitiveTerm=" + value, BUDGET);
+    }
+
+    @Override
+    public Query wildcard(String field, String pattern, boolean caseInsensitive) {
+        if (caseInsensitive == false) {
+            // Rewrites a pattern naming a term, a prefix or a contained run into the query that answers it directly.
+            return ColumnarStringAutomatonQuery.forWildcard(field, pattern, BUDGET);
+        }
+        return new ColumnarStringAutomatonQuery(
+            field,
+            AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term(field, pattern)),
+            "pattern=" + pattern + ",caseInsensitive=true",
+            BUDGET
+        );
+    }
+
+    @Override
+    public Query automaton(String field, Automaton automaton, String description) {
+        return new ColumnarStringAutomatonQuery(field, automaton, description, BUDGET);
+    }
+
+    @Override
+    public Query regexp(
+        String field,
+        String pattern,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        @Nullable CircuitBreaker breaker
+    ) {
+        return new ColumnarStringAutomatonQuery(
+            field,
+            // The byte-run form, as the scanning path uses: it is the one that tolerates a caller with no breaker.
+            AutomatonQueries.toRegexpByteRunAutomaton(field, pattern, syntaxFlags, matchFlags, maxDeterminizedStates, breaker),
+            "regexp=" + pattern + ",flags=" + syntaxFlags + "," + matchFlags,
+            BUDGET
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ColumnarBinaryDocValuesQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ColumnarBinaryDocValuesQueries.java
@@ -45,11 +45,7 @@ final class ColumnarBinaryDocValuesQueries implements BinaryDocValuesQueries {
 
     static final ColumnarBinaryDocValuesQueries INSTANCE = new ColumnarBinaryDocValuesQueries();
 
-    /**
-     * The column library keeps no notion of a heap budget, so it is handed one. Every columnar query consults this once
-     * per segment before it reads anything - matching a term against a dictionary reads every term, and a segment that
-     * arrives as an overlay rather than as a column is decoded a document at a time.
-     */
+    /** The column library keeps no notion of a heap budget, so it is handed the search layer's. */
     private static final ScanBudget BUDGET = ContextIndexSearcher::checkBinaryDvDecodeBreaker;
 
     private ColumnarBinaryDocValuesQueries() {}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesQueries.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automaton;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Queries over binary doc values that carry a blob per document: every one of them is read and compared. The framing of
+ * that blob still varies, so it is carried through to whichever reader decodes it.
+ */
+final class ScanningBinaryDocValuesQueries implements BinaryDocValuesQueries {
+
+    private final BinaryDocValuesFormat format;
+
+    ScanningBinaryDocValuesQueries(BinaryDocValuesFormat format) {
+        this.format = Objects.requireNonNull(format);
+    }
+
+    @Override
+    public Query term(String field, BytesRef term) {
+        return new ScanningBinaryDocValuesTermQuery(field, term, format);
+    }
+
+    @Override
+    public Query terms(String field, Collection<BytesRef> terms) {
+        return new ScanningBinaryDocValuesTermInSetQuery(field, List.copyOf(terms), format);
+    }
+
+    @Override
+    public Query range(String field, @Nullable BytesRef lower, @Nullable BytesRef upper, boolean includeLower, boolean includeUpper) {
+        return new ScanningBinaryDocValuesRangeQuery(field, lower, upper, includeLower, includeUpper, format);
+    }
+
+    @Override
+    public Query prefix(String field, String value, boolean caseInsensitive) {
+        return new ScanningBinaryDocValuesPrefixQuery(field, value, caseInsensitive, format);
+    }
+
+    @Override
+    public Query fuzzy(String field, String term, int maxEdits, int prefixLength, boolean transpositions) {
+        return ScanningBinaryDocValuesAutomatonQuery.forFuzzy(field, term, maxEdits, prefixLength, transpositions, format);
+    }
+
+    @Override
+    public Query caseInsensitiveTerm(String field, String value) {
+        return ScanningBinaryDocValuesAutomatonQuery.forCaseInsensitiveTerm(field, value, format);
+    }
+
+    @Override
+    public Query wildcard(String field, String pattern, boolean caseInsensitive) {
+        return ScanningBinaryDocValuesAutomatonQuery.forWildcard(field, pattern, caseInsensitive, format);
+    }
+
+    @Override
+    public Query automaton(String field, Automaton automaton, String description) {
+        return new ScanningBinaryDocValuesAutomatonQuery(field, automaton, format, description);
+    }
+
+    @Override
+    public Query regexp(
+        String field,
+        String pattern,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        @Nullable CircuitBreaker breaker
+    ) {
+        return new ScanningBinaryDocValuesRegexpQuery(field, pattern, syntaxFlags, matchFlags, maxDeterminizedStates, format, breaker);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesQueries.java
@@ -16,9 +16,14 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Queries over binary doc values that carry a blob per document: every one of them is read and compared. The framing of
@@ -26,9 +31,27 @@ import java.util.Objects;
  */
 final class ScanningBinaryDocValuesQueries implements BinaryDocValuesQueries {
 
+    /**
+     * One per format, since the format is all that distinguishes them. A columnar field is answered by its column and
+     * not by scanning, so there is nothing here for it and asking is a routing mistake.
+     */
+    private static final Map<BinaryDocValuesFormat, ScanningBinaryDocValuesQueries> BY_FORMAT = new EnumMap<>(
+        Arrays.stream(BinaryDocValuesFormat.values())
+            .filter(format -> format != BinaryDocValuesFormat.COLUMNAR_PAYLOAD)
+            .collect(Collectors.toMap(Function.identity(), ScanningBinaryDocValuesQueries::new))
+    );
+
+    static ScanningBinaryDocValuesQueries forFormat(BinaryDocValuesFormat format) {
+        final ScanningBinaryDocValuesQueries queries = BY_FORMAT.get(Objects.requireNonNull(format));
+        if (queries == null) {
+            throw new IllegalArgumentException("[" + format + "] is answered by the column, not by scanning");
+        }
+        return queries;
+    }
+
     private final BinaryDocValuesFormat format;
 
-    ScanningBinaryDocValuesQueries(BinaryDocValuesFormat format) {
+    private ScanningBinaryDocValuesQueries(BinaryDocValuesFormat format) {
         this.format = Objects.requireNonNull(format);
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQuery.java
@@ -59,19 +59,14 @@ public class ScanningBinaryDocValuesTermQuery extends AbstractBinaryDocValuesQue
         if (values == null) {
             return null;
         }
-        // A payload blob is never a bare term, so the direct comparison below can never apply to one — and there is no
-        // .counts companion to look up on the way to finding that out.
-        if (binaryFormat != BinaryDocValuesFormat.COLUMNAR_PAYLOAD) {
-            DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(fieldName + COUNT_FIELD_SUFFIX);
-            // tryTermEqualIterator is only valid for single-valued fields (see its javadoc on
-            // BlockLoader.OptionalColumnAtATimeReader). It returns a TwoPhaseIterator-backed iterator,
-            // so sub-segment slicing (DataPartitioning.DOC) scales with cores.
-            if ((countsSkipper == null || countsSkipper.maxValue() <= 1)
-                && values instanceof BlockLoader.OptionalColumnAtATimeReader direct) {
-                DocIdSetIterator iter = direct.tryTermEqualIterator(term);
-                if (iter != null) {
-                    return iter;
-                }
+        DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(fieldName + COUNT_FIELD_SUFFIX);
+        // tryTermEqualIterator is only valid for single-valued fields (see its javadoc on
+        // BlockLoader.OptionalColumnAtATimeReader). It returns a TwoPhaseIterator-backed iterator,
+        // so sub-segment slicing (DataPartitioning.DOC) scales with cores.
+        if ((countsSkipper == null || countsSkipper.maxValue() <= 1) && values instanceof BlockLoader.OptionalColumnAtATimeReader direct) {
+            DocIdSetIterator iter = direct.tryTermEqualIterator(term);
+            if (iter != null) {
+                return iter;
             }
         }
         // Fall back to the scanning two-phase path (handles multi-valued via the counts field).

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -196,6 +196,15 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
      * once the accumulating buffers push heap over the limit - turning a node OOM into a recoverable
      * {@link org.elasticsearch.common.breaker.CircuitBreakingException}.
      */
+    /**
+     * As {@link #checkBinaryDvDecodeBreaker(CircuitBreaker)}, resolving the breaker from {@code searcher}. Shaped to be
+     * passed as a method reference where a caller can only be handed a searcher - see {@code ScanBudget} in the columnar
+     * library, which has no notion of a circuit breaker of its own.
+     */
+    public static void checkBinaryDvDecodeBreaker(IndexSearcher searcher) {
+        checkBinaryDvDecodeBreaker(circuitBreakerOrNull(searcher));
+    }
+
     public static void checkBinaryDvDecodeBreaker(@Nullable CircuitBreaker breaker) {
         if (breaker != null) {
             // Passing 0 bytes means the child breaker never accumulates and hence there is no need to explicitly release anything.

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -196,6 +196,14 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
      * once the accumulating buffers push heap over the limit - turning a node OOM into a recoverable
      * {@link org.elasticsearch.common.breaker.CircuitBreakingException}.
      */
+    public static void checkBinaryDvDecodeBreaker(@Nullable CircuitBreaker breaker) {
+        if (breaker != null) {
+            // Passing 0 bytes means the child breaker never accumulates and hence there is no need to explicitly release anything.
+            // The call still runs the parent's real-heap check, which trips once the accumulating buffers push heap over the limit.
+            breaker.addEstimateBytesAndMaybeBreak(0L, "binary_doc_values_decode");
+        }
+    }
+
     /**
      * As {@link #checkBinaryDvDecodeBreaker(CircuitBreaker)}, resolving the breaker from {@code searcher}. Shaped to be
      * passed as a method reference where a caller can only be handed a searcher - see {@code ScanBudget} in the columnar
@@ -203,14 +211,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
      */
     public static void checkBinaryDvDecodeBreaker(IndexSearcher searcher) {
         checkBinaryDvDecodeBreaker(circuitBreakerOrNull(searcher));
-    }
-
-    public static void checkBinaryDvDecodeBreaker(@Nullable CircuitBreaker breaker) {
-        if (breaker != null) {
-            // Passing 0 bytes means the child breaker never accumulates and hence there is no need to explicitly release anything.
-            // The call still runs the parent's real-heap check, which trips once the accumulating buffers push heap over the limit.
-            breaker.addEstimateBytesAndMaybeBreak(0L, "binary_doc_values_decode");
-        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordCodecTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
@@ -27,7 +28,9 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -256,6 +259,112 @@ public class ColumnarKeywordCodecTests extends ESSingleNodeTestCase {
         assertHitCount(client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("kw", "")), 1);
         // A pattern that accepts the empty string still must not accept a null.
         assertHitCount(client().prepareSearch(INDEX).setQuery(QueryBuilders.regexpQuery("kw", "[ab]*")), 3);
+    }
+
+    /**
+     * Every query shape the mapper can build, answered by the column and by the format it replaces, over the same
+     * documents. The columnar path bisects, matches over ordinals and tests a term once for every value naming it,
+     * which is a different implementation of every one of these - so the only thing that says it is right is that it
+     * agrees with the path it is standing in for, on documents holding several values, nulls, and the empty string.
+     */
+    public void testEveryQueryShapeAgreesWithTheFormatItReplaces() throws IOException {
+        assumeTrue("columnar_codec feature flag must be enabled", ColumnarDocValuesFormatSelector.COLUMNAR_CODEC_FEATURE_FLAG.isEnabled());
+
+        final IndexMode mode = randomFrom(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR);
+        final String mapping = """
+            {"properties":{"@timestamp":{"type":"date"},"kw":{"type":"keyword","index":false}}}""";
+        final List<String> docs = List.of(
+            "\"alpha\"",
+            "[\"alpha\", \"beta\"]",
+            "[\"gamma\", null, \"alpha\"]",
+            "null",
+            "[null]",
+            "\"\"",
+            "[\"\", null]",
+            "\"ALPHA\"",
+            "\"alphabet\"",
+            "[\"delta\", \"delta\"]",
+            "\"zeta\"",
+            "[]"
+        );
+
+        final String withCodec = INDEX + "-codec";
+        final String withoutCodec = INDEX + "-no-codec";
+        for (boolean on : new boolean[] { true, false }) {
+            final String index = on ? withCodec : withoutCodec;
+            indicesAdmin().prepareCreate(index).setSettings(columnarSettings(mode, on)).setMapping(mapping).get();
+            for (int i = 0; i < docs.size(); i++) {
+                prepareIndex(index).setId(Integer.toString(i))
+                    .setSource("{\"@timestamp\":\"2024-01-01T00:00:0" + (i % 10) + "Z\",\"kw\":" + docs.get(i) + "}", XContentType.JSON)
+                    .get();
+            }
+            indicesAdmin().prepareRefresh(index).get();
+        }
+        // Without these the two agreeing would prove nothing, since neither would have reached the codec.
+        assertKeywordFieldUsesColumnarFormat(withCodec);
+        assertKeywordFieldAvoidsColumnarFormat(withoutCodec);
+
+        final Map<String, QueryBuilder> shapes = new LinkedHashMap<>();
+        shapes.put("term", QueryBuilders.termQuery("kw", "alpha"));
+        shapes.put("term empty", QueryBuilders.termQuery("kw", ""));
+        shapes.put("term absent", QueryBuilders.termQuery("kw", "nothing"));
+        shapes.put("terms", QueryBuilders.termsQuery("kw", "alpha", "zeta", "nothing"));
+        shapes.put("terms with empty", QueryBuilders.termsQuery("kw", "", "delta"));
+        shapes.put("prefix", QueryBuilders.prefixQuery("kw", "alph"));
+        shapes.put("prefix empty", QueryBuilders.prefixQuery("kw", ""));
+        shapes.put("prefix ci", QueryBuilders.prefixQuery("kw", "ALPH").caseInsensitive(true));
+        shapes.put("range", QueryBuilders.rangeQuery("kw").gte("alpha").lte("delta"));
+        shapes.put("range open lower", QueryBuilders.rangeQuery("kw").lt("beta"));
+        shapes.put("range open upper", QueryBuilders.rangeQuery("kw").gt("delta"));
+        shapes.put("range exclusive", QueryBuilders.rangeQuery("kw").gt("alpha").lt("zeta"));
+        shapes.put("wildcard", QueryBuilders.wildcardQuery("kw", "al*a"));
+        shapes.put("wildcard contains", QueryBuilders.wildcardQuery("kw", "*lph*"));
+        shapes.put("wildcard ci", QueryBuilders.wildcardQuery("kw", "al*A").caseInsensitive(true));
+        shapes.put("regexp", QueryBuilders.regexpQuery("kw", "[ad].*a"));
+        shapes.put("regexp accepting empty", QueryBuilders.regexpQuery("kw", "[a-z]*"));
+        shapes.put("fuzzy", QueryBuilders.fuzzyQuery("kw", "alpxa"));
+        shapes.put("term ci", QueryBuilders.termQuery("kw", "ALPHA").caseInsensitive(true));
+
+        for (var shape : shapes.entrySet()) {
+            final List<String> columnar = hits(withCodec, shape.getValue());
+            final List<String> plain = hits(withoutCodec, shape.getValue());
+            assertEquals(shape.getKey(), plain, columnar);
+        }
+
+        // exists is the one shape that deliberately does not agree. The codec writes a payload for an explicit null,
+        // which is what keeps an all-null array distinct from an absent field, so such a document has the field where
+        // under the format it replaces it does not. Documents 3 ("null") and 4 ("[null]") are the difference; the
+        // empty array of document 11 writes nothing either way and is absent from both.
+        final List<String> existsColumnar = hits(withCodec, QueryBuilders.existsQuery("kw"));
+        final List<String> existsPlain = hits(withoutCodec, QueryBuilders.existsQuery("kw"));
+        assertFalse("an explicit null is not present without the codec", existsPlain.contains("3"));
+        assertFalse("nor is an all-null array", existsPlain.contains("4"));
+        assertTrue("but it is with it", existsColumnar.contains("3"));
+        assertTrue("and so is an all-null array", existsColumnar.contains("4"));
+        assertFalse("an empty array is absent either way", existsColumnar.contains("11") || existsPlain.contains("11"));
+        final List<String> expected = new ArrayList<>(existsPlain);
+        expected.add("3");
+        expected.add("4");
+        expected.sort(String::compareTo);
+        assertEquals("and nothing else differs", expected, existsColumnar);
+    }
+
+    /** The ids a query matches, in order, so a disagreement names the documents rather than just a count. */
+    private List<String> hits(String index, QueryBuilder query) {
+        final var response = client().prepareSearch(index)
+            .setQuery(query)
+            .addSort("_id", org.elasticsearch.search.sort.SortOrder.ASC)
+            .setSize(100)
+            .get();
+        try {
+            final List<String> ids = new ArrayList<>();
+            for (var hit : response.getHits().getHits()) {
+                ids.add(hit.getId());
+            }
+            return ids;
+        } finally {
+            response.decRef();
+        }
     }
 
     private static Settings columnarSettings(IndexMode mode) {

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueriesTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueriesTests.java
@@ -21,6 +21,8 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.hamcrest.Matchers.containsString;
+
 /**
  * Which query each format answers a shape with. The results these produce are checked against each other elsewhere, over
  * real documents; what this pins is that the columnar format reaches the column at all. Nothing else would notice if it
@@ -95,6 +97,15 @@ public class BinaryDocValuesQueriesTests extends ESTestCase {
         assertNotEquals(queries.prefix(FIELD, "abc", true), queries.prefix(FIELD, "abd", true));
         assertNotEquals(queries.caseInsensitiveTerm(FIELD, "abc"), queries.caseInsensitiveTerm(FIELD, "abd"));
         assertNotEquals(queries.regexp(FIELD, "a.*", 0, 0, 10000, null), queries.regexp(FIELD, "b.*", 0, 0, 10000, null));
+    }
+
+    /** A columnar field is answered by its column, so asking for a scan of one fails where it is asked. */
+    public void testAColumnHasNoScanningQuery() {
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ScanningBinaryDocValuesQueries.forFormat(BinaryDocValuesFormat.COLUMNAR_PAYLOAD)
+        );
+        assertThat(e.getMessage(), containsString("not by scanning"));
     }
 
     /** A description stands in for a predicate, so two equal queries share a cache entry. */

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueriesTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesQueriesTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automata;
+import org.elasticsearch.columnar.ColumnarStringAutomatonQuery;
+import org.elasticsearch.columnar.ColumnarStringMatchQuery;
+import org.elasticsearch.columnar.ColumnarStringTermQuery;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Which query each format answers a shape with. The results these produce are checked against each other elsewhere, over
+ * real documents; what this pins is that the columnar format reaches the column at all. Nothing else would notice if it
+ * stopped: the scanning path answers every one of these correctly, only by reading a value for every document, so a
+ * regression that quietly routed a columnar field back to it would leave every other test green.
+ */
+public class BinaryDocValuesQueriesTests extends ESTestCase {
+
+    private static final String FIELD = "kw";
+
+    /** Every shape, and the query the column answers it with. */
+    private static List<Shape> shapes() {
+        return List.of(
+            new Shape("term", q -> q.term(FIELD, new BytesRef("a")), ColumnarStringTermQuery.class),
+            new Shape("terms", q -> q.terms(FIELD, List.of(new BytesRef("a"), new BytesRef("b"))), ColumnarStringMatchQuery.class),
+            new Shape("range", q -> q.range(FIELD, new BytesRef("a"), new BytesRef("b"), true, false), ColumnarStringMatchQuery.class),
+            // A prefix is a run the column can bisect, so it never becomes an automaton.
+            new Shape("prefix", q -> q.prefix(FIELD, "a", false), ColumnarStringTermQuery.class),
+            new Shape("prefix ci", q -> q.prefix(FIELD, "a", true), ColumnarStringAutomatonQuery.class),
+            new Shape("fuzzy", q -> q.fuzzy(FIELD, "abc", 1, 0, true), ColumnarStringAutomatonQuery.class),
+            new Shape("term ci", q -> q.caseInsensitiveTerm(FIELD, "a"), ColumnarStringAutomatonQuery.class),
+            // A pattern naming a whole value, a prefix or a contained run is rewritten to the query that answers it.
+            new Shape("wildcard literal", q -> q.wildcard(FIELD, "abc", false), ColumnarStringTermQuery.class),
+            new Shape("wildcard prefix", q -> q.wildcard(FIELD, "abc*", false), ColumnarStringTermQuery.class),
+            new Shape("wildcard contains", q -> q.wildcard(FIELD, "*abc*", false), ColumnarStringTermQuery.class),
+            new Shape("wildcard", q -> q.wildcard(FIELD, "a*b*c", false), ColumnarStringAutomatonQuery.class),
+            new Shape("wildcard ci", q -> q.wildcard(FIELD, "a*b", true), ColumnarStringAutomatonQuery.class),
+            new Shape("regexp", q -> q.regexp(FIELD, "a.*", 0, 0, 10000, null), ColumnarStringAutomatonQuery.class),
+            new Shape("automaton", q -> q.automaton(FIELD, Automata.makeString("a"), "described"), ColumnarStringAutomatonQuery.class)
+        );
+    }
+
+    private record Shape(String name, Function<BinaryDocValuesQueries, Query> build, Class<? extends Query> columnar) {}
+
+    public void testColumnarFormatReachesTheColumn() {
+        final BinaryDocValuesQueries queries = BinaryDocValuesQueries.forFormat(BinaryDocValuesFormat.COLUMNAR_PAYLOAD);
+        for (Shape shape : shapes()) {
+            final Query query = shape.build().apply(queries);
+            assertEquals(shape.name(), shape.columnar(), query.getClass());
+        }
+    }
+
+    /** The formats that carry a blob per document keep reading one, whatever the shape. */
+    public void testBlobFormatsScan() {
+        for (BinaryDocValuesFormat format : List.of(BinaryDocValuesFormat.SEPARATE_COUNT, BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL)) {
+            final BinaryDocValuesQueries queries = BinaryDocValuesQueries.forFormat(format);
+            for (Shape shape : shapes()) {
+                final Query query = shape.build().apply(queries);
+                assertFalse(
+                    format + " " + shape.name() + " reached the column",
+                    query.getClass().getPackageName().startsWith("org.elasticsearch.columnar")
+                );
+            }
+        }
+    }
+
+    /**
+     * Every parameter that changes which documents a pattern matches has to reach {@link Query#equals}, or two
+     * queries that ask different things share a cache entry and a {@code bool} keeping both collapses them into one.
+     * An automaton carries what it was built from, which is what makes this hold however the description is spelt.
+     */
+    public void testPatternQueriesCompareOnWhatTheyMatch() {
+        final BinaryDocValuesQueries queries = BinaryDocValuesQueries.forFormat(BinaryDocValuesFormat.COLUMNAR_PAYLOAD);
+        assertEquals(queries.fuzzy(FIELD, "alpha", 1, 0, true), queries.fuzzy(FIELD, "alpha", 1, 0, true));
+        assertNotEquals(queries.fuzzy(FIELD, "alpha", 1, 0, true), queries.fuzzy(FIELD, "alpha", 2, 0, true));
+        // A prefix the edit distance may not touch, so the two accept different values.
+        assertNotEquals(queries.fuzzy(FIELD, "alpha", 1, 0, true), queries.fuzzy(FIELD, "alpha", 1, 3, true));
+        // Whether a transposition counts as one edit or two, so "alhpa" is accepted by one and not the other.
+        assertNotEquals(queries.fuzzy(FIELD, "alpha", 1, 0, true), queries.fuzzy(FIELD, "alpha", 1, 0, false));
+        assertNotEquals(queries.wildcard(FIELD, "a*b", false), queries.wildcard(FIELD, "a*c", false));
+        assertNotEquals(queries.wildcard(FIELD, "a*b", false), queries.wildcard(FIELD, "a*b", true));
+        assertNotEquals(queries.prefix(FIELD, "abc", true), queries.prefix(FIELD, "abd", true));
+        assertNotEquals(queries.caseInsensitiveTerm(FIELD, "abc"), queries.caseInsensitiveTerm(FIELD, "abd"));
+        assertNotEquals(queries.regexp(FIELD, "a.*", 0, 0, 10000, null), queries.regexp(FIELD, "b.*", 0, 0, 10000, null));
+    }
+
+    /** A description stands in for a predicate, so two equal queries share a cache entry. */
+    public void testQueriesWithNoNaturalEqualityStillCompare() {
+        final BinaryDocValuesQueries queries = BinaryDocValuesQueries.forFormat(BinaryDocValuesFormat.COLUMNAR_PAYLOAD);
+        assertEquals(
+            queries.terms(FIELD, List.of(new BytesRef("a"), new BytesRef("b"))),
+            queries.terms(FIELD, List.of(new BytesRef("b"), new BytesRef("a")))
+        );
+        assertNotEquals(queries.terms(FIELD, List.of(new BytesRef("a"))), queries.terms(FIELD, List.of(new BytesRef("b"))));
+        assertEquals(
+            queries.range(FIELD, new BytesRef("a"), new BytesRef("b"), true, false),
+            queries.range(FIELD, new BytesRef("a"), new BytesRef("b"), true, false)
+        );
+        assertNotEquals(
+            queries.range(FIELD, new BytesRef("a"), new BytesRef("b"), true, false),
+            queries.range(FIELD, new BytesRef("a"), new BytesRef("b"), true, true)
+        );
+    }
+}


### PR DESCRIPTION
Keyword fields in a strict-columnar index have no inverted index, so every filter on one is answered from doc values. Today that means reading the blob of every document and comparing, whatever those doc values are framed as.

This routes those filters by that framing. `BinaryDocValuesQueries` is chosen once from the field's `BinaryDocValuesFormat` and hands out one implementation per format, so the query methods on `KeywordFieldType` delegate instead of each growing a branch. A field stored as a ColumNAR column gets queries the column answers itself: a term or a prefix by bisecting an ordered column, a wildcard narrowed to whichever of those it turns out to be, and a set, a range or a length as one test per dictionary term that every value naming it inherits, with only escaped values tested on their own. Every other format keeps the scanning queries it already had.

`ColumnarStringMatchQuery` is new and covers the shapes that are a predicate and nothing more. It is compared and cached on whatever the caller built that predicate from, and `ColumnarStringAutomatonQuery` on the automaton itself, so two queries that ask different things cannot share a cache entry however their descriptions are spelt.

`ScanBudget` is the seam through which the search layer's circuit breaker reaches the columnar library, which keeps no notion of one. It is consulted once per segment when the scorer is asked for its iterator, so nothing is opened or allocated ahead of it.

A columnar field no longer reaches the scanning queries at all: they refuse one where the query is built, so the arms that used to serve it are unreachable and say so.
