### PR TITLE
Harden ML feature-reset cleanup timeouts

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -15,6 +15,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -957,6 +958,15 @@ public abstract class ESRestTestCase extends ESTestCase {
     public static void performPostFeaturesReset(RestClient restClient) throws IOException {
         final var request = new Request(HttpPost.METHOD_NAME, "/_features/_reset");
         request.addParameter("error_trace", "true");
+        request.addParameter("master_timeout", "90s");
+        // encryption-at-rest periodic CI can exceed the 30s default master timeout during full-suite test cleanup
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setRequestConfig(
+                    RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueSeconds(120).millis())).build()
+                )
+                .build()
+        );
         assertOK(restClient.performRequest(request));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -15,7 +15,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -958,15 +957,6 @@ public abstract class ESRestTestCase extends ESTestCase {
     public static void performPostFeaturesReset(RestClient restClient) throws IOException {
         final var request = new Request(HttpPost.METHOD_NAME, "/_features/_reset");
         request.addParameter("error_trace", "true");
-        request.addParameter("master_timeout", "90s");
-        // encryption-at-rest periodic CI can exceed the 30s default master timeout during full-suite test cleanup
-        request.setOptions(
-            RequestOptions.DEFAULT.toBuilder()
-                .setRequestConfig(
-                    RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueSeconds(120).millis())).build()
-                )
-                .build()
-        );
         assertOK(restClient.performRequest(request));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
@@ -6,10 +6,13 @@
  */
 package org.elasticsearch.xpack.core.ml.integration;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.io.IOException;
@@ -17,7 +20,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.test.rest.ESRestTestCase.performPostFeaturesReset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -34,7 +36,18 @@ public class MlRestTestStateCleaner {
     public void resetFeatures() throws IOException {
         deletePipelinesWithInferenceProcessors();
         // This resets all features, not just ML, but they should have been getting reset between tests anyway so it shouldn't matter
-        performPostFeaturesReset(adminClient);
+        final Request resetFeaturesRequest = new Request("POST", "/_features/_reset");
+        resetFeaturesRequest.addParameter("master_timeout", "90s");
+        resetFeaturesRequest.addParameter("error_trace", "true");
+        // encryption-at-rest periodic CI can exceed the 30s default master timeout during full-suite ML cleanup
+        resetFeaturesRequest.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setRequestConfig(
+                    RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueSeconds(120).millis())).build()
+                )
+                .build()
+        );
+        ESRestTestCase.assertOK(adminClient.performRequest(resetFeaturesRequest));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- Raise `master_timeout` (90s) and per-request HTTP socket timeout (120s) on `POST /_features/_reset` in `MlRestTestStateCleaner`, matching the 8.19 fix.
- Prophylactic for encryption-at-rest periodic CI: the 30s default is latent on main even though #158138 only observed failures on 8.19.
- Companion: elastic/elasticsearch#158736.