### PR TITLE
[ESQL] Decline Parquet repeated pushdown

### DIFF
--- a/docs/changelog/158727.yaml
+++ b/docs/changelog/158727.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158727
+summary: Decline Parquet repeated pushdown
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -442,10 +442,10 @@ final class ParquetPushedExpressions {
         if (value == null && op.isOrdered()) {
             return null;
         }
-        // IS NULL / IS NOT NULL (null-valued EQ/NOT_EQ) over a list column (resolves to a LIST group,
-        // not a primitive) must decline: pushing notEq(column("v"), null) names a leaf-absent column
-        // that parquet-mr drops entirely. The null-mask evaluator that answers instead is multivalue-safe.
-        // esql-planning#1056.
+        // IS NULL / IS NOT NULL (null-valued EQ/NOT_EQ) over a list must decline: a 3-level LIST
+        // attribute is a group (resolver returns null); a 2-level repeated leaf is a primitive that
+        // parquet-mr still rejects (maxRepLevel > 0). resolveNestedPrimitive covers both.
+        // FilterExec's MV-safe evaluator answers instead. esql-planning#1056.
         if (value == null && resolveNestedPrimitive(schema, columnName) == null) {
             return null;
         }
@@ -672,9 +672,13 @@ final class ParquetPushedExpressions {
      * Resolves a (possibly dotted) {@code name} to the leaf {@link PrimitiveType} in {@code schema}.
      * Applies the same D2 precedence as the prior PR's projection-time flattener: a literal
      * top-level field named exactly {@code "a.b.c"} wins over the dotted-path traversal
-     * {@code a -> b -> c}. Returns {@code null} when the path is missing or lands on a group
-     * (e.g. an intermediate STRUCT, MAP, or LIST) rather than a primitive — predicate pushdown
-     * is only meaningful at primitive leaves.
+     * {@code a -> b -> c}. Returns {@code null} when the path is missing, lands on a group
+     * (e.g. an intermediate STRUCT, MAP, or LIST) rather than a primitive, or any type on the
+     * resolved path is {@link Type.Repetition#REPEATED}. parquet-mr FilterPredicates cannot
+     * target a repeated column ({@code maxRepLevel > 0}); a 2-level {@code repeated} leaf is a
+     * primitive, so the path-wide repetition check is required in addition to the group check.
+     * A 3-level LIST attribute is still a group and still returns {@code null}. Predicate
+     * pushdown is only meaningful at non-repeated primitive leaves.
      *
      * <p>This is the single dotted-path resolver used by {@link #isPhysicalDouble} and
      * {@link #buildDatetimePredicate} (and {@link #translateDatetimeIn}). Translation of the
@@ -687,8 +691,7 @@ final class ParquetPushedExpressions {
     @Nullable
     static PrimitiveType resolveNestedPrimitive(MessageType schema, String dottedName) {
         if (schema.containsField(dottedName)) {
-            Type leaf = schema.getType(dottedName);
-            return leaf.isPrimitive() ? leaf.asPrimitiveType() : null;
+            return pushablePrimitive(schema.getType(dottedName));
         }
         // Walk left-to-right, allowing literal-dot top-level prefixes to compose with nested
         // children — the exact-name fast path above already handled the no-dot case. Probe each
@@ -701,6 +704,7 @@ final class ParquetPushedExpressions {
             String topLevel = dottedName.substring(0, probeDot);
             if (schema.containsField(topLevel)) {
                 Type field = schema.getType(topLevel);
+                boolean repeatedOnPath = field.isRepetition(Type.Repetition.REPEATED);
                 for (int i = prefixLen; i < segments.length; i++) {
                     if (field.isPrimitive()) {
                         return null;
@@ -711,13 +715,30 @@ final class ParquetPushedExpressions {
                         break;
                     }
                     field = group.getType(segments[i]);
+                    repeatedOnPath |= field.isRepetition(Type.Repetition.REPEATED);
                 }
-                if (field != null && field.isPrimitive()) {
-                    return field.asPrimitiveType();
+                if (repeatedOnPath == false) {
+                    PrimitiveType primitive = pushablePrimitive(field);
+                    if (primitive != null) {
+                        return primitive;
+                    }
                 }
             }
             probeDot = dottedName.indexOf('.', probeDot + 1);
             prefixLen++;
+        }
+        return null;
+    }
+
+    /**
+     * A FilterPredicate host must be a non-{@link Type.Repetition#REPEATED} primitive. Groups
+     * (LIST/STRUCT/MAP) and repeated leaves both decline; the latter is parquet-mr's
+     * {@code maxRepLevel > 0} without needing a {@code ColumnDescriptor}.
+     */
+    @Nullable
+    private static PrimitiveType pushablePrimitive(Type type) {
+        if (type != null && type.isPrimitive() && type.isRepetition(Type.Repetition.REPEATED) == false) {
+            return type.asPrimitiveType();
         }
         return null;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -50,6 +50,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.float16Type;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
@@ -2343,25 +2344,44 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         assertNull(ParquetPushedExpressions.resolveNestedPrimitive(schema, "event"));
     }
 
+    public void testResolveNestedPrimitiveRepeatedLeafReturnsNull() {
+        MessageType schema = new MessageType("test", Types.repeated(INT32).named("Int32_list"));
+        assertNull(ParquetPushedExpressions.resolveNestedPrimitive(schema, "Int32_list"));
+    }
+
+    public void testResolveNestedPrimitiveRepeatedAncestorReturnsNull() {
+        // Leaf may be OPTIONAL; parquet-mr still refuses the path because maxRepLevel > 0.
+        MessageType schema = Types.buildMessage()
+            .repeatedGroup()
+            .optional(DOUBLE)
+            .named("lat")
+            .optional(DOUBLE)
+            .named("lon")
+            .named("addr")
+            .named("test");
+        assertNull(ParquetPushedExpressions.resolveNestedPrimitive(schema, "addr.lat"));
+    }
+
     // --- helpers ---
 
-    // IS NULL / IS NOT NULL over a top-level list must NOT push a predicate (esql-planning#1056): the
-    // attribute name resolves to a LIST group, so notEq(column("tags"), null) names a leaf-absent
-    // column that parquet-mr drops. They decline so the multivalue-safe null-mask evaluator answers.
-    // (Value predicates — comparisons/IN/LIKE — are NOT declined here; their evaluator is not MV-safe.)
+    // List / repeated leaves must NOT push (esql-planning#1056): a 3-level LIST attribute is a
+    // group; a 2-level repeated leaf is a primitive that parquet-mr still rejects. Both decline
+    // so the MV-safe evaluator answers.
 
     private static MessageType intListSchema() {
         return new MessageType("test", Types.optionalList().optionalElement(INT32).named("ints"));
     }
 
     private static MessageType stringListSchema() {
-        return new MessageType(
-            "test",
-            Types.optionalList()
-                .optionalElement(PrimitiveType.PrimitiveTypeName.BINARY)
-                .as(LogicalTypeAnnotation.stringType())
-                .named("tags")
-        );
+        return new MessageType("test", Types.optionalList().optionalElement(BINARY).as(LogicalTypeAnnotation.stringType()).named("tags"));
+    }
+
+    private static MessageType repeatedIntSchema() {
+        return new MessageType("test", Types.repeated(INT32).named("Int32_list"));
+    }
+
+    private static MessageType repeatedStringSchema() {
+        return new MessageType("test", Types.repeated(BINARY).as(LogicalTypeAnnotation.stringType()).named("String_list"));
     }
 
     public void testTopLevelListIsNotNullDeclines() {
@@ -2372,6 +2392,38 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
     public void testTopLevelStringListIsNotNullDeclines() {
         Expression expr = new IsNotNull(Source.EMPTY, attr("tags", DataType.KEYWORD));
         assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(stringListSchema()));
+    }
+
+    public void testRepeatedPrimitiveIsNullDeclines() {
+        Expression expr = new IsNull(Source.EMPTY, attr("Int32_list", DataType.INTEGER));
+        assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(repeatedIntSchema()));
+    }
+
+    public void testRepeatedPrimitiveIsNotNullDeclines() {
+        Expression expr = new IsNotNull(Source.EMPTY, attr("Int32_list", DataType.INTEGER));
+        assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(repeatedIntSchema()));
+    }
+
+    public void testRepeatedPrimitiveEqualsDeclines() {
+        assertNull(new ParquetPushedExpressions(List.of(eq("Int32_list", DataType.INTEGER, 4))).toFilterPredicate(repeatedIntSchema()));
+    }
+
+    public void testRepeatedStringIsNullDeclines() {
+        Expression expr = new IsNull(Source.EMPTY, attr("String_list", DataType.KEYWORD));
+        assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(repeatedStringSchema()));
+    }
+
+    public void testRepeatedStringIsNotNullDeclines() {
+        Expression expr = new IsNotNull(Source.EMPTY, attr("String_list", DataType.KEYWORD));
+        assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(repeatedStringSchema()));
+    }
+
+    public void testRepeatedStringEqualsDeclines() {
+        assertNull(
+            new ParquetPushedExpressions(List.of(eq("String_list", DataType.KEYWORD, new BytesRef("x")))).toFilterPredicate(
+                repeatedStringSchema()
+            )
+        );
     }
 
     public void testFlatColumnStillPushesControl() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
@@ -490,6 +490,68 @@ public class ParquetReaderFilterDifferentialTests extends ESTestCase {
         assertMvSurvivors(bytes, not(like(tags, "Sen*")), Set.of(3L));
     }
 
+    /**
+     * 2-level {@code repeated} leaves are primitives, so minting a FilterPredicate used to throw
+     * parquet-mr's {@code FilterPredicates do not currently support repeated columns} out of
+     * RowGroupFilter. Decline at resolveNestedPrimitive; the MV-safe evaluator answers: empty
+     * repeated is null, {@code ==} is true only on a single-value cell.
+     */
+    public void testBareRepeatedPrimitivePredicates() throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .repeated(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("v")
+            .named("bare_repeated_schema");
+
+        byte[] bytes = writeBareRepeatedParquet(schema);
+        ReferenceAttribute v = attr("v", DataType.INTEGER);
+
+        // Row 2 is empty repeated (= null). Exactly one IS NULL survivor.
+        assertMvSurvivors(bytes, isNull(v), Set.of(2L));
+        // v == 4: only the single-value 4 (row 1). MV rows excluded.
+        assertMvSurvivors(bytes, eq(v, 4, DataType.INTEGER), Set.of(1L));
+    }
+
+    private byte[] writeBareRepeatedParquet(MessageType schema) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            // Row 0: id=0, v=[1,2]
+            Group r0 = factory.newGroup();
+            r0.add("id", 0L);
+            r0.add("v", 1);
+            r0.add("v", 2);
+            writer.write(r0);
+
+            // Row 1: id=1, v=[4]
+            Group r1 = factory.newGroup();
+            r1.add("id", 1L);
+            r1.add("v", 4);
+            writer.write(r1);
+
+            // Row 2: id=2, v=[] (empty = null)
+            Group r2 = factory.newGroup();
+            r2.add("id", 2L);
+            writer.write(r2);
+
+            // Row 3: id=3, v=[7,5]
+            Group r3 = factory.newGroup();
+            r3.add("id", 3L);
+            r3.add("v", 7);
+            r3.add("v", 5);
+            writer.write(r3);
+        }
+        return out.toByteArray();
+    }
+
     private byte[] writeMvParquet(MessageType schema) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         SimpleGroupFactory factory = new SimpleGroupFactory(schema);


### PR DESCRIPTION
parquet-mr rejects FilterPredicates on maxRepLevel > 0.
A 2-level repeated leaf is still a primitive, so the
resolver must refuse any REPEATED path instead of 400ing.