### PR TITLE
Harden ML feature-reset cleanup timeouts and unmute #158138/#158139

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -107,12 +107,6 @@ tests:
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=upgraded_cluster/90_ml_data_frame_analytics_crud/Get mixed cluster outlier_detection job}
   issue: https://github.com/elastic/elasticsearch/issues/158137
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/preview_datafeed/Test preview aggregation datafeed with doc_count}
-  issue: https://github.com/elastic/elasticsearch/issues/158138
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-  issue: https://github.com/elastic/elasticsearch/issues/158139
 - class: org.elasticsearch.compute.operator.exchange.ExchangeServiceTests
   method: testExchangeSourceContinueOnFailure
   issue: https://github.com/elastic/elasticsearch/issues/157535

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
@@ -6,11 +6,14 @@
  */
 package org.elasticsearch.xpack.core.ml.integration;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.io.IOException;
@@ -32,7 +35,18 @@ public class MlRestTestStateCleaner {
     public void resetFeatures() throws IOException {
         deleteAllTrainedModelIngestPipelines();
         // This resets all features, not just ML, but they should have been getting reset between tests anyway so it shouldn't matter
-        adminClient.performRequest(new Request("POST", "/_features/_reset"));
+        final Request resetFeaturesRequest = new Request("POST", "/_features/_reset");
+        resetFeaturesRequest.addParameter("master_timeout", "90s");
+        resetFeaturesRequest.addParameter("error_trace", "true");
+        // encryption-at-rest periodic CI can exceed the 30s default master timeout during full-suite ML cleanup
+        resetFeaturesRequest.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setRequestConfig(
+                    RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueSeconds(120).millis())).build()
+                )
+                .build()
+        );
+        ESRestTestCase.assertOK(adminClient.performRequest(resetFeaturesRequest));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- Raise `master_timeout` (90s) and per-request HTTP socket timeout (120s) on `POST /_features/_reset` in `MlRestTestStateCleaner` so encryption-at-rest periodic CI teardown does not hit the 30s default.
- Unmute the two `MlWithSecurityIT` yaml tests muted for the same `/_features/_reset` timeout flake (#158138, #158139).
- Companion: elastic/elasticsearch#158737 (same `MlRestTestStateCleaner` change on main).

Closes #158138
Closes #158139