### PR TITLE
ESQL: Run ndjson datasource QA on integ-test distribution

### DIFF
--- a/x-pack/plugin/esql-datasource-ndjson/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/build.gradle
@@ -30,6 +30,21 @@ dependencies {
   // GCS fixture infrastructure for mocking GCS operations
   javaRestTestImplementation project(':test:fixtures:gcs-fixture')
 
+  // Field types and ingest features used by the shared esql csv-spec datasets
+  clusterModules project(xpackModule('enrich'))
+  clusterModules project(xpackModule('analytics'))
+  clusterModules project(xpackModule('spatial'))
+  clusterModules project(xpackModule('mapper-aggregate-metric'))
+  clusterModules project(xpackModule('mapper-unsigned-long'))
+  clusterModules project(xpackModule('mapper-version'))
+  clusterModules project(xpackModule('mapper-constant-keyword'))
+  clusterModules project(xpackModule('wildcard'))
+  clusterModules project(':modules:mapper-extras')
+  clusterModules project(':modules:aggregations')
+  clusterModules project(':modules:ingest-common')
+  clusterModules project(':modules:data-streams')
+  clusterModules project(':modules:reindex')
+
   // Repository S3 module for cluster
   clusterModules project(':modules:repository-s3')
   // Repository GCS module for cluster
@@ -37,18 +52,25 @@ dependencies {
   clusterPlugins project(':plugins:mapper-size')
   clusterPlugins project(':plugins:mapper-murmur3')
   clusterPlugins project(':x-pack:plugin:inference:qa:test-service-plugin')
+  // inference-service-test declares x-pack-inference as an extended plugin
+  clusterModules project(xpackModule('inference'))
+
+  clusterModules project(xpackModule('esql'))
+  // Not referenced by the cluster spec directly: x-pack-esql pulls in x-pack-ml, which extends
+  // x-pack-autoscaling, and the node installs that chain recursively from the plugin descriptors.
+  clusterModules project(xpackModule('autoscaling'))
 
   // The datasource plugin under test
-  clusterPlugins project(xpackModule('esql-datasource-ndjson'))
-  clusterPlugins project(xpackModule('esql-datasource-gzip'))
-  clusterPlugins project(xpackModule('esql-datasource-zstd'))
-  clusterPlugins project(xpackModule('esql-datasource-bzip2'))
-  clusterPlugins project(xpackModule('esql-datasource-http'))
-  clusterPlugins project(xpackModule('esql-datasource-s3'))
+  clusterModules project(xpackModule('esql-datasource-ndjson'))
+  clusterModules project(xpackModule('esql-datasource-gzip'))
+  clusterModules project(xpackModule('esql-datasource-zstd'))
+  clusterModules project(xpackModule('esql-datasource-bzip2'))
+  clusterModules project(xpackModule('esql-datasource-http'))
+  clusterModules project(xpackModule('esql-datasource-s3'))
   // GCS datasource plugin for gs:// storage backend
-  clusterPlugins project(xpackModule('esql-datasource-gcs'))
+  clusterModules project(xpackModule('esql-datasource-gcs'))
   // Azure Blob datasource plugin for wasbs:///wasb:// storage backend
-  clusterPlugins project(xpackModule('esql-datasource-azure'))
+  clusterModules project(xpackModule('esql-datasource-azure'))
 }
 
 // Standalone NDJSON under iceberg-fixtures/standalone/ is generated from esql:qa:testFixtures CSV basenames.
@@ -107,7 +129,6 @@ tasks.named('processJavaRestTestResources').configure {
 
 tasks.named('javaRestTest') {
   dependsOn 'generateStandaloneNdjsonFixtures'
-  usesDefaultDistribution("to be triaged")
   maxParallelForks = 1
   enabled = buildParams.snapshotBuild
 
@@ -148,7 +169,6 @@ tasks.named('processCsvSpecTestResources').configure {
 def csvSpecTests = tasks.register('csvSpecTests', StandaloneRestIntegTestTask) {
   dependsOn 'generateStandaloneNdjsonFixtures'
   dependsOn generateEsqlSpecTests
-  usesDefaultDistribution("to be triaged")
   maxParallelForks = 1
   enabled = buildParams.snapshotBuild
   testClassesDirs = sourceSets.csvSpecTest.output.classesDirs

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/Clusters.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/Clusters.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.qa.ndjson;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 
@@ -38,9 +37,34 @@ public class Clusters {
 
     public static ElasticsearchCluster testCluster(Supplier<String> s3EndpointSupplier, LocalClusterConfigProvider configProvider) {
         return ElasticsearchCluster.local()
-            .distribution(DistributionType.DEFAULT)
             .shared(true)
             .plugin("inference-service-test")
+            .module("x-pack-inference")
+            .module("x-pack-esql")
+            // The datasource modules under test. Each extends x-pack-esql, and the format modules
+            // are resolved by scheme/extension at query time rather than being referenced directly.
+            .module("esql-datasource-ndjson")
+            .module("esql-datasource-gzip")
+            .module("esql-datasource-zstd")
+            .module("esql-datasource-bzip2")
+            .module("esql-datasource-http")
+            .module("esql-datasource-s3")
+            .module("esql-datasource-gcs")
+            .module("esql-datasource-azure")
+            // Field types and ingest features used by the shared esql csv-spec datasets
+            .module("x-pack-enrich")
+            .module("x-pack-analytics")
+            .module("spatial")
+            .module("x-pack-aggregate-metric")
+            .module("unsigned-long")
+            .module("mapper-version")
+            .module("constant-keyword")
+            .module("wildcard")
+            .module("mapper-extras")
+            .module("aggregations")
+            .module("ingest-common")
+            .module("data-streams")
+            .module("reindex")
             // Enable S3 repository plugin for S3 access
             .module("repository-s3")
             // Enable GCS repository module for GCS access


### PR DESCRIPTION
## What this does

Removes `usesDefaultDistribution` from the two test tasks in
`x-pack/plugin/esql-datasource-ndjson/qa` and declares the required modules
explicitly, so the suite runs on the integ-test distribution and can be cached.

The change is two-sided, which is not obvious from the build files:

- `build.gradle` — `clusterModules` makes an artifact *available*
- `Clusters.java` — `.module(...)` decides what is actually *installed*

`installModules()` only runs for `INTEG_TEST`, so the pre-existing
`clusterModules` declarations in this project were never installed. They were
task inputs with no runtime effect.

## Status: draft, one test still failing

`external-basic.categorizeByFullName` fails with
`illegal_argument_exception: failed to find global filter under [limit]`,
reproduced across all compression variants and storage backends. The remaining
~306 failures are `circuit breakers not reset to 0`, the cascade after a query
leaves a breaker non-zero.

`CATEGORIZE` is ML-backed and this cluster sets `xpack.ml.enabled: false`, but
the error is an ESQL planner error rather than a missing-capability error, so
the mechanism is not established yet. This is the only thing standing between
this branch and a working migration.

Clean sequential runs, same narrow filter:

| | Distribution | Result | Wall time |
|---|---|---|---|
| `main` | default | 2,190 tests, 0 failures | 7m45s |
| this branch | integ-test | 314 failures | >55 min (stopped) |

## Notes for reviewers

- `x-pack-autoscaling` is declared in `build.gradle` but never named in the
  cluster spec. ESQL pulls in `x-pack-ml`, which extends `x-pack-autoscaling`,
  and the node installs that chain recursively from the plugin descriptors.
  Gradle transitive resolution does not reach it, so the declaration is
  required even though nothing references it directly.
- `reindex` and `data-streams` were added as part of a batch that collectively
  got past module resolution. They were not individually proven necessary, so
  the minimal set may be slightly smaller.
- Module names cannot be derived from project paths: `x-pack-enrich` and
  `x-pack-aggregate-metric`, but `spatial`, `unsigned-long`,
  `constant-keyword`, `mapper-version`, `wildcard`.

Context: elastic/esql-planning#1857