### PR TITLE
Read a keyword column a page at a time for ES|QL

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/StringFormat.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/StringFormat.java
@@ -808,7 +808,7 @@ public enum StringFormat {
         long checksum;
 
         @Override
-        public void appendOrdinals(int[] ordinals, int count, BytesRef[] dictionary, int dictionarySize) {
+        public void appendOrdinals(int[] ordinals, int count, int[] valueCounts, int docCount, BytesRef[] dictionary, int dictionarySize) {
             // One hash a distinct value rather than one a document, which is the whole point of the page
             // coming back as ordinals.
             for (int i = 0; i < dictionarySize; i++) {
@@ -820,7 +820,7 @@ public enum StringFormat {
         }
 
         @Override
-        public void appendValues(BytesRef[] values, int count) {
+        public void appendValues(BytesRef[] values, int count, int[] valueCounts, int docCount) {
             for (int i = 0; i < count; i++) {
                 checksum += StringFormat.group(groups, values[i]);
             }
@@ -831,14 +831,14 @@ public enum StringFormat {
         long checksum;
 
         @Override
-        public void appendOrdinals(int[] ordinals, int count, BytesRef[] dictionary, int dictionarySize) {
+        public void appendOrdinals(int[] ordinals, int count, int[] valueCounts, int docCount, BytesRef[] dictionary, int dictionarySize) {
             for (int i = 0; i < count; i++) {
                 checksum += dictionary[ordinals[i]].length;
             }
         }
 
         @Override
-        public void appendValues(BytesRef[] values, int count) {
+        public void appendValues(BytesRef[] values, int count, int[] valueCounts, int docCount) {
             for (int i = 0; i < count; i++) {
                 checksum += values[i].length;
             }
@@ -852,7 +852,7 @@ public enum StringFormat {
         long checksum;
 
         @Override
-        public void appendOrdinals(int[] ordinals, int count, BytesRef[] dictionary, int dictionarySize) {
+        public void appendOrdinals(int[] ordinals, int count, int[] valueCounts, int docCount, BytesRef[] dictionary, int dictionarySize) {
             if (groupOf.length < dictionarySize) {
                 groupOf = new int[dictionarySize];
             }
@@ -865,7 +865,7 @@ public enum StringFormat {
         }
 
         @Override
-        public void appendValues(BytesRef[] values, int count) {
+        public void appendValues(BytesRef[] values, int count, int[] valueCounts, int docCount) {
             for (int i = 0; i < count; i++) {
                 checksum += group(groups, values[i]);
             }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
@@ -63,6 +63,11 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues impleme
     }
 
     @Override
+    public BytesRef extreme(boolean max, BytesRef dst) throws IOException {
+        return reader.extreme(iterator.rank(), max, dst);
+    }
+
+    @Override
     public boolean advanceExact(int target) throws IOException {
         return iterator.advanceExact(target);
     }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
@@ -68,6 +68,29 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues impleme
     }
 
     @Override
+    public int nonNullValues(BytesRef dst) throws IOException {
+        final int rank = iterator.rank();
+        final long first = reader.firstValueAddress(rank);
+        final long count = reader.valueCount(rank);
+        int found = 0;
+        for (long i = 0; i < count; i++) {
+            final long address = first + i;
+            if (reader.isNullSlot(address)) {
+                continue;
+            }
+            if (++found > 1) {
+                // The caller wants the arity, not the values, and has what it needs the moment there are two.
+                return 2;
+            }
+            final BytesRef value = reader.valueAt(address);
+            dst.bytes = value.bytes;
+            dst.offset = value.offset;
+            dst.length = value.length;
+        }
+        return found;
+    }
+
+    @Override
     public boolean advanceExact(int target) throws IOException {
         return iterator.advanceExact(target);
     }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
@@ -222,6 +222,49 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
         return best < 0 ? null : termAt(best, dst);
     }
 
+    /**
+     * How many values the column's vocabulary names: its terms, and the values that escaped them.
+     *
+     * <p>A column has one of these for its whole life, so a consumer that resolves it does so once for the segment
+     * however many pages it reads. That is the point of it: a page-local dictionary has to be rebuilt, and everything
+     * derived from it recomputed, for every page, because each page's is a different one.
+     */
+    public int vocabularySize() {
+        return dictionarySize + Math.toIntExact(escapeCount);
+    }
+
+    /**
+     * Reads the vocabulary into {@code into}, which must hold {@link #vocabularySize} entries. The terms come first,
+     * in term order, and the values that escaped them follow in the order they were written - so a term keeps the
+     * ordinal it has in the column, and an escape takes one past the last of them.
+     *
+     * <p>The escapes are the whole of what makes this more than the dictionary. A value that escaped is named by no
+     * term, and naming it here is what lets every value of the column index one vector.
+     */
+    public void readVocabulary(BytesRef[] into) throws IOException {
+        for (int i = 0; i < dictionarySize; i++) {
+            termAt(i + StringColumnMetadata.Dictionary.FIRST_TERM_ORDINAL, into[i]);
+        }
+        for (int i = 0; i < escapeCount; i++) {
+            escapes.get(i, into[dictionarySize + i]);
+        }
+    }
+
+    /**
+     * Where the value at {@code valueAddress} sits in {@link #readVocabulary}, or -1 when the slot is null and names
+     * nothing at all.
+     */
+    public int vocabularyOrdinalAt(long valueAddress) throws IOException {
+        final int ordinal = ordinalAt(valueAddress);
+        if (ordinal == StringColumnMetadata.Dictionary.NULL_ORDINAL) {
+            return -1;
+        }
+        if (ordinal == escapeOrdinal) {
+            return dictionarySize + Math.toIntExact(escapeRankOf(valueAddress));
+        }
+        return ordinal - StringColumnMetadata.Dictionary.FIRST_TERM_ORDINAL;
+    }
+
     /** The value behind the escape marker at {@code valueAddress}, for a consumer that took ordinals. */
     public BytesRef resolveEscape(long valueAddress, BytesRef dst) throws IOException {
         escapes.get(escapeRankOf(valueAddress), dst);

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
@@ -195,12 +195,12 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
 
     /**
      * The extreme value, decided over ordinals. The dictionary is in term order, so the largest ordinal a document
-     * holds names its largest value and the smallest its smallest - the terms are never read to find out, and only the
+     * holds names its largest value and the smallest its smallest — the terms are never read to find out, and only the
      * one that wins is resolved.
      *
-     * <p>Two ordinals are not terms and neither can be compared as one. A null is no value, so it is passed over. An
-     * escaped value sorts wherever its bytes do, which its ordinal - one past every term - does not say, so a document
-     * holding one is decided by comparing bytes after all.
+     * <p>Two slots do not order that way. A null is no value, so it is passed over. An escaped value sorts wherever its
+     * bytes do, which its ordinal — one past every term — does not say, so a document holding one is decided by
+     * comparing bytes after all.
      */
     @Override
     public BytesRef extreme(int rank, boolean max, BytesRef dst) throws IOException {

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
@@ -222,49 +222,6 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
         return best < 0 ? null : termAt(best, dst);
     }
 
-    /**
-     * How many values the column's vocabulary names: its terms, and the values that escaped them.
-     *
-     * <p>A column has one of these for its whole life, so a consumer that resolves it does so once for the segment
-     * however many pages it reads. That is the point of it: a page-local dictionary has to be rebuilt, and everything
-     * derived from it recomputed, for every page, because each page's is a different one.
-     */
-    public int vocabularySize() {
-        return dictionarySize + Math.toIntExact(escapeCount);
-    }
-
-    /**
-     * Reads the vocabulary into {@code into}, which must hold {@link #vocabularySize} entries. The terms come first,
-     * in term order, and the values that escaped them follow in the order they were written - so a term keeps the
-     * ordinal it has in the column, and an escape takes one past the last of them.
-     *
-     * <p>The escapes are the whole of what makes this more than the dictionary. A value that escaped is named by no
-     * term, and naming it here is what lets every value of the column index one vector.
-     */
-    public void readVocabulary(BytesRef[] into) throws IOException {
-        for (int i = 0; i < dictionarySize; i++) {
-            termAt(i + StringColumnMetadata.Dictionary.FIRST_TERM_ORDINAL, into[i]);
-        }
-        for (int i = 0; i < escapeCount; i++) {
-            escapes.get(i, into[dictionarySize + i]);
-        }
-    }
-
-    /**
-     * Where the value at {@code valueAddress} sits in {@link #readVocabulary}, or -1 when the slot is null and names
-     * nothing at all.
-     */
-    public int vocabularyOrdinalAt(long valueAddress) throws IOException {
-        final int ordinal = ordinalAt(valueAddress);
-        if (ordinal == StringColumnMetadata.Dictionary.NULL_ORDINAL) {
-            return -1;
-        }
-        if (ordinal == escapeOrdinal) {
-            return dictionarySize + Math.toIntExact(escapeRankOf(valueAddress));
-        }
-        return ordinal - StringColumnMetadata.Dictionary.FIRST_TERM_ORDINAL;
-    }
-
     /** The value behind the escape marker at {@code valueAddress}, for a consumer that took ordinals. */
     public BytesRef resolveEscape(long valueAddress, BytesRef dst) throws IOException {
         escapes.get(escapeRankOf(valueAddress), dst);

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
@@ -193,6 +193,35 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
         return Math.toIntExact(ordinals.valueAt(valueAddress));
     }
 
+    /**
+     * The extreme value, decided over ordinals. The dictionary is in term order, so the largest ordinal a document
+     * holds names its largest value and the smallest its smallest - the terms are never read to find out, and only the
+     * one that wins is resolved.
+     *
+     * <p>Two ordinals are not terms and neither can be compared as one. A null is no value, so it is passed over. An
+     * escaped value sorts wherever its bytes do, which its ordinal - one past every term - does not say, so a document
+     * holding one is decided by comparing bytes after all.
+     */
+    @Override
+    public BytesRef extreme(int rank, boolean max, BytesRef dst) throws IOException {
+        final long first = firstValueAddress(rank);
+        final long count = valueCount(rank);
+        int best = -1;
+        for (long i = 0; i < count; i++) {
+            final int ordinal = ordinalAt(first + i);
+            if (ordinal == StringColumnMetadata.Dictionary.NULL_ORDINAL) {
+                continue;
+            }
+            if (ordinal == escapeOrdinal) {
+                return super.extreme(rank, max, dst);
+            }
+            if (best < 0 || (max ? ordinal > best : ordinal < best)) {
+                best = ordinal;
+            }
+        }
+        return best < 0 ? null : termAt(best, dst);
+    }
+
     /** The value behind the escape marker at {@code valueAddress}, for a consumer that took ordinals. */
     public BytesRef resolveEscape(long valueAddress, BytesRef dst) throws IOException {
         escapes.get(escapeRankOf(valueAddress), dst);

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
@@ -206,7 +206,8 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
             // carry several slots, nor on one where a slot may be the reserved null, which names no term.
             return false;
         }
-        growPage(count);
+        growPageDocs(count);
+        growPageValues(count);
         if (ranksOfAll(docs, offset, count) == false) {
             return false;
         }
@@ -445,11 +446,38 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
     }
 
     @Override
-    protected boolean appendPage(int count, StringBlockSink sink) throws IOException {
+    protected boolean appendPage(int docCount, StringBlockSink sink) throws IOException {
+        // Where the page's values are, as addresses. One a document where the column holds one apiece, and otherwise
+        // a document's run of them with its nulls left out, which are no value a page can carry.
+        final int values;
+        if (pageable()) {
+            values = docCount;
+            growPageValues(docCount);
+            for (int i = 0; i < docCount; i++) {
+                pageValueAddresses[i] = pageRanks[i];
+            }
+        } else {
+            values = countPageValues(docCount);
+            growPageValues(Math.max(values, 1));
+            int at = 0;
+            for (int i = 0; i < docCount; i++) {
+                final long first = firstValueAddress(pageRanks[i]);
+                final long held = valueCount(pageRanks[i]);
+                for (long slotOf = 0; slotOf < held; slotOf++) {
+                    final long address = first + slotOf;
+                    if (isNullSlot(address) == false) {
+                        pageValueAddresses[at++] = address;
+                    }
+                }
+            }
+            assert at == values : "addressed " + at + " values, counted " + values;
+        }
+        final int[] counts = pageable() ? null : pageValueCounts;
+
         int escapedInPage = 0;
         final OrdinalBlockCursor cursor = new OrdinalBlockCursor();
-        for (int i = 0; i < count; i++) {
-            final int ordinal = cursor.at(pageRanks[i]);
+        for (int i = 0; i < values; i++) {
+            final int ordinal = cursor.at(pageValueAddresses[i]);
             pageOrdinals[i] = ordinal;
             if (ordinal >= escapeOrdinal) {
                 escapedInPage++;
@@ -457,7 +485,7 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
         }
 
         // The ordinals this page holds, each once and in order, so a slot can be found by bisecting them.
-        final int distinct = distinctOrdinals(count, dictionarySize);
+        final int distinct = distinctOrdinals(values, dictionarySize);
 
         pageBytesLength = 0;
         int slot = 0;
@@ -466,7 +494,7 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
             appendToPage(slot, scratch);
         }
         startPageSlots(escapedInPage);
-        for (int i = 0; i < count; i++) {
+        for (int i = 0; i < values; i++) {
             final int ordinal = pageOrdinals[i];
             if (ordinal < escapeOrdinal) {
                 pageOrdinals[i] = slotOf(ordinal, distinct);
@@ -474,7 +502,7 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
                 // Nothing names an escaped value but its bytes, so two documents holding the same ones are
                 // found to share a slot by those bytes. They cannot be found among the terms: a value
                 // escaped because the vocabulary does not hold it.
-                escapes.get(escapeRankOf(pageRanks[i]), scratch);
+                escapes.get(escapeRankOf(pageValueAddresses[i]), scratch);
                 final int found = pageSlotFor(scratch, slot);
                 if (found == slot) {
                     slot++;
@@ -484,15 +512,15 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
         }
         point(pageDictionary, slot);
 
-        // A page with as many entries as documents is no shorter as ordinals than as values.
-        if ((long) slot * MIN_PAGE_REPEAT > count) {
-            for (int i = 0; i < count; i++) {
+        // A page with as many entries as values is no shorter as ordinals than as values.
+        if ((long) slot * MIN_PAGE_REPEAT > values) {
+            for (int i = 0; i < values; i++) {
                 pageValues[i] = pageDictionary[pageOrdinals[i]];
             }
-            sink.appendValues(pageValues, count);
+            sink.appendValues(pageValues, values, counts, docCount);
             return true;
         }
-        sink.appendOrdinals(pageOrdinals, count, pageDictionary, slot);
+        sink.appendOrdinals(pageOrdinals, values, counts, docCount, pageDictionary, slot);
         return true;
     }
 

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/PlainStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/PlainStringColumnReader.java
@@ -226,7 +226,51 @@ public final class PlainStringColumnReader extends StringColumnReader {
      * entry a run rather than one a document, without comparing any bytes.
      */
     @Override
-    protected boolean appendPage(int count, StringBlockSink sink) throws IOException {
+    protected boolean appendPage(int docCount, StringBlockSink sink) throws IOException {
+        if (pageable()) {
+            // One value a document and every one of them present: the page is the documents, and a run tells itself
+            // from the address its value was read at without any of the accounting below.
+            return appendSingleValuedPage(docCount, sink);
+        }
+        final int values = countPageValues(docCount);
+        growPageValues(Math.max(values, 1));
+        pageBytesLength = 0;
+        startPageSlots(values);
+        int slots = 0;
+        int at = 0;
+        for (int i = 0; i < docCount; i++) {
+            final int rank = pageRanks[i];
+            final long first = firstValueAddress(rank);
+            final long held = valueCount(rank);
+            for (long s = 0; s < held; s++) {
+                final long address = first + s;
+                if (isNullSlot(address)) {
+                    continue;
+                }
+                this.values.get(address, scratch);
+                final int slot = pageSlotFor(scratch, slots);
+                if (slot == slots) {
+                    slots++;
+                }
+                pageOrdinals[at++] = slot;
+            }
+        }
+        assert at == values : "wrote " + at + " values, counted " + values;
+        point(pageDictionary, slots);
+        if ((long) slots * MIN_PAGE_REPEAT > values) {
+            for (int i = 0; i < values; i++) {
+                pageValues[i] = pageDictionary[pageOrdinals[i]];
+            }
+            sink.appendValues(pageValues, values, pageValueCounts, docCount);
+            return true;
+        }
+        sink.appendOrdinals(pageOrdinals, values, pageValueCounts, docCount, pageDictionary, slots);
+        return true;
+    }
+
+    /** A page of a column holding one value a document, which is the shape a run-encoded column pays off on. */
+    private boolean appendSingleValuedPage(int count, StringBlockSink sink) throws IOException {
+        growPageValues(count);
         pageBytesLength = 0;
         startPageSlots(count);
         int slots = 0;
@@ -259,10 +303,10 @@ public final class PlainStringColumnReader extends StringColumnReader {
             for (int i = 0; i < count; i++) {
                 pageValues[i] = pageDictionary[pageOrdinals[i]];
             }
-            sink.appendValues(pageValues, count);
+            sink.appendValues(pageValues, count, null, count);
             return true;
         }
-        sink.appendOrdinals(pageOrdinals, count, pageDictionary, slots);
+        sink.appendOrdinals(pageOrdinals, count, null, count, pageDictionary, slots);
         return true;
     }
 }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/PlainStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/PlainStringColumnReader.java
@@ -34,6 +34,19 @@ import java.util.function.Predicate;
  */
 public final class PlainStringColumnReader extends StringColumnReader {
 
+    /** Pages read as values before a column is asked again whether a dictionary would pay for it. */
+    private static final int PAGES_BETWEEN_TRIES = 32;
+
+    /**
+     * The fewest values a page must hold for what it named to say anything about the column. A page of one value
+     * names one, which is always too many to pay for, so judging a column on one would stop it ever building a
+     * dictionary again.
+     */
+    private static final int VALUES_TO_JUDGE_BY = 128;
+
+    private boolean tooManyToPay;
+    private int pagesSinceTried;
+
     private final ValueStream.Reader values;
 
     /** The value addresses holding a null, ascending; null when no slot in the column is one. */
@@ -270,6 +283,9 @@ public final class PlainStringColumnReader extends StringColumnReader {
 
     /** A page of a column holding one value a document, which is the shape a run-encoded column pays off on. */
     private boolean appendSingleValuedPage(int count, StringBlockSink sink) throws IOException {
+        if (namesTooManyToPay()) {
+            return appendSingleValuedPageAsValues(count, sink);
+        }
         growPageValues(count);
         pageBytesLength = 0;
         startPageSlots(count);
@@ -299,7 +315,9 @@ public final class PlainStringColumnReader extends StringColumnReader {
         }
         point(pageDictionary, slots);
         // As many entries as documents is no shorter as ordinals than as values.
-        if ((long) slots * MIN_PAGE_REPEAT > count) {
+        final boolean tooMany = (long) slots * MIN_PAGE_REPEAT > count;
+        rememberWhetherItPaid(tooMany, count);
+        if (tooMany) {
             for (int i = 0; i < count; i++) {
                 pageValues[i] = pageDictionary[pageOrdinals[i]];
             }
@@ -308,5 +326,63 @@ public final class PlainStringColumnReader extends StringColumnReader {
         }
         sink.appendOrdinals(pageOrdinals, count, null, count, pageDictionary, slots);
         return true;
+    }
+
+    /**
+     * The same page, without a dictionary being built for it. A page handed over as values never reads the one
+     * the method above builds, and building it hashes every value and probes a table for it. So a column whose
+     * last page named too many values to pay is read this way instead: runs are still collapsed, which costs no
+     * bytes to find, but nothing is hashed.
+     *
+     * <p>Only the way the values are found changes. What the sink is given is what it would have been given.
+     */
+    private boolean appendSingleValuedPageAsValues(int count, StringBlockSink sink) throws IOException {
+        growPageValues(count);
+        pageBytesLength = 0;
+        int runs = 0;
+        long previous = -1;
+        int previousLength = -1;
+        int previousRun = -1;
+        for (int i = 0; i < count; i++) {
+            final long identity = values.read(pageRanks[i], scratch);
+            if (previousRun < 0 || identity != previous || scratch.length != previousLength) {
+                // A run staged across two blocks is stored twice and answers with a new address, so the run
+                // before is compared once by its bytes before a new one is started.
+                if (previousRun < 0 || pageSlotHolds(previousRun, scratch) == false) {
+                    appendToPage(runs, scratch);
+                    previousRun = runs++;
+                }
+                previous = identity;
+                previousLength = scratch.length;
+            }
+            pageOrdinals[i] = previousRun;
+        }
+        point(pageDictionary, runs);
+        rememberWhetherItPaid((long) runs * MIN_PAGE_REPEAT > count, count);
+        for (int i = 0; i < count; i++) {
+            pageValues[i] = pageDictionary[pageOrdinals[i]];
+        }
+        sink.appendValues(pageValues, count, null, count);
+        return true;
+    }
+
+    /**
+     * Whether the last pages of this column named too many values for a dictionary to pay. Asked before one is
+     * built, so a column that never earns it stops paying to find that out again for every page - and asked
+     * again every {@link #PAGES_BETWEEN_TRIES} pages, so a column whose values change shape is not held to what
+     * its first pages looked like.
+     */
+    private boolean namesTooManyToPay() {
+        return tooManyToPay && ++pagesSinceTried < PAGES_BETWEEN_TRIES;
+    }
+
+    private void rememberWhetherItPaid(boolean tooMany, int count) {
+        if (count < VALUES_TO_JUDGE_BY) {
+            return;
+        }
+        tooManyToPay = tooMany;
+        if (tooMany == false || pagesSinceTried >= PAGES_BETWEEN_TRIES) {
+            pagesSinceTried = 0;
+        }
     }
 }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringBlockSink.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringBlockSink.java
@@ -12,28 +12,30 @@ package org.elasticsearch.columnar.string;
 import org.apache.lucene.util.BytesRef;
 
 /**
- * Where {@link StringColumnReader#readBlock} puts a page of values.
+ * Where a page of a string column is handed to whoever asked for it.
  *
- * <p>Two shapes, because a page of a repetitive column is worth handing over as ordinals: a consumer
- * grouping by value then compares an int per document and resolves each distinct value once, rather than
- * hashing bytes once per document. A page with little repetition is handed over as values, since ordinals
- * into a dictionary as long as the page save nothing.
+ * <p>A page carries the values of a run of documents, and a document may hold several of them or none. So what arrives
+ * is a flat run of values and, beside it, how many of them each document took: {@code valueCounts} holds one entry per
+ * document, and is null where every document took exactly one, which is the common shape and the one worth not
+ * allocating for. A document that took none is a document with no value to offer - its slots were all null - and the
+ * count says so with a zero.
+ *
+ * <p>Null slots never arrive. A null is not a value a consumer of a page can hold, so a document's nulls are dropped
+ * and its count is of what remains; a document of two slots with one null arrives holding one value.
  */
 public interface StringBlockSink {
 
     /**
-     * A page as one ordinal per document into {@code dictionary}, which holds the page's distinct values
-     * and is valid until the next call. Ordinals index it directly, so they run from zero however the
-     * column numbers its terms.
+     * A page as ordinals into its own distinct values, for a page that repeats enough to be worth naming them. The
+     * ordinals index {@code dictionary}, which holds {@code dictionarySize} entries and is valid until the next call.
      *
-     * <p>Distinct is by the bytes and holds whatever shape the column has: equal values are one entry
-     * however far apart the documents carrying them sit, whether the column is in term order, clustered
-     * into runs that restart, or in no order at all, and whether or not its vocabulary names them. So the
-     * ordinal is an identity within the page, and a consumer grouping by value can group on it and resolve
-     * the bytes once an entry rather than once a document.
+     * @param ordinals    one entry per value, {@code valueCount} of them
+     * @param valueCount  values across every document in the page
+     * @param valueCounts values per document, or null when every document holds exactly one
+     * @param docCount    documents the page covers
      */
-    void appendOrdinals(int[] ordinals, int count, BytesRef[] dictionary, int dictionarySize);
+    void appendOrdinals(int[] ordinals, int valueCount, int[] valueCounts, int docCount, BytesRef[] dictionary, int dictionarySize);
 
-    /** A page as one value per document, valid until the next call. */
-    void appendValues(BytesRef[] values, int count);
+    /** A page as its values, for a page that repeats too little for ordinals to pay. Shaped as above. */
+    void appendValues(BytesRef[] values, int valueCount, int[] valueCounts, int docCount);
 }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
@@ -73,6 +73,10 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
      */
     protected static final int MIN_PAGE_REPEAT = 2;
     protected int[] pageRanks = new int[0];
+    /** Values each document of the page holds, its nulls not counted. */
+    protected int[] pageValueCounts = new int[0];
+    /** Where each of the page's values is, which is a document's rank only where the column holds one apiece. */
+    protected long[] pageValueAddresses = new long[0];
     protected int[] pageOrdinals = new int[0];
     protected BytesRef[] pageValues = new BytesRef[0];
     protected BytesRef[] pageDictionary = new BytesRef[0];
@@ -138,6 +142,29 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
      */
     protected boolean pageable() {
         return meta.hasValueAddresses() == false && meta.hasNullSlots() == false;
+    }
+
+    /**
+     * How many values each document of the page holds, filling {@link #pageValueCounts} and answering the total. A
+     * document's nulls are not among them: a null is not a value a page can carry, so it is dropped and a document
+     * left holding none is a document with nothing to offer.
+     */
+    protected int countPageValues(int docCount) throws IOException {
+        int total = 0;
+        for (int i = 0; i < docCount; i++) {
+            final int rank = pageRanks[i];
+            final long first = firstValueAddress(rank);
+            final long slots = valueCount(rank);
+            int values = 0;
+            for (long s = 0; s < slots; s++) {
+                if (isNullSlot(first + s) == false) {
+                    values++;
+                }
+            }
+            pageValueCounts[i] = values;
+            total += values;
+        }
+        return total;
     }
 
     /** The value address of a document's first slot, given its rank. */
@@ -477,14 +504,11 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
      *         a time; true when {@code sink} was called exactly once
      */
     public boolean readBlock(int[] docs, int offset, int count, StringBlockSink sink) throws IOException {
-        if (pageable() == false) {
-            return false;
-        }
         if (count == 0) {
-            sink.appendValues(pageValues, 0);
+            sink.appendValues(pageValues, 0, null, 0);
             return true;
         }
-        growPage(count);
+        growPageDocs(count);
         if (ranksOfAll(docs, offset, count) == false) {
             return false;
         }
@@ -572,17 +596,29 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
         }
     }
 
-    protected void growPage(int count) {
-        if (pageRanks.length >= count) {
+    /** Room for a page covering {@code docCount} documents, whatever they turn out to hold. */
+    protected void growPageDocs(int docCount) {
+        if (pageRanks.length < docCount) {
+            pageRanks = new int[docCount];
+            pageValueCounts = new int[docCount];
+        }
+    }
+
+    /**
+     * Room for {@code valueCount} values. Separate from the documents because a page of multi-valued documents holds
+     * more values than documents, and a page whose documents are all null holds fewer.
+     */
+    protected void growPageValues(int valueCount) {
+        if (pageOrdinals.length >= valueCount) {
             return;
         }
-        pageRanks = new int[count];
-        pageOrdinals = new int[count];
-        pageStarts = new int[count];
-        pageLengths = new int[count];
-        pageValues = new BytesRef[count];
-        pageDictionary = new BytesRef[count];
-        for (int i = 0; i < count; i++) {
+        pageOrdinals = new int[valueCount];
+        pageValueAddresses = new long[valueCount];
+        pageStarts = new int[valueCount];
+        pageLengths = new int[valueCount];
+        pageValues = new BytesRef[valueCount];
+        pageDictionary = new BytesRef[valueCount];
+        for (int i = 0; i < valueCount; i++) {
             pageValues[i] = new BytesRef();
             pageDictionary[i] = new BytesRef();
         }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.LongValues;
 import org.elasticsearch.columnar.substrate.ColumnIterator;
 import org.elasticsearch.columnar.substrate.ColumnIteratorReader;
@@ -73,6 +74,9 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
      */
     protected static final int MIN_PAGE_REPEAT = 2;
     protected int[] pageRanks = new int[0];
+    /** The running extreme, held so comparing one value against another survives the buffer being reused. */
+    private final BytesRefBuilder extremeSoFar = new BytesRefBuilder();
+
     /** Values each document of the page holds, its nulls not counted. */
     protected int[] pageValueCounts = new int[0];
     /** Where each of the page's values is, which is a document's rank only where the column holds one apiece. */
@@ -248,6 +252,38 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
      */
     public boolean valuesSorted() {
         return meta.valuesSorted();
+    }
+
+    /**
+     * The largest or smallest value a document holds, or null when it holds none - its slots were all null, or it has
+     * no slot at all. The returned {@link BytesRef} is only valid until the next call.
+     *
+     * <p>Compared here as bytes, which is all a column that stores its values can do.
+     * {@link DictionaryStringColumnReader} decides it over ordinals instead, and reads one term rather than all of
+     * them.
+     */
+    public BytesRef extreme(int rank, boolean max, BytesRef dst) throws IOException {
+        final long first = firstValueAddress(rank);
+        final long count = valueCount(rank);
+        boolean found = false;
+        for (long i = 0; i < count; i++) {
+            final BytesRef value = valueAt(first + i);
+            if (value == null) {
+                continue;
+            }
+            // Copied rather than pointed at: the next read reuses the buffer this one came back in.
+            if (found == false || (max ? value.compareTo(extremeSoFar.get()) > 0 : value.compareTo(extremeSoFar.get()) < 0)) {
+                extremeSoFar.copyBytes(value);
+                found = true;
+            }
+        }
+        if (found == false) {
+            return null;
+        }
+        dst.bytes = extremeSoFar.bytes();
+        dst.offset = 0;
+        dst.length = extremeSoFar.length();
+        return dst;
     }
 
     /** Whether this column names its values with ordinals rather than storing them. */

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
@@ -554,7 +554,6 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
     /** Hands {@code count} resolved ranks to the sink, in whichever form the column's values take. */
     protected abstract boolean appendPage(int count, StringBlockSink sink) throws IOException;
 
-    /** Copies a value into the page's own bytes, so the reader's buffer can be reused for the next one. */
     /**
      * Opens a page's dictionary for at most {@code slots} entries found by their bytes, which is what
      * {@link #pageSlotFor} then finds them by.
@@ -613,6 +612,7 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
             );
     }
 
+    /** Copies a value into the page's own bytes, so the reader's buffer can be reused for the next one. */
     protected void appendToPage(int slot, BytesRef value) {
         if (pageBytes.length < pageBytesLength + value.length) {
             pageBytes = ArrayUtil.grow(pageBytes, pageBytesLength + value.length);

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
@@ -35,4 +35,14 @@ public interface StringColumnSource {
      * the next call.
      */
     BytesRef extreme(boolean max, BytesRef dst) throws IOException;
+
+    /**
+     * How many non-null values the document these values are positioned on holds, capped at two, leaving its only one
+     * in {@code dst} when it holds exactly one.
+     *
+     * <p>Capped because the callers are the single-value functions, which want to know whether the arity is nothing,
+     * one, or more than one and nothing further. Answered from what the column already records - how many slots the
+     * document has, and which of them are null - so nothing is decoded to count.
+     */
+    int nonNullValues(BytesRef dst) throws IOException;
 }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
@@ -9,6 +9,10 @@
 
 package org.elasticsearch.columnar.string;
 
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+
 /**
  * Binary doc values that can hand over the string column behind them, so a search matches a term against
  * the column rather than reading a value for every document.
@@ -22,4 +26,13 @@ public interface StringColumnSource {
 
     /** The column behind these values. */
     StringColumnReader reader();
+
+    /**
+     * The largest or smallest value the document these values are positioned on holds, or null when it holds none.
+     *
+     * <p>Here rather than on the column because the column addresses documents by rank, and which rank these values
+     * stand on is what the surface knows and the column does not. The returned {@link BytesRef} is only valid until
+     * the next call.
+     */
+    BytesRef extreme(boolean max, BytesRef dst) throws IOException;
 }

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringBlockReadTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringBlockReadTests.java
@@ -143,7 +143,14 @@ public class StringBlockReadTests extends ColumnarStringTestCase {
             final boolean[] sawOrdinals = { false };
             assertTrue(label + " page", reader.readBlock(docs, 0, docs.length, new StringBlockSink() {
                 @Override
-                public void appendOrdinals(int[] ordinals, int count, BytesRef[] dictionary, int dictionarySize) {
+                public void appendOrdinals(
+                    int[] ordinals,
+                    int count,
+                    int[] valueCounts,
+                    int docCount,
+                    BytesRef[] dictionary,
+                    int dictionarySize
+                ) {
                     sawOrdinals[0] = true;
                     final Map<String, Integer> slotOf = new HashMap<>();
                     for (int i = 0; i < dictionarySize; i++) {
@@ -158,7 +165,7 @@ public class StringBlockReadTests extends ColumnarStringTestCase {
                 }
 
                 @Override
-                public void appendValues(BytesRef[] values, int count) {
+                public void appendValues(BytesRef[] values, int count, int[] valueCounts, int docCount) {
                     for (int i = 0; i < count; i++) {
                         assertEquals(label + " doc " + docs[i], docValues[docs[i]].utf8ToString(), values[i].utf8ToString());
                     }
@@ -276,10 +283,17 @@ public class StringBlockReadTests extends ColumnarStringTestCase {
                     "a page covering documents with no value cannot be served",
                     reader.readBlock(all, 0, all.length, new StringBlockSink() {
                         @Override
-                        public void appendOrdinals(int[] ords, int n, BytesRef[] dictionary, int dictionarySize) {}
+                        public void appendOrdinals(
+                            int[] ords,
+                            int n,
+                            int[] valueCounts,
+                            int docCount,
+                            BytesRef[] dictionary,
+                            int dictionarySize
+                        ) {}
 
                         @Override
-                        public void appendValues(BytesRef[] values, int n) {}
+                        public void appendValues(BytesRef[] values, int n, int[] valueCounts, int docCount) {}
                     })
                 );
                 if (reader.hasDictionary()) {
@@ -298,14 +312,21 @@ public class StringBlockReadTests extends ColumnarStringTestCase {
                     "a page of documents that all have a value is served",
                     reader.readBlock(dense, 0, dense.length, new StringBlockSink() {
                         @Override
-                        public void appendOrdinals(int[] ords, int n, BytesRef[] dictionary, int dictionarySize) {
+                        public void appendOrdinals(
+                            int[] ords,
+                            int n,
+                            int[] valueCounts,
+                            int docCount,
+                            BytesRef[] dictionary,
+                            int dictionarySize
+                        ) {
                             for (int i = 0; i < n; i++) {
                                 seen.add(dictionary[ords[i]].utf8ToString());
                             }
                         }
 
                         @Override
-                        public void appendValues(BytesRef[] values, int n) {
+                        public void appendValues(BytesRef[] values, int n, int[] valueCounts, int docCount) {
                             for (int i = 0; i < n; i++) {
                                 seen.add(values[i].utf8ToString());
                             }
@@ -387,7 +408,7 @@ public class StringBlockReadTests extends ColumnarStringTestCase {
         private boolean wasOrdinals;
 
         @Override
-        public void appendOrdinals(int[] ordinals, int count, BytesRef[] dictionary, int dictionarySize) {
+        public void appendOrdinals(int[] ordinals, int count, int[] valueCounts, int docCount, BytesRef[] dictionary, int dictionarySize) {
             wasOrdinals = true;
             for (int i = 0; i < count; i++) {
                 assertTrue("ordinal in range", ordinals[i] >= 0 && ordinals[i] < dictionarySize);
@@ -396,7 +417,7 @@ public class StringBlockReadTests extends ColumnarStringTestCase {
         }
 
         @Override
-        public void appendValues(BytesRef[] pageValues, int count) {
+        public void appendValues(BytesRef[] pageValues, int count, int[] valueCounts, int docCount) {
             for (int i = 0; i < count; i++) {
                 values.add(BytesRef.deepCopyOf(pageValues[i]));
             }

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringDictionaryTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringDictionaryTests.java
@@ -175,59 +175,6 @@ public class StringDictionaryTests extends ColumnarStringTestCase {
         });
     }
 
-    /**
-     * The column's vocabulary: every value it holds, named once, terms first and the values that escaped them after.
-     * This is what a consumer resolves in place of rebuilding a dictionary for every page it reads, so what it has to
-     * be is complete - a value the vocabulary does not name is a value such a consumer could not have read at all.
-     */
-    public void testVocabularyNamesEveryValueIncludingTheEscapes() throws IOException {
-        final String[] terms = { "DEBUG", "ERROR", "INFO", "TRACE", "WARN" };
-        final BytesRef[][] docSlots = new BytesRef[between(400, 1500)][];
-        for (int d = 0; d < docSlots.length; d++) {
-            final BytesRef[] slots = new BytesRef[between(1, 3)];
-            for (int s = 0; s < slots.length; s++) {
-                slots[s] = switch ((d + s) % 13) {
-                    case 3 -> new BytesRef("escaped-" + d + "-" + s);
-                    case 7 -> null;
-                    default -> new BytesRef(terms[(d + s) % terms.length]);
-                };
-            }
-            docSlots[d] = slots;
-        }
-        withColumn(docSlots, randomValidBlockSize(), randomChunkCodec(), randomTargetChunkBytes(), ROOMY, (metadata, reader) -> {
-            final DictionaryStringColumnReader column = (DictionaryStringColumnReader) reader;
-            assertTrue("expected values to have escaped", column.escapeCount() > 0);
-            assertEquals("vocabulary", column.dictionarySize() + column.escapeCount(), column.vocabularySize());
-
-            final BytesRef[] vocabulary = new BytesRef[column.vocabularySize()];
-            for (int i = 0; i < vocabulary.length; i++) {
-                vocabulary[i] = new BytesRef();
-            }
-            column.readVocabulary(vocabulary);
-            // Read once, so nothing below may depend on the reader's own reusable buffers.
-            for (int i = 0; i < vocabulary.length; i++) {
-                vocabulary[i] = BytesRef.deepCopyOf(vocabulary[i]);
-            }
-            // The terms keep their order, which is what lets an ordinal comparison stand in for a term comparison.
-            for (int i = 1; i < column.dictionarySize(); i++) {
-                assertTrue("terms in order at " + i, vocabulary[i - 1].compareTo(vocabulary[i]) < 0);
-            }
-
-            for (int d = 0; d < docSlots.length; d++) {
-                final long first = reader.firstValueAddress(d);
-                for (int s = 0; s < docSlots[d].length; s++) {
-                    final int at = column.vocabularyOrdinalAt(first + s);
-                    if (docSlots[d][s] == null) {
-                        assertEquals("doc " + d + " slot " + s + " is null", -1, at);
-                        continue;
-                    }
-                    assertTrue("doc " + d + " slot " + s + " names an entry", at >= 0 && at < vocabulary.length);
-                    assertEquals("doc " + d + " slot " + s, docSlots[d][s], vocabulary[at]);
-                }
-            }
-        });
-    }
-
     /** Nothing repeats, so there is no vocabulary and the values are stored as they are. */
     public void testAllDistinctValuesStayPlain() throws IOException {
         final BytesRef[] docValues = new BytesRef[between(200, 1500)];

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringDictionaryTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringDictionaryTests.java
@@ -175,6 +175,59 @@ public class StringDictionaryTests extends ColumnarStringTestCase {
         });
     }
 
+    /**
+     * The column's vocabulary: every value it holds, named once, terms first and the values that escaped them after.
+     * This is what a consumer resolves in place of rebuilding a dictionary for every page it reads, so what it has to
+     * be is complete - a value the vocabulary does not name is a value such a consumer could not have read at all.
+     */
+    public void testVocabularyNamesEveryValueIncludingTheEscapes() throws IOException {
+        final String[] terms = { "DEBUG", "ERROR", "INFO", "TRACE", "WARN" };
+        final BytesRef[][] docSlots = new BytesRef[between(400, 1500)][];
+        for (int d = 0; d < docSlots.length; d++) {
+            final BytesRef[] slots = new BytesRef[between(1, 3)];
+            for (int s = 0; s < slots.length; s++) {
+                slots[s] = switch ((d + s) % 13) {
+                    case 3 -> new BytesRef("escaped-" + d + "-" + s);
+                    case 7 -> null;
+                    default -> new BytesRef(terms[(d + s) % terms.length]);
+                };
+            }
+            docSlots[d] = slots;
+        }
+        withColumn(docSlots, randomValidBlockSize(), randomChunkCodec(), randomTargetChunkBytes(), ROOMY, (metadata, reader) -> {
+            final DictionaryStringColumnReader column = (DictionaryStringColumnReader) reader;
+            assertTrue("expected values to have escaped", column.escapeCount() > 0);
+            assertEquals("vocabulary", column.dictionarySize() + column.escapeCount(), column.vocabularySize());
+
+            final BytesRef[] vocabulary = new BytesRef[column.vocabularySize()];
+            for (int i = 0; i < vocabulary.length; i++) {
+                vocabulary[i] = new BytesRef();
+            }
+            column.readVocabulary(vocabulary);
+            // Read once, so nothing below may depend on the reader's own reusable buffers.
+            for (int i = 0; i < vocabulary.length; i++) {
+                vocabulary[i] = BytesRef.deepCopyOf(vocabulary[i]);
+            }
+            // The terms keep their order, which is what lets an ordinal comparison stand in for a term comparison.
+            for (int i = 1; i < column.dictionarySize(); i++) {
+                assertTrue("terms in order at " + i, vocabulary[i - 1].compareTo(vocabulary[i]) < 0);
+            }
+
+            for (int d = 0; d < docSlots.length; d++) {
+                final long first = reader.firstValueAddress(d);
+                for (int s = 0; s < docSlots[d].length; s++) {
+                    final int at = column.vocabularyOrdinalAt(first + s);
+                    if (docSlots[d][s] == null) {
+                        assertEquals("doc " + d + " slot " + s + " is null", -1, at);
+                        continue;
+                    }
+                    assertTrue("doc " + d + " slot " + s + " names an entry", at >= 0 && at < vocabulary.length);
+                    assertEquals("doc " + d + " slot " + s, docSlots[d][s], vocabulary[at]);
+                }
+            }
+        });
+    }
+
     /** Nothing repeats, so there is no vocabulary and the values are stored as they are. */
     public void testAllDistinctValuesStayPlain() throws IOException {
         final BytesRef[] docValues = new BytesRef[between(200, 1500)];

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringMatchTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringMatchTests.java
@@ -236,14 +236,21 @@ public class StringMatchTests extends ColumnarStringTestCase {
                     final int at = from;
                     assertTrue("expected a page", reader.readBlock(docs, from, count, new StringBlockSink() {
                         @Override
-                        public void appendOrdinals(int[] ordinals, int n, BytesRef[] dictionary, int dictionarySize) {
+                        public void appendOrdinals(
+                            int[] ordinals,
+                            int n,
+                            int[] valueCounts,
+                            int docCount,
+                            BytesRef[] dictionary,
+                            int dictionarySize
+                        ) {
                             for (int i = 0; i < n; i++) {
                                 rebuilt.add(dictionary[ordinals[i]].utf8ToString());
                             }
                         }
 
                         @Override
-                        public void appendValues(BytesRef[] values, int n) {
+                        public void appendValues(BytesRef[] values, int n, int[] valueCounts, int docCount) {
                             for (int i = 0; i < n; i++) {
                                 rebuilt.add(values[i].utf8ToString());
                             }
@@ -764,23 +771,14 @@ public class StringMatchTests extends ColumnarStringTestCase {
                     expectedOfSlots(docSlots, "", true),
                     matched(reader.match(value -> value.length == 0))
                 );
-                // A page has no shape for a slot holding nothing, so the column declines to serve one.
+                // A page carries these: a document whose only slot is null simply holds no value in it.
                 final int[] docs = new int[Math.min(256, docSlots.length)];
                 for (int i = 0; i < docs.length; i++) {
                     docs[i] = i;
                 }
-                assertFalse("a column with null slots serves no page", reader.readBlock(docs, 0, docs.length, new StringBlockSink() {
-                    @Override
-                    public void appendOrdinals(int[] ordinals, int n, BytesRef[] dictionary, int dictionarySize) {
-                        fail("no page expected");
-                    }
-
-                    @Override
-                    public void appendValues(BytesRef[] values, int n) {
-                        fail("no page expected");
-                    }
-                }));
-                assertFalse("nor column-wide ordinals", reader.readOrdinals(docs, 0, docs.length, new int[docs.length]));
+                assertEquals("page", expectedPage(docSlots, docs), pageOf(reader, docs));
+                // Column-wide ordinals are one a document and cannot say a document has none, so those still decline.
+                assertFalse("no column-wide ordinals", reader.readOrdinals(docs, 0, docs.length, new int[docs.length]));
             });
         }
     }
@@ -813,25 +811,131 @@ public class StringMatchTests extends ColumnarStringTestCase {
                         matched(reader.matchPrefix(new BytesRef(probe)))
                     );
                 }
-                // A page is addressed by rank too, so it has to decline this column for the same reason.
+                // A page carries these too: an empty array is a document holding no value.
                 final int[] docs = new int[Math.min(256, docSlots.length)];
                 for (int i = 0; i < docs.length; i++) {
                     docs[i] = i;
                 }
-                assertFalse("a column with empty arrays serves no page", reader.readBlock(docs, 0, docs.length, new StringBlockSink() {
-                    @Override
-                    public void appendOrdinals(int[] ordinals, int n, BytesRef[] dictionary, int dictionarySize) {
-                        fail("no page expected");
-                    }
-
-                    @Override
-                    public void appendValues(BytesRef[] values, int n) {
-                        fail("no page expected");
-                    }
-                }));
-                assertFalse("nor column-wide ordinals", reader.readOrdinals(docs, 0, docs.length, new int[docs.length]));
+                assertEquals("page", expectedPage(docSlots, docs), pageOf(reader, docs));
+                assertFalse("no column-wide ordinals", reader.readOrdinals(docs, 0, docs.length, new int[docs.length]));
             });
         }
+    }
+
+    /**
+     * A page of documents holding several values, some of them null, under both layouts. A page is the shape grouping
+     * reads a column in, and until now it could only describe one value a document: a column of arrays was read a
+     * document at a time instead, which is the whole of what the ordinals were for.
+     */
+    public void testMultiValuedPages() throws IOException {
+        final BytesRef[][] docSlots = new BytesRef[between(600, 2000)][];
+        for (int d = 0; d < docSlots.length; d++) {
+            final BytesRef[] slots = new BytesRef[between(1, 4)];
+            for (int s = 0; s < slots.length; s++) {
+                // Some documents end up holding nothing but nulls, which a page has to report as holding nothing.
+                slots[s] = random().nextDouble() < 0.2 ? null : new BytesRef(TERMS[randomInt(TERMS.length - 1)]);
+            }
+            docSlots[d] = slots;
+        }
+        for (DictionaryPolicy policy : List.of(DictionaryPolicy.NONE, ROOMY)) {
+            withColumn(docSlots, randomValidBlockSize(), randomChunkCodec(), randomTargetChunkBytes(), policy, (metadata, reader) -> {
+                assertTrue("expected a multi-valued column", metadata.multiValued());
+                assertTrue("expected null slots", metadata.hasNullSlots());
+                // Read in several pages, so a page boundary falls inside the run of documents rather than only at its ends.
+                for (int page : new int[] { 1, 7, 64, 512, docSlots.length }) {
+                    for (int from = 0; from < docSlots.length; from += page) {
+                        final int count = Math.min(page, docSlots.length - from);
+                        final int[] docs = new int[count];
+                        for (int i = 0; i < count; i++) {
+                            docs[i] = from + i;
+                        }
+                        assertEquals("page of " + page + " from " + from, expectedPage(docSlots, docs), pageOf(reader, docs));
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * A page of documents holding several values, none escaping the dictionary and none null, which is the shape the
+     * ordinals were designed for: every value of the page names a term, so the page is ordinals into its own distinct
+     * values and a consumer resolves each once.
+     */
+    public void testMultiValuedPagesWithEscapes() throws IOException {
+        final BytesRef[][] docSlots = new BytesRef[between(600, 2000)][];
+        for (int d = 0; d < docSlots.length; d++) {
+            final BytesRef[] slots = new BytesRef[between(1, 3)];
+            for (int s = 0; s < slots.length; s++) {
+                slots[s] = (d + s) % 41 == 3 ? new BytesRef("escaped-" + d + "-" + s) : new BytesRef(TERMS[randomInt(TERMS.length - 1)]);
+            }
+            docSlots[d] = slots;
+        }
+        withColumn(docSlots, randomValidBlockSize(), randomChunkCodec(), randomTargetChunkBytes(), ROOMY, (metadata, reader) -> {
+            assertTrue("expected a dictionary", reader.hasDictionary());
+            assertTrue("expected a multi-valued column", metadata.multiValued());
+            assertTrue("expected values to have escaped it", reader.escapeCount() > 0);
+            for (int page : new int[] { 7, 128, 512 }) {
+                for (int from = 0; from < docSlots.length; from += page) {
+                    final int count = Math.min(page, docSlots.length - from);
+                    final int[] docs = new int[count];
+                    for (int i = 0; i < count; i++) {
+                        docs[i] = from + i;
+                    }
+                    assertEquals("page of " + page + " from " + from, expectedPage(docSlots, docs), pageOf(reader, docs));
+                }
+            }
+        });
+    }
+
+    /**
+     * A page rebuilt into the values each document holds, whichever shape it arrived in. A document with no value
+     * comes back empty, which is what a page says with a count of zero.
+     */
+    private static List<List<String>> pageOf(StringColumnReader reader, int[] docs) throws IOException {
+        final List<List<String>> rebuilt = new ArrayList<>();
+        final boolean served = reader.readBlock(docs, 0, docs.length, new StringBlockSink() {
+            @Override
+            public void appendOrdinals(int[] ordinals, int count, int[] valueCounts, int docCount, BytesRef[] dictionary, int size) {
+                final BytesRef[] values = new BytesRef[count];
+                for (int i = 0; i < count; i++) {
+                    assertTrue("ordinal in range", ordinals[i] >= 0 && ordinals[i] < size);
+                    values[i] = dictionary[ordinals[i]];
+                }
+                appendValues(values, count, valueCounts, docCount);
+            }
+
+            @Override
+            public void appendValues(BytesRef[] values, int count, int[] valueCounts, int docCount) {
+                int at = 0;
+                for (int d = 0; d < docCount; d++) {
+                    final int held = valueCounts == null ? 1 : valueCounts[d];
+                    final List<String> doc = new ArrayList<>();
+                    for (int i = 0; i < held; i++) {
+                        doc.add(values[at++].utf8ToString());
+                    }
+                    rebuilt.add(doc);
+                }
+                assertEquals("values accounted for", count, at);
+            }
+        });
+        assertTrue("expected a page", served);
+        assertEquals("one entry a document", docs.length, rebuilt.size());
+        return rebuilt;
+    }
+
+    /** What a scan over the slots themselves would hand back, a null being no value a page can carry. */
+    private static List<List<String>> expectedPage(BytesRef[][] docSlots, int[] docs) {
+        final List<List<String>> expected = new ArrayList<>();
+        for (int doc : docs) {
+            final List<String> values = new ArrayList<>();
+            for (BytesRef slot : docSlots[doc]) {
+                if (slot != null) {
+                    values.add(slot.utf8ToString());
+                }
+            }
+            expected.add(values);
+        }
+        return expected;
     }
 
     /** The documents a scan over the slots themselves would find, a null being no value to compare. */

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortField.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortField.java
@@ -23,6 +23,7 @@ import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
@@ -141,11 +142,21 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
     private static final class ColumnarPayloadMinMaxBinaryDocValues extends FilterBinaryDocValues {
         private final boolean maxMode;
         private final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
+
+        /**
+         * The column behind these values, where there is one. Asked for the extreme directly: it decides it over
+         * ordinals and resolves only the value that wins, where the payload route below has to build the whole
+         * payload out of the column and then take it apart again to find the same value.
+         */
+        @Nullable
+        private final StringColumnSource columnar;
+        private final BytesRef scratch = new BytesRef();
         private BytesRef sortKey;
 
         ColumnarPayloadMinMaxBinaryDocValues(BinaryDocValues values, boolean maxMode) {
             super(values);
             this.maxMode = maxMode;
+            this.columnar = values instanceof StringColumnSource source ? source : null;
         }
 
         @Override
@@ -189,7 +200,7 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
 
         /** Decodes the sort key of the document {@code in} is positioned on, reporting whether it has one at all. */
         private boolean decodeSortKey() throws IOException {
-            sortKey = decoder.extreme(in.binaryValue(), maxMode);
+            sortKey = columnar != null ? columnar.extreme(maxMode, scratch) : decoder.extreme(in.binaryValue(), maxMode);
             return sortKey != null;
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -753,6 +753,31 @@ public interface BlockLoader {
 
         Block buildAggregateMetricDoubleDirect(Block minBlock, Block maxBlock, Block sumBlock, Block countBlock);
 
+        /**
+         * A block of bytes named by ordinals into a dictionary the block carries with it, so a consumer resolves each
+         * distinct value once and compares ints for the rest.
+         *
+         * <p>Unlike the ordinals builders above, which read a column's own ordinals through {@link SortedDocValues} and
+         * remap them to the page, this takes a page that already arrived in that shape - a doc-values format that
+         * stores its values by ordinal internally can hand the page over as it is, with no lookup per distinct value
+         * and no remapping.
+         *
+         * @param ordinals       one entry per value, indexing {@code dictionary}, {@code valueCount} of them
+         * @param valueCount     values across every position
+         * @param valueCounts    values per position, or null when every position holds exactly one; a zero is a
+         *                       position with no value at all
+         * @param positionCount  positions the block covers
+         * @param dictionary     the distinct values, {@code dictionarySize} of them, copied by this call
+         */
+        Block buildOrdinalBytesRefDirect(
+            int[] ordinals,
+            int valueCount,
+            @Nullable int[] valueCounts,
+            int positionCount,
+            BytesRef[] dictionary,
+            int dictionarySize
+        );
+
         ExponentialHistogramBuilder exponentialHistogramBlockBuilder(int count);
 
         Block buildExponentialHistogramBlockDirect(

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
@@ -12,6 +12,8 @@ package org.elasticsearch.index.mapper.blockloader.docvalues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringBlockSink;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.core.Releasables;
@@ -121,6 +123,37 @@ public class BytesRefsFromBinaryMultiSeparateCountBlockLoader extends BlockDocVa
             super(docValues);
         }
 
+        /**
+         * A page read from the column rather than a payload decoded for every document.
+         *
+         * <p>Where the column keeps a dictionary this is the shape it already stores: the page comes back as ordinals
+         * into its own distinct values, each resolved once however many documents name it, and is handed over without
+         * a lookup per value or a remapping. Where it does not, the page still comes back a page at a time, and a run
+         * of equal values is copied once.
+         *
+         * <p>The column declines a page covering a document it has no value for, since a page has no way to say which
+         * one; the payload path below then reads them, as it does for a segment that arrives as an overlay rather than
+         * as a column.
+         */
+        @Override
+        public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)
+            throws IOException {
+            if (docValues.docValues() instanceof StringColumnSource columnar) {
+                final int count = docs.count() - offset;
+                if (count > 0) {
+                    final int[] wanted = new int[count];
+                    for (int i = 0; i < count; i++) {
+                        wanted[i] = docs.get(offset + i);
+                    }
+                    final PageSink sink = new PageSink(factory);
+                    if (columnar.reader().readBlock(wanted, 0, count, sink)) {
+                        return sink.block;
+                    }
+                }
+            }
+            return super.read(factory, docs, offset, nullsFiltered);
+        }
+
         @Override
         public void read(int doc, BlockLoader.BytesRefBuilder builder) throws IOException {
             if (docValues.docValues().advanceExact(doc) == false) {
@@ -133,6 +166,46 @@ public class BytesRefsFromBinaryMultiSeparateCountBlockLoader extends BlockDocVa
         @Override
         public String toString() {
             return "BytesRefsFromColumnarPayload";
+        }
+    }
+
+    /** Turns a page of a string column into a block, in whichever of the two shapes the page arrived. */
+    private static final class PageSink implements StringBlockSink {
+
+        private final BlockLoader.BlockFactory factory;
+        private BlockLoader.Block block;
+
+        private PageSink(BlockLoader.BlockFactory factory) {
+            this.factory = factory;
+        }
+
+        @Override
+        public void appendOrdinals(int[] ordinals, int valueCount, int[] valueCounts, int docCount, BytesRef[] dictionary, int size) {
+            block = factory.buildOrdinalBytesRefDirect(ordinals, valueCount, valueCounts, docCount, dictionary, size);
+        }
+
+        @Override
+        public void appendValues(BytesRef[] values, int valueCount, int[] valueCounts, int docCount) {
+            // Sized in positions, which is what the block holds - a multi-valued page has more values than those.
+            try (BlockLoader.BytesRefBuilder builder = factory.bytesRefs(docCount)) {
+                int at = 0;
+                for (int doc = 0; doc < docCount; doc++) {
+                    final int held = valueCounts == null ? 1 : valueCounts[doc];
+                    if (held == 0) {
+                        builder.appendNull();
+                    } else if (held == 1) {
+                        builder.appendBytesRef(values[at++]);
+                    } else {
+                        builder.beginPositionEntry();
+                        for (int i = 0; i < held; i++) {
+                            builder.appendBytesRef(values[at++]);
+                        }
+                        builder.endPositionEntry();
+                    }
+                }
+                assert at == valueCount : "read " + at + " values, was given " + valueCount;
+                block = builder.build();
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
@@ -134,6 +134,10 @@ public class BytesRefsFromBinaryMultiSeparateCountBlockLoader extends BlockDocVa
          * <p>The column declines a page covering a document it has no value for, since a page has no way to say which
          * one; the payload path below then reads them, as it does for a segment that arrives as an overlay rather than
          * as a column.
+         *
+         * <p>A document may repeat within a page, which a lookup or a top-n asks for. The iterator a page resolves its
+         * ranks through is only required not to be moved backwards, so asking it twice for the same document is a
+         * position it already holds.
          */
         @Override
         public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MultiValuedBinaryColumnarPayloadLengthReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MultiValuedBinaryColumnarPayloadLengthReader.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.blockloader.Warnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
@@ -91,7 +92,11 @@ public abstract class MultiValuedBinaryColumnarPayloadLengthReader extends Block
         if (values.docValues().advanceExact(docId) == false) {
             return null;
         }
-        int nonNull = reader.nonNullCount(values.docValues().binaryValue(), scratch);
+        // Asked of the column where there is one, which knows how many slots the document has and which are null
+        // without decoding anything. A segment arriving as an overlay rather than as a column has its payload read.
+        final int nonNull = values.docValues() instanceof StringColumnSource columnar
+            ? columnar.nonNullValues(scratch)
+            : reader.nonNullCount(values.docValues().binaryValue(), scratch);
         if (nonNull == 1) {
             return length(scratch);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBytesRefsFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBytesRefsFromBinaryBlockLoader.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
@@ -83,14 +85,32 @@ public class MvMaxBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.Do
             super(values);
         }
 
+        /**
+         * The extreme value of the document, taken from the column where there is one.
+         *
+         * <p>A dictionary column decides it over ordinals: the dictionary is in term order, so the extreme ordinal a
+         * document holds names its extreme value, and only that one is resolved to a term. Otherwise the payload is
+         * decoded and its values compared, as it is for a segment arriving as an overlay rather than as a column.
+         */
         @Override
         public void read(int doc, BytesRefBuilder builder) throws IOException {
             if (false == docValues.docValues().advanceExact(doc)) {
                 builder.appendNull();
                 return;
             }
+            if (docValues.docValues() instanceof StringColumnSource columnar) {
+                final BytesRef extreme = columnar.extreme(true, scratch);
+                if (extreme == null) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(extreme);
+                }
+                return;
+            }
             reader.readMax(docValues.docValues().binaryValue(), builder);
         }
+
+        private final BytesRef scratch = new BytesRef();
 
         @Override
         public String toString() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBytesRefsFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBytesRefsFromBinaryBlockLoader.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
@@ -90,14 +92,32 @@ public class MvMinBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.Do
             super(values);
         }
 
+        /**
+         * The extreme value of the document, taken from the column where there is one.
+         *
+         * <p>A dictionary column decides it over ordinals: the dictionary is in term order, so the extreme ordinal a
+         * document holds names its extreme value, and only that one is resolved to a term. Otherwise the payload is
+         * decoded and its values compared, as it is for a segment arriving as an overlay rather than as a column.
+         */
         @Override
         public void read(int doc, BytesRefBuilder builder) throws IOException {
             if (false == docValues.docValues().advanceExact(doc)) {
                 builder.appendNull();
                 return;
             }
+            if (docValues.docValues() instanceof StringColumnSource columnar) {
+                final BytesRef extreme = columnar.extreme(false, scratch);
+                if (extreme == null) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(extreme);
+                }
+                return;
+            }
             reader.readMin(docValues.docValues().binaryValue(), builder);
         }
+
+        private final BytesRef scratch = new BytesRef();
 
         @Override
         public String toString() {

--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
@@ -305,6 +305,67 @@ public class ColumnarKeywordBlockLoaderTests extends ESTestCase {
         }
     }
 
+    /**
+     * A page whose documents repeat, which a lookup or a top-n asks for. The column resolves a page's ranks through one
+     * iterator, which is only required not to be moved backwards, so a document asked for twice is a position it
+     * already holds. Over a sparse column, where that iterator carries a position rather than being the doc id itself.
+     */
+    public void testRepeatedDocumentsInAPage() throws IOException {
+        final String[][] docs = new String[between(200, 800)][];
+        for (int d = 0; d < docs.length; d++) {
+            // Every third document has no value at all, so the column is sparse and its iterator carries a position
+            // rather than being its own doc id. Only documents that do have one are asked for below.
+            docs[d] = d % 3 == 1 ? null : new String[] { "term-" + (d % 7) };
+        }
+        final FieldType type = columnarBinaryFieldType();
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig().setCodec(columnarCodec()))) {
+                for (String[] slots : docs) {
+                    final Document doc = new Document();
+                    if (slots != null) {
+                        doc.add(new Field(FIELD, encode(slots), type));
+                    }
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final LeafReaderContext leaf = reader.leaves().get(0);
+                final var loader = new BytesRefsFromBinaryMultiSeparateCountBlockLoader(FIELD, BinaryDocValuesFormat.COLUMNAR_PAYLOAD);
+                // Each document that has a value, twice, in order: ascending, but never advancing between the pair.
+                final java.util.List<Integer> present = new java.util.ArrayList<>();
+                for (int d = 0; d < docs.length; d++) {
+                    if (docs[d] != null) {
+                        present.add(d);
+                        present.add(d);
+                    }
+                }
+                final int[] wanted = present.stream().mapToInt(Integer::intValue).toArray();
+                final BlockLoader.Docs repeated = new BlockLoader.Docs() {
+                    @Override
+                    public int count() {
+                        return wanted.length;
+                    }
+
+                    @Override
+                    public int get(int i) {
+                        return wanted[i];
+                    }
+
+                    @Override
+                    public boolean mayContainDuplicates() {
+                        return true;
+                    }
+                };
+                final TestBlock block = (TestBlock) loader.reader(NOOP, leaf).read(TestBlock.factory(), repeated, 0, false);
+                assertEquals("positions", wanted.length, block.size());
+                for (int i = 0; i < wanted.length; i++) {
+                    assertEquals("position " + i + " (doc " + wanted[i] + ")", new BytesRef(docs[wanted[i]][0]), block.get(i));
+                }
+            }
+        }
+    }
+
     private static BlockLoader.Docs docs(int from, int count) {
         return new BlockLoader.Docs() {
             @Override

--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
@@ -32,13 +32,17 @@ import org.elasticsearch.columnar.string.StringBlockSink;
 import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.index.mapper.blockloader.MockWarnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.ByteLengthFromBytesRefDocValuesBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromBinaryBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.Utf8CodePointsFromOrdsBlockLoader;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -174,18 +178,59 @@ public class ColumnarKeywordBlockLoaderTests extends ESTestCase {
                 final LeafReaderContext leaf = reader.leaves().get(0);
                 assertThat("the field is a column", leaf.reader().getBinaryDocValues(FIELD), instanceOf(StringColumnSource.class));
                 final var loader = loaders.apply(FIELD);
-                final BlockLoader.RowStrideReader rows = (BlockLoader.RowStrideReader) loader.reader(NOOP, leaf);
-                try (BlockLoader.Builder builder = loader.builder(TestBlock.factory(), docs.length)) {
-                    for (int d = 0; d < docs.length; d++) {
-                        rows.read(d, null, builder);
-                    }
-                    final TestBlock block = (TestBlock) builder.build();
-                    assertEquals("positions", docs.length, block.size());
-                    for (int d = 0; d < docs.length; d++) {
-                        assertEquals("document " + d + " of " + Arrays.toString(docs[d]), expected.get(d), block.get(d));
-                    }
+                final TestBlock block = (TestBlock) loader.reader(NOOP, leaf).read(TestBlock.factory(), docs(0, docs.length), 0, false);
+                assertEquals("positions", docs.length, block.size());
+                for (int d = 0; d < docs.length; d++) {
+                    assertEquals("document " + d + " of " + Arrays.toString(docs[d]), expected.get(d), block.get(d));
                 }
             }
+        }
+    }
+
+    /**
+     * BYTE_LENGTH and LENGTH, which answer only for a document holding exactly one value and warn for one holding
+     * more. The arity comes from the column - how many slots a document has and which of them are null - so a payload
+     * is never decoded to count. Every arity is here: none, one, and several, by both nulls and real values.
+     */
+    public void testLengthFunctions() throws IOException {
+        final String[][] docs = new String[between(200, 800)][];
+        for (int d = 0; d < docs.length; d++) {
+            docs[d] = switch (d % 8) {
+                case 0 -> new String[] { "abc" };                     // one value
+                case 1 -> new String[] { "\u00e9\u00e8" };                    // two code points, four bytes
+                case 2 -> new String[] { null, "one-left" };          // one value after the nulls go
+                case 3 -> new String[] { "a", "b" };                  // several: no answer, and a warning
+                case 4 -> new String[] { null };                      // none
+                case 5 -> new String[0];                              // none
+                case 6 -> new String[] { "" };                        // one value, of no bytes
+                default -> new String[] { "term-" + (d % 5) };
+            };
+        }
+        for (boolean bytes : new boolean[] { true, false }) {
+            final List<Object> expected = new ArrayList<>();
+            for (String[] slots : docs) {
+                String only = null;
+                int nonNull = 0;
+                for (String slot : slots) {
+                    if (slot != null) {
+                        nonNull++;
+                        only = slot;
+                    }
+                }
+                expected.add(nonNull != 1 ? null : bytes ? new BytesRef(only).length : only.codePointCount(0, only.length()));
+            }
+            assertLoaderMatches(
+                docs,
+                fieldName -> bytes
+                    ? new ByteLengthFromBytesRefDocValuesBlockLoader(new MockWarnings(), fieldName, BinaryDocValuesFormat.COLUMNAR_PAYLOAD)
+                    : new Utf8CodePointsFromOrdsBlockLoader(
+                        new MockWarnings(),
+                        fieldName,
+                        ByteSizeValue.ofKb(1),
+                        BinaryDocValuesFormat.COLUMNAR_PAYLOAD
+                    ),
+                expected
+            );
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
@@ -35,11 +35,15 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromBinaryBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -100,6 +104,89 @@ public class ColumnarKeywordBlockLoaderTests extends ESTestCase {
                 docs[d] = new String[] { "unique-value-" + d };
             }
         });
+    }
+
+    /**
+     * The extreme value of each document, which a dictionary column decides over ordinals rather than by comparing
+     * terms. Escapes and nulls are the two ordinals that are not terms, so both shapes are here: an escaped value
+     * sorts by its bytes wherever its ordinal sits, and a null is no value to be the extreme of.
+     */
+    public void testMvMaxAndMvMin() throws IOException {
+        final String[][] docs = new String[between(200, 1200)][];
+        for (int d = 0; d < docs.length; d++) {
+            docs[d] = switch (d % 7) {
+                case 0 -> new String[] { "b-" + (d % 5), "a-" + (d % 3), "c" };
+                case 1 -> new String[] { "a-" + (d % 3) };
+                // Rare enough to escape a dictionary built from what the column repeats, and sorting below every
+                // term it holds, so an ordinal comparison would get it wrong.
+                case 2 -> new String[] { "b-" + (d % 5), "AAA-escapes-" + d };
+                case 3 -> new String[] { null, "c" };
+                case 4 -> new String[] { null };
+                case 5 -> new String[0];
+                default -> new String[] { "c", "b-" + (d % 5) };
+            };
+        }
+        for (boolean max : new boolean[] { true, false }) {
+            assertLoaderMatches(
+                docs,
+                fieldName -> max
+                    ? new MvMaxBytesRefsFromBinaryBlockLoader(fieldName, BinaryDocValuesFormat.COLUMNAR_PAYLOAD)
+                    : new MvMinBytesRefsFromBinaryBlockLoader(fieldName, BinaryDocValuesFormat.COLUMNAR_PAYLOAD),
+                expected(docs, max)
+            );
+        }
+    }
+
+    /** What a scan over the values would decide, which is what the ordinals have to agree with. */
+    private static List<Object> expected(String[][] docs, boolean max) {
+        final List<Object> extremes = new ArrayList<>();
+        for (String[] slots : docs) {
+            String best = null;
+            for (String slot : slots) {
+                if (slot == null) {
+                    continue;
+                }
+                if (best == null || (max ? slot.compareTo(best) > 0 : slot.compareTo(best) < 0)) {
+                    best = slot;
+                }
+            }
+            extremes.add(best == null ? null : new BytesRef(best));
+        }
+        return extremes;
+    }
+
+    private void assertLoaderMatches(
+        String[][] docs,
+        java.util.function.Function<String, BlockDocValuesReader.DocValuesBlockLoader> loaders,
+        List<Object> expected
+    ) throws IOException {
+        final FieldType type = columnarBinaryFieldType();
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig().setCodec(columnarCodec()))) {
+                for (String[] slots : docs) {
+                    final Document doc = new Document();
+                    doc.add(new Field(FIELD, encode(slots), type));
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final LeafReaderContext leaf = reader.leaves().get(0);
+                assertThat("the field is a column", leaf.reader().getBinaryDocValues(FIELD), instanceOf(StringColumnSource.class));
+                final var loader = loaders.apply(FIELD);
+                final BlockLoader.RowStrideReader rows = (BlockLoader.RowStrideReader) loader.reader(NOOP, leaf);
+                try (BlockLoader.Builder builder = loader.builder(TestBlock.factory(), docs.length)) {
+                    for (int d = 0; d < docs.length; d++) {
+                        rows.read(d, null, builder);
+                    }
+                    final TestBlock block = (TestBlock) builder.build();
+                    assertEquals("positions", docs.length, block.size());
+                    for (int d = 0; d < docs.length; d++) {
+                        assertEquals("document " + d + " of " + Arrays.toString(docs[d]), expected.get(d), block.get(d));
+                    }
+                }
+            }
+        }
     }
 
     private interface Documents {

--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordBlockLoaderTests.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.columnar;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.ColumNARDocValuesFormat;
+import org.elasticsearch.columnar.ColumnarFieldType;
+import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringBlockSink;
+import org.elasticsearch.columnar.string.StringColumnSource;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * The block a page of a columnar keyword column becomes, against the block the same documents become when read one at a
+ * time. The page path is a different implementation of the same answer - it can hand back ordinals into the page's own
+ * distinct values rather than the values themselves - so the only thing that says it is right is that the two agree.
+ *
+ * <p>Worth its own test because nothing else reaches it: the ESQL columnar suites run in columnar index mode without the
+ * columnar codec, so they never build a {@code BINARY_COLUMNAR_PAYLOAD} field at all.
+ */
+public class ColumnarKeywordBlockLoaderTests extends ESTestCase {
+
+    private static final String FIELD = "kw";
+    private static final CircuitBreaker NOOP = new NoopCircuitBreaker("test");
+
+    public void testSingleValued() throws IOException {
+        assertPageMatchesPerDocument(docs -> {
+            for (int d = 0; d < docs.length; d++) {
+                docs[d] = new String[] { "term-" + (d % 5) };
+            }
+        });
+    }
+
+    public void testMultiValued() throws IOException {
+        assertPageMatchesPerDocument(docs -> {
+            for (int d = 0; d < docs.length; d++) {
+                docs[d] = switch (d % 4) {
+                    case 0 -> new String[] { "a-" + (d % 7), "b-" + (d % 3) };
+                    case 1 -> new String[] { "a-" + (d % 7) };
+                    case 2 -> new String[] { "a-" + (d % 7), "b-" + (d % 3), "c" };
+                    default -> new String[] { "c" };
+                };
+            }
+        });
+    }
+
+    public void testNullsAndEmptyArrays() throws IOException {
+        assertPageMatchesPerDocument(docs -> {
+            for (int d = 0; d < docs.length; d++) {
+                docs[d] = switch (d % 6) {
+                    case 0 -> new String[] { "a-" + (d % 5), null, "b" };
+                    case 1 -> new String[] { null };          // a document holding no value
+                    case 2 -> new String[0];                  // an empty array, likewise
+                    case 3 -> new String[] { null, null };
+                    case 4 -> new String[] { "" };            // the empty string is a value
+                    default -> new String[] { "a-" + (d % 5) };
+                };
+            }
+        });
+    }
+
+    /** Values distinct enough that a page has nothing worth naming, so it comes back as values rather than ordinals. */
+    public void testPageThatDoesNotRepeat() throws IOException {
+        assertPageMatchesPerDocument(docs -> {
+            for (int d = 0; d < docs.length; d++) {
+                docs[d] = new String[] { "unique-value-" + d };
+            }
+        });
+    }
+
+    private interface Documents {
+        void fill(String[][] docs);
+    }
+
+    private void assertPageMatchesPerDocument(Documents documents) throws IOException {
+        final String[][] docs = new String[between(200, 1500)][];
+        documents.fill(docs);
+
+        final FieldType type = columnarBinaryFieldType();
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig().setCodec(columnarCodec()))) {
+                for (String[] slots : docs) {
+                    final Document doc = new Document();
+                    doc.add(new Field(FIELD, encode(slots), type));
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals("one segment", 1, reader.leaves().size());
+                final LeafReaderContext leaf = reader.leaves().get(0);
+                final var loader = new BytesRefsFromBinaryMultiSeparateCountBlockLoader(FIELD, BinaryDocValuesFormat.COLUMNAR_PAYLOAD);
+
+                // The comparison below is between the page path and the per-document path, and would agree for the
+                // wrong reason if the column declined every page and both sides read a document at a time. So the
+                // column is asked directly whether it serves these shapes at all.
+                final BinaryDocValues values = leaf.reader().getBinaryDocValues(FIELD);
+                assertThat("the field is a column", values, instanceOf(StringColumnSource.class));
+                final int[] everything = new int[docs.length];
+                for (int i = 0; i < docs.length; i++) {
+                    everything[i] = i;
+                }
+                assertTrue(
+                    "the column serves a page of these documents",
+                    ((StringColumnSource) values).reader().readBlock(everything, 0, everything.length, NOOP_SINK)
+                );
+
+                // Read in several pages, so a boundary falls inside the run of documents rather than only at its ends.
+                for (int page : new int[] { 1, 7, 128, docs.length }) {
+                    for (int from = 0; from < docs.length; from += page) {
+                        final int count = Math.min(page, docs.length - from);
+                        final BlockLoader.Docs wanted = docs(from, count);
+
+                        final TestBlock asPage = (TestBlock) loader.reader(NOOP, leaf).read(TestBlock.factory(), wanted, 0, false);
+                        final TestBlock perDocument = readOneAtATime(loader, leaf, wanted);
+
+                        assertEquals("positions at " + from + " of " + page, perDocument.size(), asPage.size());
+                        for (int i = 0; i < asPage.size(); i++) {
+                            assertEquals("page of " + page + " document " + (from + i), perDocument.get(i), asPage.get(i));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /** The same documents through the row-stride path, which reads and decodes a payload apiece. */
+    private static TestBlock readOneAtATime(
+        BytesRefsFromBinaryMultiSeparateCountBlockLoader loader,
+        LeafReaderContext leaf,
+        BlockLoader.Docs wanted
+    ) throws IOException {
+        final BlockLoader.RowStrideReader rows = loader.rowStrideReader(NOOP, leaf);
+        try (BlockLoader.Builder builder = loader.builder(TestBlock.factory(), wanted.count())) {
+            for (int i = 0; i < wanted.count(); i++) {
+                rows.read(wanted.get(i), null, builder);
+            }
+            return (TestBlock) builder.build();
+        }
+    }
+
+    private static BlockLoader.Docs docs(int from, int count) {
+        return new BlockLoader.Docs() {
+            @Override
+            public int count() {
+                return count;
+            }
+
+            @Override
+            public int get(int i) {
+                return from + i;
+            }
+
+            @Override
+            public boolean mayContainDuplicates() {
+                return false;
+            }
+        };
+    }
+
+    /** Every doc-values field through the columnar format, which is what makes the field a column. */
+    private static Codec columnarCodec() {
+        final Codec base = TestUtil.getDefaultCodec();
+        final DocValuesFormat columnar = new ColumNARDocValuesFormat();
+        return new FilterCodec(base.getName(), base) {
+            private final DocValuesFormat perField = new PerFieldDocValuesFormat() {
+                @Override
+                public DocValuesFormat getDocValuesFormatForField(String field) {
+                    return columnar;
+                }
+            };
+
+            @Override
+            public DocValuesFormat docValuesFormat() {
+                return perField;
+            }
+        };
+    }
+
+    private static FieldType columnarBinaryFieldType() {
+        final FieldType type = new FieldType();
+        type.setDocValuesType(DocValuesType.BINARY);
+        type.putAttribute(ColumNARDocValuesFormat.TYPE_ATTRIBUTE, ColumnarFieldType.STRING.name());
+        type.freeze();
+        return type;
+    }
+
+    /** Takes a page and does nothing with it, for a test asking only whether one is served. */
+    private static final StringBlockSink NOOP_SINK = new StringBlockSink() {
+        @Override
+        public void appendOrdinals(int[] ordinals, int valueCount, int[] valueCounts, int docCount, BytesRef[] dict, int dictSize) {}
+
+        @Override
+        public void appendValues(BytesRef[] values, int valueCount, int[] valueCounts, int docCount) {}
+    };
+
+    private static BytesRef encode(String[] slots) {
+        final List<BytesRef> refs = new ArrayList<>(slots.length);
+        for (String slot : slots) {
+            refs.add(slot == null ? null : new BytesRef(slot));
+        }
+        return BytesRef.deepCopyOf(new StringBinaryPayload.Builder().encode(refs));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortFieldTests.java
@@ -9,6 +9,10 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.BinaryDocValues;
@@ -20,7 +24,12 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.ColumNARDocValuesFormat;
+import org.elasticsearch.columnar.ColumnarFieldType;
+import org.elasticsearch.columnar.numeric.NumericPipeline;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.index.mapper.ColumnarBinaryDocValuesField;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
@@ -32,6 +41,7 @@ import java.io.IOException;
 import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
 import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.COLUMNAR_PAYLOAD;
 import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
 
@@ -467,6 +477,107 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
                 assertEquals(new BytesRef("omega"), advanced.binaryValue());
             }
         }
+    }
+
+    /**
+     * The sort key taken from a real column rather than from a payload. A column answers {@code extreme} itself,
+     * over ordinals where it keeps a dictionary, so the sort key never goes through the payload the other tests
+     * feed in - and it has to be the same key either way, for every shape a document takes.
+     */
+    public void testColumnarColumnAgreesWithThePayload() throws IOException {
+        final String[][] docs = new String[between(200, 600)][];
+        for (int d = 0; d < docs.length; d++) {
+            docs[d] = switch (d % 7) {
+                case 0 -> new String[] { "term-" + (d % 5) };
+                case 1 -> new String[] { "term-" + (d % 5), "term-" + ((d + 3) % 5) };
+                // A value the dictionary will not name, so the extreme is decided by bytes rather than by ordinal.
+                case 2 -> new String[] { "escaped-" + d, "term-1" };
+                case 3 -> new String[] { null, "term-2" };
+                case 4 -> new String[] { null };
+                case 5 -> new String[0];
+                default -> null;
+            };
+        }
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null).setCodec(columnarCodec()))) {
+            for (String[] slots : docs) {
+                final LuceneDocument doc = new LuceneDocument();
+                if (slots != null) {
+                    if (slots.length == 0) {
+                        ColumnarBinaryDocValuesField.recordEmptyArray(doc, "name");
+                    }
+                    for (String slot : slots) {
+                        if (slot == null) {
+                            ColumnarBinaryDocValuesField.recordNull(doc, "name");
+                        } else {
+                            ColumnarBinaryDocValuesField.recordValue(doc, "name", new BytesRef(slot), ValueOrdering.UNSORTED);
+                        }
+                    }
+                }
+                w.addDocument(doc);
+            }
+            w.forceMerge(1);
+            try (DirectoryReader reader = DirectoryReader.open(w)) {
+                final LeafReader leaf = getOnlyLeafReader(reader);
+                assertThat(
+                    "the field has to be a column, or this reads the same payload path as every other test here",
+                    leaf.getBinaryDocValues("name"),
+                    instanceOf(StringColumnSource.class)
+                );
+                for (boolean maxMode : new boolean[] { false, true }) {
+                    final BinaryDocValues keys = columnarSortKeys(leaf, maxMode);
+                    for (int d = 0; d < docs.length; d++) {
+                        final BytesRef expected = expectedExtreme(docs[d], maxMode);
+                        if (keys.advanceExact(d) == false) {
+                            assertNull("doc " + d + " maxMode=" + maxMode + " read as missing", expected);
+                            continue;
+                        }
+                        assertEquals("doc " + d + " maxMode=" + maxMode, expected, keys.binaryValue());
+                    }
+                }
+            }
+        }
+    }
+
+    /** The extreme non-null value of a document, worked out from the values themselves. */
+    private static BytesRef expectedExtreme(String[] slots, boolean maxMode) {
+        if (slots == null) {
+            return null;
+        }
+        BytesRef best = null;
+        for (String slot : slots) {
+            if (slot == null) {
+                continue;
+            }
+            final BytesRef candidate = new BytesRef(slot);
+            if (best == null || (maxMode ? candidate.compareTo(best) > 0 : candidate.compareTo(best) < 0)) {
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    private static Codec columnarCodec() {
+        final Codec base = TestUtil.getDefaultCodec();
+        // The type is injected rather than read from a field attribute: these documents are built through
+        // ColumnarBinaryDocValuesField, which is the mapper's field and carries no codec attribute.
+        final DocValuesFormat columnar = new ColumNARDocValuesFormat(
+            (fieldName, fieldType) -> NumericPipeline::defaultPipeline,
+            field -> ColumnarFieldType.STRING,
+            ColumNARDocValuesFormat.DEFAULT_BLOCK_SIZE
+        );
+        return new FilterCodec(base.getName(), base) {
+            private final DocValuesFormat perField = new PerFieldDocValuesFormat() {
+                @Override
+                public DocValuesFormat getDocValuesFormatForField(String field) {
+                    return columnar;
+                }
+            };
+
+            @Override
+            public DocValuesFormat docValuesFormat() {
+                return perField;
+            }
+        };
     }
 
     private static BinaryDocValues columnarSortKeys(LeafReader leaf, boolean maxMode) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -500,6 +500,37 @@ public class TestBlock implements BlockLoader.Block {
             }
 
             @Override
+            public BlockLoader.Block buildOrdinalBytesRefDirect(
+                int[] ordinals,
+                int valueCount,
+                int[] valueCounts,
+                int positionCount,
+                BytesRef[] dictionary,
+                int dictionarySize
+            ) {
+                // Resolved here rather than kept as ordinals: a test block holds the values a position has, and a
+                // caller comparing against one should not have to know which shape the page happened to arrive in.
+                BlockLoader.BytesRefBuilder builder = bytesRefs(positionCount);
+                int at = 0;
+                for (int position = 0; position < positionCount; position++) {
+                    int held = valueCounts == null ? 1 : valueCounts[position];
+                    if (held == 0) {
+                        builder.appendNull();
+                    } else if (held == 1) {
+                        builder.appendBytesRef(dictionary[ordinals[at++]]);
+                    } else {
+                        builder.beginPositionEntry();
+                        for (int i = 0; i < held; i++) {
+                            builder.appendBytesRef(dictionary[ordinals[at++]]);
+                        }
+                        builder.endPositionEntry();
+                    }
+                }
+                assert at == valueCount : "read " + at + " ordinals, was given " + valueCount;
+                return builder.build();
+            }
+
+            @Override
             public BlockLoader.Block buildAggregateMetricDoubleDirect(
                 BlockLoader.Block minBlock,
                 BlockLoader.Block maxBlock,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/DelegatingBlockLoaderFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/DelegatingBlockLoaderFactory.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -190,6 +191,53 @@ public abstract class DelegatingBlockLoaderFactory implements BlockLoader.BlockF
             (DoubleBlock) sumBlock,
             (IntBlock) countBlock
         );
+    }
+
+    @Override
+    public BlockLoader.Block buildOrdinalBytesRefDirect(
+        int[] ordinals,
+        int valueCount,
+        int[] valueCounts,
+        int positionCount,
+        BytesRef[] dictionary,
+        int dictionarySize
+    ) {
+        BytesRefVector dict = null;
+        IntBlock ords = null;
+        OrdinalBytesRefBlock result = null;
+        try {
+            try (BytesRefVector.Builder bytes = factory.newBytesRefVectorBuilder(dictionarySize)) {
+                for (int i = 0; i < dictionarySize; i++) {
+                    bytes.appendBytesRef(dictionary[i]);
+                }
+                dict = bytes.build();
+            }
+            try (IntBlock.Builder builder = factory.newIntBlockBuilder(valueCount)) {
+                int at = 0;
+                for (int position = 0; position < positionCount; position++) {
+                    final int held = valueCounts == null ? 1 : valueCounts[position];
+                    if (held == 0) {
+                        builder.appendNull();
+                    } else if (held == 1) {
+                        builder.appendInt(ordinals[at++]);
+                    } else {
+                        builder.beginPositionEntry();
+                        for (int i = 0; i < held; i++) {
+                            builder.appendInt(ordinals[at++]);
+                        }
+                        builder.endPositionEntry();
+                    }
+                }
+                assert at == valueCount : "read " + at + " ordinals, was given " + valueCount;
+                ords = builder.build();
+            }
+            result = new OrdinalBytesRefBlock(ords, dict);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(ords, dict);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarCodecIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarCodecIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.codec.columnar.ColumnarDocValuesFormatSelector;
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link CsvColumnarIT} with the ColumNAR codec on, so the values are read out of a real column rather than out of
+ * the doc-values format the index mode alone leaves in place.
+ *
+ * <p>The distinction matters more than it looks. Columnar <em>index mode</em> settles how a field is mapped; the
+ * columnar <em>codec</em> settles how its doc values are written, and only with both does a keyword become a
+ * {@code BINARY_COLUMNAR_PAYLOAD} field backed by a string column. Without the codec none of the column's own read
+ * paths are reached at all - not the page reader that grouping goes through, not the ordinals a page is handed over
+ * as, not the extremes taken from them. This runs the whole spec suite over columns so that they are.
+ */
+public class CsvColumnarCodecIT extends CsvColumnarIT {
+
+    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s", shuffle = false)
+    public static List<Object[]> readScriptSpec() throws Exception {
+        return new ArrayList<>(CsvColumnarIT.readScriptSpec());
+    }
+
+    /**
+     * Replaces the strategy the superclass installed with one that turns the codec on as well. JUnit runs a
+     * superclass {@code @BeforeClass} first, so this lands after {@link CsvColumnarIT#installColumnarStrategy()}.
+     */
+    @BeforeClass
+    public static void installColumnarCodecStrategy() {
+        assumeTrue("columnar_codec feature flag must be enabled", ColumnarDocValuesFormatSelector.COLUMNAR_CODEC_FEATURE_FLAG.isEnabled());
+        indexLoadStrategy = new ColumnarStrategy(
+            Settings.builder().put(modeSettings()).put(IndexSettings.COLUMNAR_CODEC_ENABLED_SETTING.getKey(), true).build()
+        );
+    }
+
+    public CsvColumnarCodecIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions);
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarCodecIT.java.new
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarCodecIT.java.new
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.codec.columnar.ColumnarDocValuesFormatSelector;
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link CsvColumnarIT} with the ColumNAR codec on, so the values are read out of a real column rather than out of
+ * the doc-values format the index mode alone leaves in place.
+ *
+ * <p>The distinction matters more than it looks. Columnar <em>index mode</em> settles how a field is mapped; the
+ * columnar <em>codec</em> settles how its doc values are written, and only with both does a keyword become a
+ * {@code BINARY_COLUMNAR_PAYLOAD} field backed by a string column. Without the codec none of the column's own read
+ * paths are reached at all - not the page reader that grouping goes through, not the ordinals a page is handed over
+ * as, not the extremes taken from them. This runs the whole spec suite over columns so that they are.
+ */
+public class CsvColumnarCodecIT extends CsvColumnarIT {
+
+    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s", shuffle = false)
+    public static List<Object[]> readScriptSpec() throws Exception {
+        return new ArrayList<>(CsvColumnarIT.readScriptSpec());
+    }
+
+    /**
+     * Replaces the strategy the superclass installed with one that turns the codec on as well. JUnit runs a
+     * superclass {@code @BeforeClass} first, so this lands after {@link CsvColumnarIT#installColumnarStrategy()}.
+     */
+    @BeforeClass
+    public static void installColumnarCodecStrategy() {
+        assumeTrue("columnar_codec feature flag must be enabled", ColumnarDocValuesFormatSelector.COLUMNAR_CODEC_FEATURE_FLAG.isEnabled());
+        indexLoadStrategy = new ColumnarStrategy(
+            Settings.builder().put(modeSettings()).put(IndexSettings.COLUMNAR_CODEC_ENABLED_SETTING.getKey(), true).build()
+        );
+    }
+
+    public CsvColumnarCodecIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions);
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -603,7 +603,7 @@ public class CsvColumnarIT extends CsvIT {
      *   <li>Honours the {@code skip_columnar:} preamble directive to silence individual tests.</li>
      * </ul>
      */
-    private static final class ColumnarStrategy implements IndexLoadStrategy {
+    static final class ColumnarStrategy implements IndexLoadStrategy {
 
         private final Settings extraSettings;
 


### PR DESCRIPTION
ES|QL reads a keyword column a document at a time, decoding a payload for each. A ColumNAR column can hand over a whole page of them, so this adds that path, plus a few functions that ask the column a question instead of asking for its values.

`StringBlockSink` gains the shape a page takes when documents hold several values or none: a flat run of values with a count per document beside it, null where every document holds exactly one. `BlockLoader.BlockFactory` gains `buildOrdinalBytesRefDirect`, for a page that already arrived as ordinals into its own distinct values. A page covering a document the column has no value for is declined and read the old way, as is a segment that arrives as an overlay rather than as a column.

`MV_MAX` and `MV_MIN` take the extreme from ordinals, since the dictionary is in term order and only the winning ordinal is resolved to a term. `LENGTH` and `BYTE_LENGTH` ask the column how many non-null values a document holds rather than decoding its payload to count them. A sort key is taken the same way, which a DSL sort and an ES|QL top-n both pick up, since both build the sort field through `SortBuilder`.

The plain path no longer builds a page dictionary for a page it is going to hand over as values. It collapses runs, which costs no byte comparisons, and hashes nothing.

`CsvColumnarCodecIT` runs the ES|QL spec suite with the codec actually installed; the existing `CsvColumnarIT` never exercised it.
