### PR TITLE
[8.19] Fix RolesBackwardsCompatibilityIT BWC failures (#158644)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -66,8 +66,6 @@ tests:
 - class: org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT
   method: testSnapshotUpgrader {upgradedNodes=2}
   issue: https://github.com/elastic/elasticsearch/issues/158092
-- class: org.elasticsearch.upgrades.RolesBackwardsCompatibilityIT
-  issue: https://github.com/elastic/elasticsearch/issues/158093
 - class: org.elasticsearch.upgrades.SemanticTextUpgradeIT
   issue: https://github.com/elastic/elasticsearch/issues/158094
 - class: org.elasticsearch.upgrades.MlAssignmentPlannerUpgradeIT

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/RolesBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/RolesBackwardsCompatibilityIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.Request;
@@ -299,17 +298,15 @@ public class RolesBackwardsCompatibilityIT extends AbstractXpackRollingUpgradeWi
 
     private boolean nodeSupportTransportVersion(NodeInfo testNodeInfo, TransportVersion transportVersion) {
         if (testNodeInfo.transportVersion().equals(TransportVersion.zero())) {
-            // In cases where we were not able to find a TransportVersion, a pre-8.8.0 node answered about a newer (upgraded) node.
-            // In that case, the node will be current (upgraded), and remote indices are supported for sure.
-            var nodeIsCurrent = testNodeInfo.version().equals(Build.current().version());
-            assertTrue(nodeIsCurrent);
-            return true;
+            return testNodeInfo.isUpgradedVersionCluster();
         }
         return testNodeInfo.transportVersion().supports(transportVersion);
     }
 
     private static RoleDescriptor randomRoleDescriptor(boolean includeDescription, boolean includeManageRoles) {
         final Set<String> excludedPrivileges = Set.of(
+            "read_failure_store",
+            "manage_failure_store",
             "cross_cluster_replication",
             "cross_cluster_replication_internal",
             "manage_data_stream_lifecycle"


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix RolesBackwardsCompatibilityIT BWC failures (#158644)