### PR TITLE
[9.4] Fix NPE in Amazon Bedrock chat completion when a message has no content (#158527)

### DIFF
--- a/docs/changelog/158527.yaml
+++ b/docs/changelog/158527.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 158521
+pr: 158527
+summary: Fix NPE in Amazon Bedrock chat completion when a message has no content
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockConverseUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockConverseUtils.java
@@ -166,8 +166,9 @@ public final class AmazonBedrockConverseUtils {
         return false;
     }
 
-    private static List<SystemContentBlock> getSystemContentBlock(Content content) {
+    private static List<SystemContentBlock> getSystemContentBlock(@Nullable Content content) {
         return switch (content) {
+            case null -> List.of();
             case ContentString stringContent -> convertContentString(
                 stringContent.content(),
                 (text) -> SystemContentBlock.builder().text(text).build()
@@ -184,6 +185,7 @@ public final class AmazonBedrockConverseUtils {
     private static Message convertToolResultMessage(org.elasticsearch.inference.completion.Message requestMessage) {
         // Bedrock allows empty tool result string content but not empty tool result object content
         var convertedToolResultContentBlock = switch (requestMessage.content()) {
+            case null -> List.<ToolResultContentBlock>of();
             case ContentString stringContent -> List.of(ToolResultContentBlock.builder().text(stringContent.content()).build());
             case ContentObjects objectsContent -> objectsContent.contentObjects()
                 .stream()
@@ -234,8 +236,10 @@ public final class AmazonBedrockConverseUtils {
         return Message.builder().role(ConversationRole.ASSISTANT).content(blocks).build();
     }
 
-    private static List<ContentBlock> convertContentToBlocks(Content content) {
+    private static List<ContentBlock> convertContentToBlocks(@Nullable Content content) {
         var blocks = switch (content) {
+            // Messages can omit content, e.g. an assistant message that carries only tool_calls
+            case null -> List.<ContentBlock>of();
             case ContentString stringContent -> convertContentString(
                 stringContent.content(),
                 (text) -> ContentBlock.builder().text(text).build()

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockConverseUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockConverseUtilsTests.java
@@ -564,6 +564,70 @@ public class AmazonBedrockConverseUtilsTests extends ESTestCase {
         assertThat(secondMessage.content().get(1).toolUse().toolUseId(), is(TOOL_CALL_ID));
     }
 
+    public void testConvertChatCompletionMessages_AssistantMessageWithNullContentAndToolCalls() {
+        var toolCall = new ToolCall(TOOL_CALL_ID, new ToolCall.FunctionField("{\"key\":\"value\"}", FUNCTION_NAME), "function");
+        var assistantMessage = new org.elasticsearch.inference.completion.Message(
+            null,
+            ChatCompletionRole.ASSISTANT.toString(),
+            null,
+            List.of(toolCall)
+        );
+
+        var result = convertChatCompletionMessagesToConverse(List.of(assistantMessage), true);
+
+        // The default user message should get added
+        assertThat(result.messages().size(), is(2));
+        assertThat(result.messages().get(0), is(DEFAULT_USER_MESSAGE));
+
+        var secondMessage = result.messages().get(1);
+        assertThat(secondMessage.role(), is(ConversationRole.ASSISTANT));
+        assertThat(secondMessage.content().size(), is(1));
+        assertThat(secondMessage.content().get(0).toolUse().name(), is(FUNCTION_NAME));
+        assertThat(secondMessage.content().get(0).toolUse().toolUseId(), is(TOOL_CALL_ID));
+    }
+
+    public void testConvertChatCompletionMessages_AssistantMessageWithNullContentAndNoToolCalls() {
+        var assistantMessage = new org.elasticsearch.inference.completion.Message(
+            null,
+            ChatCompletionRole.ASSISTANT.toString(),
+            null,
+            null
+        );
+
+        var result = convertChatCompletionMessagesToConverse(List.of(assistantMessage), true);
+
+        assertThat(result.messages(), empty());
+        assertThat(result.systemContent(), empty());
+    }
+
+    public void testConvertChatCompletionMessages_UserMessageWithNullContent() {
+        var userMessage = new org.elasticsearch.inference.completion.Message(null, ChatCompletionRole.USER.toString(), null, null);
+
+        var result = convertChatCompletionMessagesToConverse(List.of(userMessage), false);
+
+        assertThat(result.messages(), empty());
+        assertThat(result.systemContent(), empty());
+    }
+
+    public void testConvertChatCompletionMessages_SystemMessageWithNullContent() {
+        var systemMessage = new org.elasticsearch.inference.completion.Message(null, ChatCompletionRole.SYSTEM.toString(), null, null);
+
+        var result = convertChatCompletionMessagesToConverse(List.of(systemMessage), false);
+
+        assertThat(result.messages(), empty());
+        assertThat(result.systemContent(), empty());
+    }
+
+    public void testConvertChatCompletionMessages_ToolMessageWithNullContent() {
+        var toolMessage = new org.elasticsearch.inference.completion.Message(null, ChatCompletionRole.TOOL.toString(), TOOL_CALL_ID, null);
+
+        var exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> convertChatCompletionMessagesToConverse(List.of(toolMessage), true)
+        );
+        assertThat(exception.getMessage(), is("Tool message must have non-empty contents"));
+    }
+
     public void testToDocument_Null() {
         var doc = AmazonBedrockConverseUtils.toDocument(null);
         assertThat(doc, is(Document.fromNull()));


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix NPE in Amazon Bedrock chat completion when a message has no content (#158527)