### PR TITLE
[9.5] [ML] Harden AD reopen against scroll-context exhaustion (#153260) (#154925)

### DIFF
--- a/docs/changelog/154925.yaml
+++ b/docs/changelog/154925.yaml
@@ -1,0 +1,7 @@
+area: Machine Learning
+issues:
+ - 153260
+pr: 154925
+summary: Prevent AD job reopen from exhausting search scroll contexts during mass
+  reassignment
+type: bug

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ReopenScrollContextIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ReopenScrollContextIT.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.persistent.PersistentTasksClusterService;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.search.SearchService;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ml.MlConfigVersion;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.persistent.PersistentTasksClusterService.isUnassignedOrMisassigned;
+import static org.elasticsearch.test.NodeRoles.onlyRoles;
+import static org.elasticsearch.xpack.core.ml.MlTasks.DATAFEED_TASK_NAME;
+import static org.elasticsearch.xpack.core.ml.MlTasks.JOB_TASK_NAME;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration regression: datafeed-attached AD jobs recover to {@link JobState#OPENED} and datafeeds resume
+ * after full-fleet reassignment under a constrained {@code search.max_open_scroll_context}.
+ * <p>
+ * Per-attempt slice reduction and capacity-aware reopen backoff are covered by unit tests in
+ * {@link org.elasticsearch.xpack.ml.job.persistence.JobDataDeleterTests} and
+ * {@link org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutorTests}. Internal-cluster ML
+ * result/annotation indices are single-shard, so revert-on-open {@code AUTO_SLICES} resolves to one slice here;
+ * this IT validates end-to-end recovery after node failure, not scroll-context exhaustion.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class ReopenScrollContextIT extends BaseMlIntegTestCase {
+
+    private static final int NUM_JOBS = 8;
+    private static final int SCROLL_CONTEXT_BUDGET = 5;
+    private static final String JOB_ID_PREFIX = "reopen-scroll-";
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(MachineLearning.CONCURRENT_JOB_ALLOCATIONS.getKey(), NUM_JOBS)
+            .build();
+    }
+
+    public void testDatafeedAttachedJobsShouldRecoverAfterReassignmentWithStarvedScrollBudget() throws Exception {
+        internalCluster().ensureAtMostNumDataNodes(0);
+        internalCluster().startMasterOnlyNode();
+        String coLocatedMlNode = internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)));
+        ensureStableCluster();
+
+        ClusterUpdateSettingsRequest scrollBudgetRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
+        scrollBudgetRequest.persistentSettings(
+            Settings.builder().put(SearchService.MAX_OPEN_SCROLL_CONTEXT.getKey(), SCROLL_CONTEXT_BUDGET).build()
+        );
+        client().admin().cluster().updateSettings(scrollBudgetRequest).actionGet();
+
+        List<String> jobIds = IntStream.range(0, NUM_JOBS).mapToObj(i -> JOB_ID_PREFIX + i).toList();
+        for (int i = 0; i < NUM_JOBS; i++) {
+            String jobId = jobIds.get(i);
+            String indexName = "data-" + i;
+            String datafeedId = jobId + "-datafeed";
+            setupSourceIndexAndJobWithDatafeed(jobId, datafeedId, indexName);
+        }
+
+        assertBusy(() -> assertAllJobsCoLocatedOnNode(jobIds, coLocatedMlNode), 30, TimeUnit.SECONDS);
+
+        // Jobs happily running on the first ML node do not rebalance when a second ML node joins.
+        internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)));
+        ensureStableCluster();
+        assertBusy(() -> assertAllJobsCoLocatedOnNode(jobIds, coLocatedMlNode), 30, TimeUnit.SECONDS);
+
+        setMlIndicesDelayedNodeLeftTimeoutToZero();
+        ensureGreen();
+
+        for (String jobId : jobIds) {
+            String datafeedId = jobId + "-datafeed";
+            StartDatafeedAction.Request startDatafeedRequest = new StartDatafeedAction.Request(datafeedId, 0L);
+            client().execute(StartDatafeedAction.INSTANCE, startDatafeedRequest).get();
+            assertBusy(
+                () -> { assertThat(getDatafeedStats(datafeedId).getDatafeedState(), equalTo(DatafeedState.STARTED)); },
+                30,
+                TimeUnit.SECONDS
+            );
+        }
+
+        for (String jobId : jobIds) {
+            indexModelSnapshotFromCurrentJobStats(jobId);
+        }
+        client().admin().indices().prepareFlush().get();
+
+        Map<String, String> jobNodesBeforeFailure = jobIds.stream()
+            .collect(Collectors.toMap(jobId -> jobId, jobId -> getJobStats(jobId).getNode().getName()));
+
+        PersistentTasksClusterService persistentTasksClusterService = internalCluster().getInstance(
+            PersistentTasksClusterService.class,
+            internalCluster().getMasterName()
+        );
+        persistentTasksClusterService.setRecheckInterval(TimeValue.timeValueMillis(200));
+
+        internalCluster().stopNode(coLocatedMlNode);
+        ensureStableCluster();
+
+        awaitClusterState(state -> {
+            List<PersistentTasksCustomMetadata.PersistentTask<?>> tasks = findTasks(state, Set.of(DATAFEED_TASK_NAME, JOB_TASK_NAME));
+            if (tasks == null || tasks.size() != NUM_JOBS * 2) {
+                return false;
+            }
+            for (PersistentTasksCustomMetadata.PersistentTask<?> task : tasks) {
+                if (isUnassignedOrMisassigned(task.getAssignment(), state.nodes())) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        assertBusy(() -> {
+            for (String jobId : jobIds) {
+                GetJobsStatsAction.Response.JobStats jobStats = getJobStats(jobId);
+                JobState state = jobStats.getState();
+                assertThat("job [" + jobId + "] must not fail during reopen", state, not(equalTo(JobState.FAILED)));
+                assertThat("job [" + jobId + "] must reopen after reassignment", state, equalTo(JobState.OPENED));
+                assertThat("job [" + jobId + "] must be reassigned", jobStats.getNode(), is(notNullValue()));
+                assertThat(
+                    "job [" + jobId + "] must not remain on the stopped node",
+                    jobStats.getNode().getName(),
+                    not(equalTo(coLocatedMlNode))
+                );
+                assertThat(
+                    "job [" + jobId + "] must change assignment after node failure",
+                    jobStats.getNode().getName(),
+                    not(equalTo(jobNodesBeforeFailure.get(jobId)))
+                );
+
+                String datafeedId = jobId + "-datafeed";
+                GetDatafeedsStatsAction.Response.DatafeedStats datafeedStats = getDatafeedStats(datafeedId);
+                assertThat("datafeed [" + datafeedId + "] must resume", datafeedStats.getDatafeedState(), equalTo(DatafeedState.STARTED));
+                assertThat("datafeed [" + datafeedId + "] must be reassigned", datafeedStats.getNode(), is(notNullValue()));
+                assertThat(
+                    "datafeed [" + datafeedId + "] must not remain on the stopped node",
+                    datafeedStats.getNode().getName(),
+                    not(equalTo(coLocatedMlNode))
+                );
+            }
+        }, 5, TimeUnit.MINUTES);
+    }
+
+    private void assertAllJobsCoLocatedOnNode(List<String> jobIds, String expectedNode) {
+        Set<String> nodes = jobIds.stream().map(jobId -> getJobStats(jobId).getNode().getName()).collect(Collectors.toSet());
+        assertEquals("all jobs must run on a single ML node", 1, nodes.size());
+        assertEquals(expectedNode, nodes.iterator().next());
+    }
+
+    private void setupSourceIndexAndJobWithDatafeed(String jobId, String datafeedId, String indexName) throws Exception {
+        client().admin().indices().prepareCreate(indexName).setMapping("time", "type=date").get();
+        long numDocs = randomIntBetween(32, 256);
+        long now = System.currentTimeMillis();
+        long weekAgo = now - 604800000L;
+        long twoWeeksAgo = weekAgo - 604800000L;
+        indexDocs(logger, indexName, numDocs, twoWeeksAgo, weekAgo);
+
+        Job.Builder job = createScheduledJob(jobId, ByteSizeValue.ofMb(2));
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+
+        DatafeedConfig datafeedConfig = createDatafeed(
+            datafeedId,
+            jobId,
+            Collections.singletonList(indexName),
+            TimeValue.timeValueSeconds(1)
+        );
+        client().execute(PutDatafeedAction.INSTANCE, new PutDatafeedAction.Request(datafeedConfig)).actionGet();
+
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId)).actionGet();
+        assertBusy(() -> {
+            GetJobsStatsAction.Response statsResponse = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+                .actionGet();
+            assertEquals(JobState.OPENED, statsResponse.getResponse().results().get(0).getState());
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    private void indexModelSnapshotFromCurrentJobStats(String jobId) throws Exception {
+        GetJobsStatsAction.Response.JobStats jobStats = getJobStats(jobId);
+        DataCounts dataCounts = jobStats.getDataCounts();
+
+        ModelSnapshot modelSnapshot = new ModelSnapshot.Builder(jobId).setLatestResultTimeStamp(dataCounts.getLatestRecordTimeStamp())
+            .setLatestRecordTimeStamp(dataCounts.getLatestRecordTimeStamp())
+            .setMinVersion(MlConfigVersion.CURRENT)
+            .setSnapshotId(jobId + "_mock_snapshot")
+            .setTimestamp(new Date())
+            .setModelSizeStats(new ModelSizeStats.Builder(jobId).build())
+            .build();
+
+        try (XContentBuilder xContentBuilder = JsonXContent.contentBuilder()) {
+            modelSnapshot.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+            IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.jobResultsAliasedName(jobId));
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            indexRequest.id(ModelSnapshot.documentId(modelSnapshot));
+            indexRequest.source(xContentBuilder);
+            client().index(indexRequest).actionGet();
+        }
+
+        JobUpdate jobUpdate = new JobUpdate.Builder(jobId).setModelSnapshotId(modelSnapshot.getSnapshotId()).build();
+        client().execute(UpdateJobAction.INSTANCE, new UpdateJobAction.Request(jobId, jobUpdate)).actionGet();
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -462,6 +462,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -779,6 +780,47 @@ public class MachineLearning extends Plugin
         Setting.Property.NodeScope
     );
 
+    /** Matches {@link org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.OpenJobRetryableAction} normal backoff. */
+    private static final TimeValue JOB_OPEN_NORMAL_RETRY_INITIAL_DELAY = TimeValue.timeValueSeconds(5);
+    private static final TimeValue JOB_OPEN_NORMAL_RETRY_MAX_DELAY = TimeValue.timeValueMinutes(5);
+
+    /**
+     * Largest delay bound safe for {@link org.elasticsearch.action.support.RetryableAction} jitter scheduling.
+     */
+    private static final TimeValue CAPACITY_RETRY_JITTER_SAFE_MAX = TimeValue.timeValueMillis(2L * Integer.MAX_VALUE - 1L);
+
+    /**
+     * Backoff-bound floor for capacity-constrained failures in the AD job-open pipeline
+     * (scroll-context/circuit-breaker/thread-pool saturation). Longer than the default 5s so the search tier can
+     * drain before the revert delete is re-issued. Because {@code RetryableAction} sleeps on the previous bound for
+     * the failing attempt, this floor takes effect from the second capacity retry onward—the first capacity failure
+     * still waits the prior ~5s bound. Applied by
+     * {@link org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.OpenJobRetryableAction}.
+     * See elastic/elasticsearch#153260.
+     */
+    public static final Setting<TimeValue> JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY = Setting.timeSetting(
+        "xpack.ml.job_open_capacity_retry_initial_delay",
+        TimeValue.timeValueSeconds(30),
+        JOB_OPEN_NORMAL_RETRY_INITIAL_DELAY,
+        CAPACITY_RETRY_JITTER_SAFE_MAX,
+        new CapacityRetryInitialDelayValidator(),
+        Property.NodeScope
+    );
+
+    /**
+     * Maximum retry backoff bound for capacity-constrained failures in the AD job-open pipeline. Higher than the
+     * default 5m cap so repeated capacity failures back off further, letting scroll contexts expire between attempts.
+     * See elastic/elasticsearch#153260.
+     */
+    public static final Setting<TimeValue> JOB_OPEN_CAPACITY_RETRY_MAX_DELAY = Setting.timeSetting(
+        "xpack.ml.job_open_capacity_retry_max_delay",
+        TimeValue.timeValueMinutes(10),
+        JOB_OPEN_NORMAL_RETRY_MAX_DELAY,
+        CAPACITY_RETRY_JITTER_SAFE_MAX,
+        new CapacityRetryMaxDelayValidator(),
+        Property.NodeScope
+    );
+
     /**
      * Minimum number of consecutive search cycles a cross-cluster scope change must persist before being
      * confirmed. Lowering this value (together with {@link #CCS_STABILIZATION_FLOOR}) enables faster
@@ -924,6 +966,8 @@ public class MachineLearning extends Plugin
             MAX_ML_NODE_SIZE,
             DELAYED_DATA_CHECK_FREQ,
             JOB_OPEN_RETRY_TIMEOUT,
+            JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY,
+            JOB_OPEN_CAPACITY_RETRY_MAX_DELAY,
             CCS_STABILIZATION_CYCLES,
             CCS_STABILIZATION_FLOOR,
             DUMMY_ENTITY_MEMORY,
@@ -2509,6 +2553,64 @@ public class MachineLearning extends Plugin
     public void signalShutdown(Collection<String> shutdownNodeIds) {
         if (enabled) {
             mlLifeCycleService.get().signalGracefulShutdown(shutdownNodeIds);
+        }
+    }
+
+    private static final class CapacityRetryInitialDelayValidator implements Setting.Validator<TimeValue> {
+
+        @Override
+        public void validate(TimeValue value) {}
+
+        @Override
+        public void validate(TimeValue initial, Map<Setting<?>, Object> settings) {
+            TimeValue max = (TimeValue) settings.get(JOB_OPEN_CAPACITY_RETRY_MAX_DELAY);
+            if (max != null && initial.compareTo(max) > 0) {
+                throw new IllegalArgumentException(
+                    "["
+                        + JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey()
+                        + "] ("
+                        + initial
+                        + ") must be less than or equal to ["
+                        + JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey()
+                        + "] ("
+                        + max
+                        + ")"
+                );
+            }
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(JOB_OPEN_CAPACITY_RETRY_MAX_DELAY).iterator();
+        }
+    }
+
+    private static final class CapacityRetryMaxDelayValidator implements Setting.Validator<TimeValue> {
+
+        @Override
+        public void validate(TimeValue value) {}
+
+        @Override
+        public void validate(TimeValue max, Map<Setting<?>, Object> settings) {
+            TimeValue initial = (TimeValue) settings.get(JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY);
+            if (initial != null && max.compareTo(initial) < 0) {
+                throw new IllegalArgumentException(
+                    "["
+                        + JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey()
+                        + "] ("
+                        + max
+                        + ") must be greater than or equal to ["
+                        + JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey()
+                        + "] ("
+                        + initial
+                        + ")"
+                );
+            }
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY).iterator();
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -32,6 +32,8 @@ import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
@@ -48,6 +50,8 @@ import org.elasticsearch.index.reindex.BulkByPaginatedSearchResponse;
 import org.elasticsearch.index.reindex.BulkByPaginatedSearchTask;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.PaginatedSearchFailure;
+import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
@@ -82,6 +86,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
@@ -91,6 +96,22 @@ public class JobDataDeleter {
     private static final Logger logger = LogManager.getLogger(JobDataDeleter.class);
 
     private static final int MAX_SNAPSHOTS_TO_DELETE = 10000;
+
+    // Bound these result/annotation DeleteByQuery requests to a single slice. The primary driver is the
+    // revert-on-open path (elastic/elasticsearch#153260): reverting to the CURRENT (latest) snapshot makes the
+    // "intervening results/annotations since snapshot" delete small by construction, so AUTO_SLICES fan-out
+    // (up to min(shards,20) scroll contexts per request) buys negligible speedup while it can exhaust
+    // search.max_open_scroll_context during a mass reopen storm. deleteAnnotations is also reached by the
+    // job-delete path (deleteAllAnnotations); annotations are low-volume there too, so one slice is fine.
+    private static final int DELETE_SLICES = 1;
+
+    // Short scroll keepalive so abandoned/partial scroll contexts free quickly instead of lingering for the 5-minute
+    // default, preventing accumulation faster than expiry when the reopen pipeline retries (elastic/elasticsearch#153260).
+    private static final TimeValue DELETE_SCROLL_KEEP_ALIVE = TimeValue.timeValueMinutes(1);
+
+    // One fresh DeleteByQuery attempt after a scroll context expires mid-delete (elastic/elasticsearch#153260).
+    private static final TimeValue DELETE_SCROLL_CONTEXT_RETRY_DELAY = TimeValue.timeValueSeconds(30);
+    private static final int MAX_DELETE_SCROLL_CONTEXT_ATTEMPTS = 2;
 
     private final Client client;
     private final String jobId;
@@ -203,22 +224,90 @@ public class JobDataDeleter {
         );
         if (indicesToQuery.length == 0) return;
 
+        executeDeleteByQueryWithScrollContextRetry(() -> newDeleteByQueryRequest(indicesToQuery, query), listener);
+    }
+
+    private DeleteByQueryRequest newDeleteByQueryRequest(String[] indicesToQuery, QueryBuilder query) {
         DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(indicesToQuery).setQuery(query)
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRefresh(true)
-            .setSlices(AbstractBulkByPaginatedSearchRequest.AUTO_SLICES);
+            .setSlices(DELETE_SLICES)
+            .setScroll(DELETE_SCROLL_KEEP_ALIVE);
 
         // _doc is the most efficient sort order and will also disable scoring
         dbqRequest.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);
+        return dbqRequest;
+    }
 
-        executeAsyncWithOrigin(
-            client,
-            ML_ORIGIN,
-            DeleteByQueryAction.INSTANCE,
-            dbqRequest,
-            ActionListener.wrap(r -> listener.onResponse(true), listener::onFailure)
-        );
+    private void executeDeleteByQueryWithScrollContextRetry(
+        Supplier<DeleteByQueryRequest> requestSupplier,
+        ActionListener<Boolean> listener
+    ) {
+        executeDeleteByQueryWithScrollContextRetry(requestSupplier, ActionListener.assertOnce(listener), 1);
+    }
+
+    private void executeDeleteByQueryWithScrollContextRetry(
+        Supplier<DeleteByQueryRequest> requestSupplier,
+        ActionListener<Boolean> listener,
+        int attempt
+    ) {
+        executeAsyncWithOrigin(client, ML_ORIGIN, DeleteByQueryAction.INSTANCE, requestSupplier.get(), ActionListener.wrap(response -> {
+            if (hasSearchContextMissingFailure(response)) {
+                if (attempt < MAX_DELETE_SCROLL_CONTEXT_ATTEMPTS) {
+                    scheduleDeleteByQueryRetry(requestSupplier, listener, attempt + 1);
+                } else {
+                    listener.onFailure(searchContextMissingFromResponse(response));
+                }
+            } else {
+                listener.onResponse(true);
+            }
+        }, failure -> {
+            if (isSearchContextMissing(failure) && attempt < MAX_DELETE_SCROLL_CONTEXT_ATTEMPTS) {
+                scheduleDeleteByQueryRetry(requestSupplier, listener, attempt + 1);
+            } else {
+                listener.onFailure(failure);
+            }
+        }));
+    }
+
+    private void scheduleDeleteByQueryRetry(Supplier<DeleteByQueryRequest> requestSupplier, ActionListener<Boolean> listener, int attempt) {
+        try {
+            client.threadPool()
+                .schedule(
+                    () -> executeDeleteByQueryWithScrollContextRetry(requestSupplier, listener, attempt),
+                    DELETE_SCROLL_CONTEXT_RETRY_DELAY,
+                    client.threadPool().generic()
+                );
+        } catch (EsRejectedExecutionException e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private static boolean hasSearchContextMissingFailure(BulkByPaginatedSearchResponse response) {
+        for (PaginatedSearchFailure failure : response.getSearchFailures()) {
+            if (org.elasticsearch.ExceptionsHelper.unwrap(failure.getReason(), SearchContextMissingException.class) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Exception searchContextMissingFromResponse(BulkByPaginatedSearchResponse response) {
+        for (PaginatedSearchFailure failure : response.getSearchFailures()) {
+            Throwable cause = org.elasticsearch.ExceptionsHelper.unwrap(failure.getReason(), SearchContextMissingException.class);
+            if (cause != null) {
+                if (cause instanceof Exception exception) {
+                    return org.elasticsearch.ExceptionsHelper.convertToElastic(exception);
+                }
+                return new IllegalStateException(cause);
+            }
+        }
+        return new IllegalStateException("expected search context missing failure");
+    }
+
+    private static boolean isSearchContextMissing(Exception failure) {
+        return org.elasticsearch.ExceptionsHelper.unwrap(failure, SearchContextMissingException.class) != null;
     }
 
     private <T> String[] removeReadOnlyIndices(
@@ -273,22 +362,8 @@ public class JobDataDeleter {
             () -> listener.onResponse(true)
         );
         if (indicesToQuery.length == 0) return;
-        DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(indicesToQuery).setQuery(query)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-            .setAbortOnVersionConflict(false)
-            .setRefresh(true)
-            .setSlices(AbstractBulkByPaginatedSearchRequest.AUTO_SLICES);
 
-        // _doc is the most efficient sort order and will also disable scoring
-        dbqRequest.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);
-
-        executeAsyncWithOrigin(
-            client,
-            ML_ORIGIN,
-            DeleteByQueryAction.INSTANCE,
-            dbqRequest,
-            ActionListener.wrap(r -> listener.onResponse(true), listener::onFailure)
-        );
+        executeDeleteByQueryWithScrollContextRetry(() -> newDeleteByQueryRequest(indicesToQuery, query), listener);
     }
 
     /**
@@ -300,7 +375,7 @@ public class JobDataDeleter {
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRefresh(false)
-            .setSlices(AbstractBulkByPaginatedSearchRequest.AUTO_SLICES);
+            .setSlices(DELETE_SLICES);
 
         // _doc is the most efficient sort order and will also disable scoring
         dbqRequest.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -32,7 +32,6 @@ import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.CheckedConsumer;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -60,6 +60,7 @@ import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManage
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.task.AbstractJobPersistentTasksExecutor;
+import org.elasticsearch.xpack.ml.utils.MlRecoverableErrorClassifier;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -345,6 +346,26 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         ActionListener<Boolean> listener
     ) {
         return new OpenJobRetryableAction(jobTask, jobTaskState, params, listener);
+    }
+
+    /**
+     * Computes the next exponential-backoff bound for the job-open retry. For capacity-constrained failures
+     * (scroll/breaker/pool saturation) the bound jumps to at least {@code capacityInitialMillis} and is capped at
+     * {@code capacityMaxMillis} (deliberately above the normal cap) so retries slow enough for the search tier to
+     * drain. Availability-class failures keep the default {@code min(prev*2, normalMaxMillis)} behavior.
+     * See elastic/elasticsearch#153260.
+     */
+    static long nextCapacityAwareDelayBound(
+        long previousBoundMillis,
+        boolean capacityConstrained,
+        long normalMaxMillis,
+        long capacityInitialMillis,
+        long capacityMaxMillis
+    ) {
+        if (capacityConstrained) {
+            return Math.min(Math.max(previousBoundMillis * 2, capacityInitialMillis), capacityMaxMillis);
+        }
+        return Math.min(previousBoundMillis * 2, normalMaxMillis);
     }
 
     // Exceptions that occur while the node is dying, i.e. after the JVM has received a SIGTERM,
@@ -679,18 +700,36 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
      * Retries the entire job opening pipeline for system-initiated reassignments.
      *
      * Uses exponential backoff with:
-     * - Initial delay: 5 seconds
-     * - Max delay: 5 minutes
+     * - Initial delay: 5 seconds; normal max delay: 5 minutes (availability-class errors)
+     * - Capacity-constrained failures ({@link MlRecoverableErrorClassifier#isCapacityConstrained}: HTTP 429 /
+     *   scroll-context exhaustion, transient circuit-breaker, non-shutdown rejection) use a longer regime: the backoff
+     *   bound escalates to {@link MachineLearning#JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY}
+     *   ({@code xpack.ml.job_open_capacity_retry_initial_delay}, default 30s) and is capped at
+     *   {@link MachineLearning#JOB_OPEN_CAPACITY_RETRY_MAX_DELAY} ({@code xpack.ml.job_open_capacity_retry_max_delay},
+     *   default 10m) so the search tier can drain (elastic/elasticsearch#153260)
      * - Total timeout: from {@link MachineLearning#JOB_OPEN_RETRY_TIMEOUT} (default 60 minutes)
+     *
+     * The exponential backoff bound is shared across error classes (inherited from {@link RetryableAction}); it is not
+     * reset when the error class changes. After a capacity-constrained failure raises the bound, a following
+     * availability-class retry inherits the raised bound rather than the 5s→5m ramp. This is intentional: backing off
+     * slightly longer immediately after capacity pressure helps the tier recover and self-heals as the bound continues
+     * under the normal cap.
      *
      * Only applies to reassignments (detected via {@link JobTaskState#isStatusStale(PersistentTask)}).
      * User-initiated opens fail fast.
      */
     class OpenJobRetryableAction extends RetryableAction<Boolean> {
 
+        private static final TimeValue INITIAL_RETRY_DELAY = TimeValue.timeValueSeconds(5);
+        private static final TimeValue MAX_RETRY_DELAY = TimeValue.timeValueMinutes(5);
+
         private final JobTask jobTask;
         private final JobTaskState jobTaskState;
         private final OpenJobAction.JobParams params;
+
+        private final long capacityInitialDelayMillis;
+        private final long capacityMaxDelayMillis;
+        private volatile boolean lastErrorCapacityConstrained = false;
 
         OpenJobRetryableAction(
             JobTask jobTask,
@@ -701,8 +740,8 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             super(
                 logger,
                 client.threadPool(),
-                TimeValue.timeValueSeconds(5),
-                TimeValue.timeValueMinutes(5),
+                INITIAL_RETRY_DELAY,
+                MAX_RETRY_DELAY,
                 clusterSettings.get(MachineLearning.JOB_OPEN_RETRY_TIMEOUT),
                 listener,
                 client.threadPool().generic()
@@ -710,6 +749,8 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             this.jobTask = Objects.requireNonNull(jobTask);
             this.jobTaskState = jobTaskState;
             this.params = Objects.requireNonNull(params);
+            this.capacityInitialDelayMillis = clusterSettings.get(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY).millis();
+            this.capacityMaxDelayMillis = clusterSettings.get(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY).millis();
         }
 
         @Override
@@ -722,7 +763,19 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             if (jobTask.isClosing() || jobTask.isVacating()) {
                 return false;
             }
+            lastErrorCapacityConstrained = MlRecoverableErrorClassifier.isCapacityConstrained(e);
             return org.elasticsearch.xpack.ml.utils.MlRecoverableErrorClassifier.isRecoverable(e);
+        }
+
+        @Override
+        protected long calculateDelayBound(long previousDelayBound) {
+            return nextCapacityAwareDelayBound(
+                previousDelayBound,
+                lastErrorCapacityConstrained,
+                MAX_RETRY_DELAY.millis(),
+                capacityInitialDelayMillis,
+                capacityMaxDelayMillis
+            );
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifier.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.indices.IndexPrimaryShardNotAllocatedException;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.transport.TransportException;
 
@@ -76,6 +77,12 @@ public final class MlRecoverableErrorClassifier {
         // IllegalIndexShardStateException: shard in wrong state (e.g. RECOVERING) – transient; retry when shard is ready.
         // Overrides NOT_FOUND status; TransportActions treats it as shard-not-available (retryable).
         if (cause instanceof IllegalIndexShardStateException) {
+            return true;
+        }
+
+        // SearchContextMissingException: expired/relocated scroll (or PIT) context — transient under load.
+        // Overrides NOT_FOUND; shortened DBQ keepalive (JobDataDeleter) can expire during bulk rejection backoff (#153260).
+        if (ExceptionsHelper.unwrap(e, SearchContextMissingException.class) != null) {
             return true;
         }
 
@@ -146,5 +153,24 @@ public final class MlRecoverableErrorClassifier {
 
         // Default: irrecoverable. Unknown exception types fail fast for clear diagnostics.
         return false;
+    }
+
+    /**
+     * Returns {@code true} if the exception indicates the cluster is out of a fungible capacity resource
+     * (scroll contexts, transient circuit-breaker memory, or a saturated thread pool) rather than an
+     * availability outage. Such errors are still recoverable, but retrying too fast re-consumes the same
+     * scarce resource; callers should apply a longer backoff. See elastic/elasticsearch#153260.
+     *
+     * @param e the exception to classify; wrapping exceptions are unwrapped before classification
+     */
+    public static boolean isCapacityConstrained(Exception e) {
+        Throwable cause = ExceptionsHelper.unwrapCause(e);
+        if (cause instanceof CircuitBreakingException cbe) {
+            return cbe.getDurability() == CircuitBreaker.Durability.TRANSIENT;
+        }
+        if (cause instanceof EsRejectedExecutionException ere) {
+            return ere.isExecutorShutdown() == false;
+        }
+        return status(cause) == RestStatus.TOO_MANY_REQUESTS;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
@@ -13,7 +13,9 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.PluginTestUtil;
@@ -326,9 +328,89 @@ public class MachineLearningTests extends ESTestCase {
         }
     }
 
-    public static class TrialLicensedMachineLearning extends MachineLearning {
+    public void testGetSettingsShouldRegisterCapacityRetryBackoffSettings() throws Exception {
+        try (MachineLearning ml = createTrialLicensedMachineLearning(Settings.EMPTY)) {
+            List<Setting<?>> settings = ml.getSettings();
+            assertThat(settings, hasItem(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY));
+            assertThat(settings, hasItem(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY));
+        }
+    }
 
-        // A license state constructed like this is considered a trial license
+    public void testCapacityRetryDefaultsShouldBeValid() {
+        assertThat(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.get(Settings.EMPTY), equalTo(TimeValue.timeValueSeconds(30)));
+        assertThat(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.get(Settings.EMPTY), equalTo(TimeValue.timeValueMinutes(10)));
+    }
+
+    public void testCapacityRetryEqualInitialAndMaxDelayShouldBeValid() {
+        Settings settings = Settings.builder()
+            .put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey(), "10m")
+            .put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey(), "10m")
+            .build();
+        assertThat(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.get(settings), equalTo(TimeValue.timeValueMinutes(10)));
+        assertThat(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.get(settings), equalTo(TimeValue.timeValueMinutes(10)));
+    }
+
+    public void testCapacityRetryInitialDelayBelowNormalMinimumShouldBeRejected() {
+        Settings settings = Settings.builder().put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey(), "4s").build();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.get(settings)
+        );
+        assertThat(e.getMessage(), containsString("must be >= [5s]"));
+    }
+
+    public void testCapacityRetryMaxDelayBelowNormalCeilingShouldBeRejected() {
+        Settings settings = Settings.builder().put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey(), "4m").build();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.get(settings)
+        );
+        assertThat(e.getMessage(), containsString("must be >= [5m]"));
+    }
+
+    public void testCapacityRetryInitialDelayGreaterThanMaxDelayShouldBeRejected() {
+        Settings settings = Settings.builder()
+            .put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey(), "10m")
+            .put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey(), "5m")
+            .build();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.get(settings)
+        );
+        assertThat(e.getMessage(), containsString(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey()));
+        assertThat(e.getMessage(), containsString(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey()));
+    }
+
+    public void testCapacityRetryMaxDelayLessThanInitialDelayShouldBeRejected() {
+        Settings settings = Settings.builder()
+            .put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey(), "10m")
+            .put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey(), "5m")
+            .build();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.get(settings)
+        );
+        assertThat(e.getMessage(), containsString(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey()));
+        assertThat(e.getMessage(), containsString(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey()));
+    }
+
+    public void testCapacityRetrySettingsAboveJitterSafeMaximumShouldBeRejected() {
+        Settings initialTooLarge = Settings.builder().put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.getKey(), "50d").build();
+        IllegalArgumentException initialException = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY.get(initialTooLarge)
+        );
+        assertThat(initialException.getMessage(), containsString("must be <="));
+
+        Settings maxTooLarge = Settings.builder().put(MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.getKey(), "50d").build();
+        IllegalArgumentException maxException = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY.get(maxTooLarge)
+        );
+        assertThat(maxException.getMessage(), containsString("must be <="));
+    }
+
+    public static class TrialLicensedMachineLearning extends MachineLearning {
         XPackLicenseState licenseState = new XPackLicenseState(() -> 0L);
 
         public TrialLicensedMachineLearning(Settings settings) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
@@ -6,42 +6,58 @@
  */
 package org.elasticsearch.xpack.ml.job.persistence;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.support.ActionTestUtils;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.reindex.BulkByPaginatedSearchResponse;
+import org.elasticsearch.index.reindex.BulkByPaginatedSearchTask;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.PaginatedSearchFailure;
+import org.elasticsearch.search.SearchContextMissingException;
+import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler.ScheduledCancellable;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.ml.job.retention.MockWritableIndexExpander;
-import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.core.Tuple.tuple;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class JobDataDeleterTests extends ESTestCase {
@@ -58,11 +74,6 @@ public class JobDataDeleterTests extends ESTestCase {
         client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);
         deleteRequestCaptor = ArgumentCaptor.forClass(DeleteByQueryRequest.class);
-    }
-
-    @After
-    public void verifyNoMoreInteractionsWithClient() {
-        verifyNoMoreInteractions(client);
     }
 
     public void testDeleteAllAnnotations() {
@@ -87,6 +98,8 @@ public class JobDataDeleterTests extends ESTestCase {
             } else {
                 assertThat(dbqQueryString, containsString("_xpack"));
             }
+            assertThat(deleteRequest.getSlices(), equalTo(1));
+            assertThat(deleteRequest.getScrollTime(), equalTo(TimeValue.timeValueMinutes(1)));
         });
         verify(client, times(2)).threadPool();
     }
@@ -118,6 +131,8 @@ public class JobDataDeleterTests extends ESTestCase {
             } else {
                 assertThat(dbqQueryString, containsString("_xpack"));
             }
+            assertThat(deleteRequest.getSlices(), equalTo(1));
+            assertThat(deleteRequest.getScrollTime(), equalTo(TimeValue.timeValueMinutes(1)));
         });
         verify(client, times(2)).threadPool();
     }
@@ -149,6 +164,8 @@ public class JobDataDeleterTests extends ESTestCase {
             } else {
                 assertThat(dbqQueryString, containsString("_xpack"));
             }
+            assertThat(deleteRequest.getSlices(), equalTo(1));
+            assertThat(deleteRequest.getScrollTime(), equalTo(TimeValue.timeValueMinutes(1)));
         });
         verify(client, times(2)).threadPool();
     }
@@ -165,6 +182,8 @@ public class JobDataDeleterTests extends ESTestCase {
         assertThat(deleteRequest.indices(), is(arrayContaining(".ml-anomalies-my-job-id")));
         String dbqQueryString = Strings.toString(deleteRequest.getSearchRequest().source().query());
         assertThat(dbqQueryString, containsString("{\"term\":{\"job_id\":{\"value\":\"my-job-id\"}}"));
+        assertThat(deleteRequest.getSlices(), equalTo(1));
+        assertThat(deleteRequest.getScrollTime(), equalTo(TimeValue.timeValueMinutes(1)));
         verify(client, times(1)).threadPool();
     }
 
@@ -195,5 +214,193 @@ public class JobDataDeleterTests extends ESTestCase {
             jobDataDeleter.deleteDatafeedTimingStats(ActionTestUtils.assertNoFailureListener(deleteResponse -> {}));
         });
         verify(client, never()).execute(eq(TransportDeleteAction.TYPE), any(DeleteRequest.class), any());
+    }
+
+    public void testDeleteInterimResultsShouldUseSingleSlice() throws Exception {
+        MockWritableIndexExpander.create(true);
+        PlainActionFuture<BulkByPaginatedSearchResponse> future = new PlainActionFuture<>();
+        future.onResponse(emptyBulkByPaginatedSearchResponse());
+        when(client.execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture())).thenReturn(future);
+
+        JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
+        jobDataDeleter.deleteInterimResults();
+
+        DeleteByQueryRequest deleteRequest = deleteRequestCaptor.getValue();
+        assertThat(deleteRequest.indices(), is(arrayContaining(AnomalyDetectorsIndex.jobResultsAliasedName(JOB_ID))));
+        String dbqQueryString = Strings.toString(deleteRequest.getSearchRequest().source().query());
+        assertThat(dbqQueryString, containsString("is_interim"));
+        assertThat(deleteRequest.getSlices(), equalTo(1));
+        verify(client).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture());
+        verify(client).threadPool();
+    }
+
+    public void testDeleteResultsFromTimeShouldRetrySearchContextMissingWithFreshRequests() {
+        MockWritableIndexExpander.create(true);
+        ThreadPool threadPool = mockThreadPoolForScheduledRetry();
+        when(client.threadPool()).thenReturn(threadPool);
+
+        AtomicInteger executeCount = new AtomicInteger();
+        ArgumentCaptor<Runnable> retryRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        ArgumentCaptor<TimeValue> retryDelayCaptor = ArgumentCaptor.forClass(TimeValue.class);
+        when(threadPool.schedule(retryRunnableCaptor.capture(), retryDelayCaptor.capture(), any())).thenReturn(
+            mock(ScheduledCancellable.class)
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByPaginatedSearchResponse> listener = invocation.getArgument(2);
+            if (executeCount.incrementAndGet() == 1) {
+                listener.onResponse(searchContextMissingResponse());
+            } else {
+                listener.onResponse(emptyBulkByPaginatedSearchResponse());
+            }
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
+
+        AtomicInteger completions = new AtomicInteger();
+        JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
+        jobDataDeleter.deleteResultsFromTime(1_000L, ActionTestUtils.assertNoFailureListener(r -> completions.incrementAndGet()));
+
+        assertThat(executeCount.get(), equalTo(1));
+        assertThat(retryDelayCaptor.getValue(), equalTo(TimeValue.timeValueSeconds(30)));
+        retryRunnableCaptor.getValue().run();
+
+        List<DeleteByQueryRequest> requests = deleteRequestCaptor.getAllValues();
+        assertThat(requests.size(), equalTo(2));
+        assertThat(requests.get(0), not(sameInstance(requests.get(1))));
+        assertThat(requests.get(0).getSlices(), equalTo(1));
+        assertThat(requests.get(1).getScrollTime(), equalTo(TimeValue.timeValueMinutes(1)));
+        assertThat(completions.get(), equalTo(1));
+        verify(client, times(2)).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
+        verify(client, atLeastOnce()).threadPool();
+    }
+
+    public void testDeleteAnnotationsShouldRetrySearchContextMissingWithFreshRequests() {
+        MockWritableIndexExpander.create(true);
+        ThreadPool threadPool = mockThreadPoolForScheduledRetry();
+        when(client.threadPool()).thenReturn(threadPool);
+
+        AtomicInteger executeCount = new AtomicInteger();
+        SearchContextMissingException scm = new SearchContextMissingException(new ShardSearchContextId("s", 1L));
+        ArgumentCaptor<Runnable> retryRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(threadPool.schedule(retryRunnableCaptor.capture(), any(TimeValue.class), any())).thenReturn(mock(ScheduledCancellable.class));
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByPaginatedSearchResponse> listener = invocation.getArgument(2);
+            if (executeCount.incrementAndGet() == 1) {
+                listener.onFailure(scm);
+            } else {
+                listener.onResponse(emptyBulkByPaginatedSearchResponse());
+            }
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
+
+        JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
+        jobDataDeleter.deleteAnnotations(null, null, null, ActionTestUtils.assertNoFailureListener(r -> {}));
+
+        assertThat(executeCount.get(), equalTo(1));
+        retryRunnableCaptor.getValue().run();
+
+        List<DeleteByQueryRequest> requests = deleteRequestCaptor.getAllValues();
+        assertThat(requests.size(), equalTo(2));
+        assertThat(requests.get(0), not(sameInstance(requests.get(1))));
+        verify(client, times(2)).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
+        verify(client, atLeastOnce()).threadPool();
+    }
+
+    public void testDeleteResultsFromTimeShouldFailAfterBoundedSearchContextMissingRetries() {
+        MockWritableIndexExpander.create(true);
+        ThreadPool threadPool = mockThreadPoolForScheduledRetry();
+        when(client.threadPool()).thenReturn(threadPool);
+
+        ArgumentCaptor<Runnable> retryRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(threadPool.schedule(retryRunnableCaptor.capture(), any(TimeValue.class), any())).thenReturn(mock(ScheduledCancellable.class));
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByPaginatedSearchResponse> listener = invocation.getArgument(2);
+            listener.onResponse(searchContextMissingResponse());
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
+
+        AtomicInteger failures = new AtomicInteger();
+        JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
+        jobDataDeleter.deleteResultsFromTime(1_000L, new org.elasticsearch.action.ActionListener<>() {
+            @Override
+            public void onResponse(Boolean response) {
+                fail("expected failure");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                failures.incrementAndGet();
+                assertTrue(isSearchContextMissing(e));
+            }
+        });
+
+        retryRunnableCaptor.getValue().run();
+        verify(client, times(2)).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
+        assertThat(failures.get(), equalTo(1));
+        verify(client, atLeastOnce()).threadPool();
+    }
+
+    public void testDeleteResultsFromTimeShouldNotRetryUnrelatedFailures() {
+        MockWritableIndexExpander.create(true);
+        RuntimeException failure = new RuntimeException("boom");
+        doAnswer(invocation -> {
+            ActionListener<BulkByPaginatedSearchResponse> listener = invocation.getArgument(2);
+            listener.onFailure(failure);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
+
+        AtomicInteger failures = new AtomicInteger();
+        JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
+        jobDataDeleter.deleteResultsFromTime(1_000L, new org.elasticsearch.action.ActionListener<>() {
+            @Override
+            public void onResponse(Boolean response) {
+                fail("expected failure");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                failures.incrementAndGet();
+                assertSame(failure, e);
+            }
+        });
+
+        verify(client, times(1)).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
+        assertThat(failures.get(), equalTo(1));
+        verify(client, times(1)).threadPool();
+    }
+
+    private static BulkByPaginatedSearchResponse emptyBulkByPaginatedSearchResponse() {
+        return new BulkByPaginatedSearchResponse(
+            TimeValue.ZERO,
+            new BulkByPaginatedSearchTask.Status(Collections.emptyList(), null, 0f),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            false
+        );
+    }
+
+    private static BulkByPaginatedSearchResponse searchContextMissingResponse() {
+        SearchContextMissingException scm = new SearchContextMissingException(new ShardSearchContextId("s", 1L));
+        return new BulkByPaginatedSearchResponse(
+            TimeValue.ZERO,
+            new BulkByPaginatedSearchTask.Status(Collections.emptyList(), null, 0f),
+            Collections.emptyList(),
+            List.of(new PaginatedSearchFailure(scm)),
+            false
+        );
+    }
+
+    private static boolean isSearchContextMissing(Exception e) {
+        return org.elasticsearch.ExceptionsHelper.unwrap(e, SearchContextMissingException.class) != null;
+    }
+
+    private ThreadPool mockThreadPoolForScheduledRetry() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        ExecutorService generic = EsExecutors.DIRECT_EXECUTOR_SERVICE;
+        when(threadPool.generic()).thenReturn(generic);
+        return threadPool;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.ml.job.task;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -89,6 +92,8 @@ import java.util.Set;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.validateJobAndId;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -132,7 +137,9 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
                     MachineLearning.MAX_ML_NODE_SIZE,
                     MachineLearning.MAX_OPEN_JOBS_PER_NODE,
                     MachineLearningField.USE_AUTO_MACHINE_MEMORY_PERCENT,
-                    MachineLearning.JOB_OPEN_RETRY_TIMEOUT
+                    MachineLearning.JOB_OPEN_RETRY_TIMEOUT,
+                    MachineLearning.JOB_OPEN_CAPACITY_RETRY_INITIAL_DELAY,
+                    MachineLearning.JOB_OPEN_CAPACITY_RETRY_MAX_DELAY
                 )
             )
         );
@@ -140,6 +147,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
         autodetectProcessManager = mock(AutodetectProcessManager.class);
         datafeedConfigProvider = mock(DatafeedConfigProvider.class);
         client = mock(Client.class);
+        when(client.threadPool()).thenReturn(tp);
         mlMemoryTracker = mock(MlMemoryTracker.class);
         licenseState = mock(XPackLicenseState.class);
     }
@@ -511,6 +519,70 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
 
         // ResourceNotFoundException -> UpdateStateRetryableAction.shouldRetry() = false -> no retry
         verify(jobTask, org.mockito.Mockito.times(1)).updatePersistentTaskState(any(), any());
+    }
+
+    public void testCapacityConstrainedFailureShouldEscalateBackoffToCapacityCeiling() {
+        long normalMax = TimeValue.timeValueMinutes(5).millis();
+        long capacityInitial = TimeValue.timeValueSeconds(30).millis();
+        long capacityMax = TimeValue.timeValueMinutes(10).millis();
+
+        // First capacity failure jumps the bound to at least the capacity initial delay.
+        long boundAfterFirst = OpenJobPersistentTasksExecutor.nextCapacityAwareDelayBound(
+            TimeValue.timeValueSeconds(5).millis(),
+            true,
+            normalMax,
+            capacityInitial,
+            capacityMax
+        );
+        assertThat(boundAfterFirst, equalTo(capacityInitial));
+
+        // Repeated capacity failures grow but are capped at the capacity ceiling (above the 5m normal cap).
+        long grown = OpenJobPersistentTasksExecutor.nextCapacityAwareDelayBound(
+            TimeValue.timeValueMinutes(8).millis(),
+            true,
+            normalMax,
+            capacityInitial,
+            capacityMax
+        );
+        assertThat(grown, equalTo(capacityMax));
+        assertThat(grown, greaterThan(normalMax));
+    }
+
+    public void testAvailabilityFailureShouldKeepDefaultBackoffCeiling() {
+        long normalMax = TimeValue.timeValueMinutes(5).millis();
+        long capacityInitial = TimeValue.timeValueSeconds(30).millis();
+        long capacityMax = TimeValue.timeValueMinutes(10).millis();
+
+        long bound = OpenJobPersistentTasksExecutor.nextCapacityAwareDelayBound(
+            TimeValue.timeValueMinutes(4).millis(),
+            false,
+            normalMax,
+            capacityInitial,
+            capacityMax
+        );
+        assertThat(bound, equalTo(normalMax)); // min(4m*2, 5m) == 5m, unchanged from existing behavior
+    }
+
+    public void testOpenJobRetryableActionShouldUseCapacityAwareDelayBound() {
+        var executor = createExecutor(Settings.EMPTY);
+        var jobTask = mock(JobTask.class);
+        when(jobTask.isClosing()).thenReturn(false);
+        when(jobTask.isVacating()).thenReturn(false);
+        var jobTaskState = new JobTaskState(JobState.OPENING, 1L, null, Instant.now());
+        var params = new OpenJobAction.JobParams("test_job");
+
+        var action = executor.createOpenJobRetryableAction(
+            jobTask,
+            jobTaskState,
+            params,
+            ActionListener.wrap(r -> {}, e -> fail(e.getMessage()))
+        );
+
+        assertTrue(action.shouldRetry(new ElasticsearchStatusException("too many requests", RestStatus.TOO_MANY_REQUESTS)));
+        assertThat(action.calculateDelayBound(TimeValue.timeValueSeconds(5).millis()), equalTo(TimeValue.timeValueSeconds(30).millis()));
+
+        assertTrue(action.shouldRetry(new SearchPhaseExecutionException("query", "partial results", ShardSearchFailure.EMPTY_ARRAY)));
+        assertThat(action.calculateDelayBound(TimeValue.timeValueSeconds(5).millis()), equalTo(TimeValue.timeValueSeconds(10).millis()));
     }
 
     private OpenJobPersistentTasksExecutor createExecutor(Settings settings) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifierTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifierTests.java
@@ -31,6 +31,9 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndexPrimaryShardNotAllocatedException;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchContextMissingException;
+import org.elasticsearch.search.TooManyScrollContextsException;
+import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.ConnectTransportException;
@@ -69,6 +72,19 @@ public class MlRecoverableErrorClassifierTests extends ESTestCase {
 
     public void testIllegalIndexShardStateException_isRecoverable() {
         var e = new IllegalIndexShardStateException(new ShardId("my-index", "uuid", 0), IndexShardState.RECOVERING, "shard not ready");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testSearchContextMissingExceptionShouldBeRecoverable() {
+        var e = new SearchContextMissingException(new ShardSearchContextId("s", 1L));
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+        assertFalse(MlRecoverableErrorClassifier.isCapacityConstrained(e));
+    }
+
+    public void testSearchPhaseExecutionExceptionWrappingSearchContextMissingShouldBeRecoverable() {
+        var scm = new SearchContextMissingException(new ShardSearchContextId("s", 1L));
+        var shardFailure = new ShardSearchFailure(scm);
+        var e = new SearchPhaseExecutionException("query", "scroll failed", new ShardSearchFailure[] { shardFailure });
         assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
     }
 
@@ -144,6 +160,63 @@ public class MlRecoverableErrorClassifierTests extends ESTestCase {
     public void testElasticsearchStatusException_tooManyRequests_isRecoverable() {
         var e = new ElasticsearchStatusException("too many requests", RestStatus.TOO_MANY_REQUESTS);
         assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    // -------------------------------------------------------------------------
+    // Capacity constraint sub-classifier
+    // -------------------------------------------------------------------------
+
+    public void testTooManyRequestsStatusShouldBeCapacityConstrained() {
+        var e = new ElasticsearchStatusException("too many requests", RestStatus.TOO_MANY_REQUESTS);
+        assertTrue(MlRecoverableErrorClassifier.isCapacityConstrained(e));
+    }
+
+    public void testTransientCircuitBreakerShouldBeCapacityConstrained() {
+        var e = new CircuitBreakingException("transient", CircuitBreaker.Durability.TRANSIENT);
+        assertTrue(MlRecoverableErrorClassifier.isCapacityConstrained(e));
+    }
+
+    public void testPermanentCircuitBreakerShouldNotBeCapacityConstrained() {
+        var e = new CircuitBreakingException("permanent", CircuitBreaker.Durability.PERMANENT);
+        assertFalse(MlRecoverableErrorClassifier.isCapacityConstrained(e));
+    }
+
+    public void testNonShutdownRejectionShouldBeCapacityConstrained() {
+        var e = new EsRejectedExecutionException("pool full", false);
+        assertTrue(MlRecoverableErrorClassifier.isCapacityConstrained(e));
+    }
+
+    public void testShutdownRejectionShouldNotBeCapacityConstrained() {
+        var e = new EsRejectedExecutionException("executor shutdown", true);
+        assertFalse(MlRecoverableErrorClassifier.isCapacityConstrained(e));
+    }
+
+    public void testAvailabilityErrorShouldNotBeCapacityConstrained() {
+        var e = new SearchPhaseExecutionException("query", "partial results", ShardSearchFailure.EMPTY_ARRAY);
+        assertFalse(MlRecoverableErrorClassifier.isCapacityConstrained(e));
+    }
+
+    public void testWrappedTooManyRequestsShouldBeCapacityConstrained() {
+        var inner = new ElasticsearchStatusException("too many requests", RestStatus.TOO_MANY_REQUESTS);
+        var wrapped = new RemoteTransportException("remote", inner);
+        assertTrue(MlRecoverableErrorClassifier.isCapacityConstrained(wrapped));
+    }
+
+    public void testWrappedTransientCircuitBreakerShouldBeCapacityConstrained() {
+        var inner = new CircuitBreakingException("transient", CircuitBreaker.Durability.TRANSIENT);
+        var wrapped = new RemoteTransportException("remote", inner);
+        assertTrue(MlRecoverableErrorClassifier.isCapacityConstrained(wrapped));
+    }
+
+    public void testWrappedNonShutdownRejectionShouldBeCapacityConstrained() {
+        var inner = new EsRejectedExecutionException("pool full", false);
+        var wrapped = new RemoteTransportException("remote", inner);
+        assertTrue(MlRecoverableErrorClassifier.isCapacityConstrained(wrapped));
+    }
+
+    public void testTooManyScrollContextsExceptionShouldBeCapacityConstrained() {
+        var e = new TooManyScrollContextsException(10, "search.max_open_scroll_context");
+        assertTrue(MlRecoverableErrorClassifier.isCapacityConstrained(e));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ML] Harden AD reopen against scroll-context exhaustion (#153260) (#154925)](https://github.com/elastic/elasticsearch/pull/154925)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)