### PR TITLE
Answer keyword mv_min, mv_max, length and sort from the column

### DIFF
--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
@@ -63,6 +63,11 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues impleme
     }
 
     @Override
+    public BytesRef extreme(boolean max, BytesRef dst) throws IOException {
+        return reader.extreme(iterator.rank(), max, dst);
+    }
+
+    @Override
     public boolean advanceExact(int target) throws IOException {
         return iterator.advanceExact(target);
     }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
@@ -68,6 +68,29 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues impleme
     }
 
     @Override
+    public int nonNullValues(BytesRef dst) throws IOException {
+        final int rank = iterator.rank();
+        final long first = reader.firstValueAddress(rank);
+        final long count = reader.valueCount(rank);
+        int found = 0;
+        for (long i = 0; i < count; i++) {
+            final long address = first + i;
+            if (reader.isNullSlot(address)) {
+                continue;
+            }
+            if (++found > 1) {
+                // The caller wants the arity, not the values, and has what it needs the moment there are two.
+                return 2;
+            }
+            final BytesRef value = reader.valueAt(address);
+            dst.bytes = value.bytes;
+            dst.offset = value.offset;
+            dst.length = value.length;
+        }
+        return found;
+    }
+
+    @Override
     public boolean advanceExact(int target) throws IOException {
         return iterator.advanceExact(target);
     }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryStringColumnReader.java
@@ -193,6 +193,35 @@ public final class DictionaryStringColumnReader extends StringColumnReader {
         return Math.toIntExact(ordinals.valueAt(valueAddress));
     }
 
+    /**
+     * The extreme value, decided over ordinals. The dictionary is in term order, so the largest ordinal a document
+     * holds names its largest value and the smallest its smallest - the terms are never read to find out, and only the
+     * one that wins is resolved.
+     *
+     * <p>Two slots do not order that way. A null is no value, so it is passed over. An escaped value sorts wherever
+     * its bytes do, which its ordinal - one past every term - does not say, so a document holding one is decided by
+     * comparing bytes after all.
+     */
+    @Override
+    public BytesRef extreme(int rank, boolean max, BytesRef dst) throws IOException {
+        final long first = firstValueAddress(rank);
+        final long count = valueCount(rank);
+        int best = -1;
+        for (long i = 0; i < count; i++) {
+            final int ordinal = ordinalAt(first + i);
+            if (ordinal == StringColumnMetadata.Dictionary.NULL_ORDINAL) {
+                continue;
+            }
+            if (ordinal == escapeOrdinal) {
+                return super.extreme(rank, max, dst);
+            }
+            if (best < 0 || (max ? ordinal > best : ordinal < best)) {
+                best = ordinal;
+            }
+        }
+        return best < 0 ? null : termAt(best, dst);
+    }
+
     /** The value behind the escape marker at {@code valueAddress}, for a consumer that took ordinals. */
     public BytesRef resolveEscape(long valueAddress, BytesRef dst) throws IOException {
         escapes.get(escapeRankOf(valueAddress), dst);

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.LongValues;
 import org.elasticsearch.columnar.substrate.ColumnIterator;
 import org.elasticsearch.columnar.substrate.ColumnIteratorReader;
@@ -80,6 +81,9 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
     private int[] pageLengths = new int[0];
     private byte[] pageBytes = new byte[0];
     protected int pageBytesLength;
+
+    /** The running extreme, held so comparing one value against another survives the buffer being reused. */
+    private final BytesRefBuilder extremeSoFar = new BytesRefBuilder();
 
     // A page's slots found by the bytes in them, so a value the page already holds is one slot and not two.
     // Stamped by generation rather than cleared, as the ordinal slots of a dictionary column are.
@@ -221,6 +225,38 @@ public abstract sealed class StringColumnReader permits PlainStringColumnReader,
      */
     public boolean valuesSorted() {
         return meta.valuesSorted();
+    }
+
+    /**
+     * The largest or smallest value a document holds, or null when it holds none - its slots were all null, or it has
+     * no slot at all. The returned {@link BytesRef} is only valid until the next call.
+     *
+     * <p>Compared here as bytes, which is all a column that stores its values can do.
+     * {@link DictionaryStringColumnReader} decides it over ordinals instead, and reads one term rather than all of
+     * them.
+     */
+    public BytesRef extreme(int rank, boolean max, BytesRef dst) throws IOException {
+        final long first = firstValueAddress(rank);
+        final long count = valueCount(rank);
+        boolean found = false;
+        for (long i = 0; i < count; i++) {
+            final BytesRef value = valueAt(first + i);
+            if (value == null) {
+                continue;
+            }
+            // Copied rather than pointed at: the next read reuses the buffer this one came back in.
+            if (found == false || (max ? value.compareTo(extremeSoFar.get()) > 0 : value.compareTo(extremeSoFar.get()) < 0)) {
+                extremeSoFar.copyBytes(value);
+                found = true;
+            }
+        }
+        if (found == false) {
+            return null;
+        }
+        dst.bytes = extremeSoFar.bytes();
+        dst.offset = 0;
+        dst.length = extremeSoFar.length();
+        return dst;
     }
 
     /** Whether this column names its values with ordinals rather than storing them. */

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
@@ -35,4 +35,18 @@ public interface StringColumnSource {
      * the next call.
      */
     BytesRef extreme(boolean max, BytesRef dst) throws IOException;
+
+    /**
+     * How many non-null values the document these values are positioned on holds, capped at two. Capped because the
+     * callers are the single-value functions, which want to know whether the arity is nothing, one, or more than one
+     * and nothing further.
+     *
+     * <p>{@code dst} is set to the first non-null value found, so it is the document's only value exactly when the
+     * answer is one. Scanning stops on the second, which leaves {@code dst} holding the first of several - no caller
+     * reads it then, and the payload route answers the same way.
+     *
+     * <p>Answered from what the column already records - how many slots the document has, and which of them are null
+     * - so nothing is decoded to count.
+     */
+    int nonNullValues(BytesRef dst) throws IOException;
 }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnSource.java
@@ -9,6 +9,10 @@
 
 package org.elasticsearch.columnar.string;
 
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+
 /**
  * Binary doc values that can hand over the string column behind them, so a search matches a term against
  * the column rather than reading a value for every document.
@@ -22,4 +26,13 @@ public interface StringColumnSource {
 
     /** The column behind these values. */
     StringColumnReader reader();
+
+    /**
+     * The largest or smallest value the document these values are positioned on holds, or null when it holds none.
+     *
+     * <p>Here rather than on the column because the column addresses documents by rank, and which rank these values
+     * stand on is what the surface knows and the column does not. The returned {@link BytesRef} is only valid until
+     * the next call.
+     */
+    BytesRef extreme(boolean max, BytesRef dst) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortField.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortField.java
@@ -23,6 +23,7 @@ import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
@@ -141,11 +142,21 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
     private static final class ColumnarPayloadMinMaxBinaryDocValues extends FilterBinaryDocValues {
         private final boolean maxMode;
         private final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
+
+        /**
+         * The column behind these values, where there is one. Asked for the extreme directly: it decides it over
+         * ordinals and resolves only the value that wins, where the payload route below has to build the whole
+         * payload out of the column and then take it apart again to find the same value.
+         */
+        @Nullable
+        private final StringColumnSource columnar;
+        private final BytesRef scratch = new BytesRef();
         private BytesRef sortKey;
 
         ColumnarPayloadMinMaxBinaryDocValues(BinaryDocValues values, boolean maxMode) {
             super(values);
             this.maxMode = maxMode;
+            this.columnar = values instanceof StringColumnSource source ? source : null;
         }
 
         @Override
@@ -189,7 +200,7 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
 
         /** Decodes the sort key of the document {@code in} is positioned on, reporting whether it has one at all. */
         private boolean decodeSortKey() throws IOException {
-            sortKey = decoder.extreme(in.binaryValue(), maxMode);
+            sortKey = columnar != null ? columnar.extreme(maxMode, scratch) : decoder.extreme(in.binaryValue(), maxMode);
             return sortKey != null;
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MultiValuedBinaryColumnarPayloadLengthReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MultiValuedBinaryColumnarPayloadLengthReader.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.blockloader.Warnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
@@ -91,7 +92,11 @@ public abstract class MultiValuedBinaryColumnarPayloadLengthReader extends Block
         if (values.docValues().advanceExact(docId) == false) {
             return null;
         }
-        int nonNull = reader.nonNullCount(values.docValues().binaryValue(), scratch);
+        // Asked of the column where there is one, which knows how many slots the document has and which are null
+        // without decoding anything. A segment arriving as an overlay rather than as a column has its payload read.
+        final int nonNull = values.docValues() instanceof StringColumnSource columnar
+            ? columnar.nonNullValues(scratch)
+            : reader.nonNullCount(values.docValues().binaryValue(), scratch);
         if (nonNull == 1) {
             return length(scratch);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBytesRefsFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBytesRefsFromBinaryBlockLoader.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
@@ -79,14 +81,32 @@ public class MvMaxBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.Do
     private static class MvMaxBytesRefsFromColumnarPayload extends AbstractBytesRefsFromBinaryReader {
         private final MultiValueColumnarPayloadBinaryDocValuesReader reader = new MultiValueColumnarPayloadBinaryDocValuesReader();
 
+        private final BytesRef scratch = new BytesRef();
+
         MvMaxBytesRefsFromColumnarPayload(TrackingBinaryDocValues values) {
             super(values);
         }
 
+        /**
+         * The extreme value of the document, taken from the column where there is one.
+         *
+         * <p>A dictionary column decides it over ordinals: the dictionary is in term order, so the extreme ordinal a
+         * document holds names its extreme value, and only that one is resolved to a term. Otherwise the payload is
+         * decoded and its values compared, as it is for a segment arriving as an overlay rather than as a column.
+         */
         @Override
         public void read(int doc, BytesRefBuilder builder) throws IOException {
             if (false == docValues.docValues().advanceExact(doc)) {
                 builder.appendNull();
+                return;
+            }
+            if (docValues.docValues() instanceof StringColumnSource columnar) {
+                final BytesRef extreme = columnar.extreme(true, scratch);
+                if (extreme == null) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(extreme);
+                }
                 return;
             }
             reader.readMax(docValues.docValues().binaryValue(), builder);

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBytesRefsFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBytesRefsFromBinaryBlockLoader.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
@@ -86,14 +88,32 @@ public class MvMinBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.Do
     private static class MinFromColumnarPayload extends AbstractBytesRefsFromBinaryReader {
         private final MultiValueColumnarPayloadBinaryDocValuesReader reader = new MultiValueColumnarPayloadBinaryDocValuesReader();
 
+        private final BytesRef scratch = new BytesRef();
+
         MinFromColumnarPayload(TrackingBinaryDocValues values) {
             super(values);
         }
 
+        /**
+         * The extreme value of the document, taken from the column where there is one.
+         *
+         * <p>A dictionary column decides it over ordinals: the dictionary is in term order, so the extreme ordinal a
+         * document holds names its extreme value, and only that one is resolved to a term. Otherwise the payload is
+         * decoded and its values compared, as it is for a segment arriving as an overlay rather than as a column.
+         */
         @Override
         public void read(int doc, BytesRefBuilder builder) throws IOException {
             if (false == docValues.docValues().advanceExact(doc)) {
                 builder.appendNull();
+                return;
+            }
+            if (docValues.docValues() instanceof StringColumnSource columnar) {
+                final BytesRef extreme = columnar.extreme(false, scratch);
+                if (extreme == null) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(extreme);
+                }
                 return;
             }
             reader.readMin(docValues.docValues().binaryValue(), builder);

--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordFunctionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordFunctionTests.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.columnar;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.ColumNARDocValuesFormat;
+import org.elasticsearch.columnar.ColumnarFieldType;
+import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringColumnSource;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromBinaryBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromBinaryBlockLoader;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * The functions that read one value a document from a keyword column, against what a scan over the values the document
+ * holds would decide. The column answers them from what it already records rather than from the document's payload, so
+ * the only thing that says it is right is that the two agree.
+ */
+public class ColumnarKeywordFunctionTests extends ESTestCase {
+
+    private static final String FIELD = "kw";
+    private static final CircuitBreaker NOOP = new NoopCircuitBreaker("test");
+
+    /**
+     * The extreme value of each document, which a dictionary column decides over ordinals rather than by comparing
+     * terms. Escapes and nulls are the two ordinals that are not terms, so both shapes are here: an escaped value
+     * sorts by its bytes wherever its ordinal sits, and a null is no value to be the extreme of.
+     */
+    public void testMvMaxAndMvMin() throws IOException {
+        final String[][] docs = new String[between(200, 1200)][];
+        for (int d = 0; d < docs.length; d++) {
+            docs[d] = switch (d % 7) {
+                case 0 -> new String[] { "b-" + (d % 5), "a-" + (d % 3), "c" };
+                case 1 -> new String[] { "a-" + (d % 3) };
+                // Rare enough to escape a dictionary built from what the column repeats, and sorting below every
+                // term it holds, so an ordinal comparison would get it wrong.
+                case 2 -> new String[] { "b-" + (d % 5), "AAA-escapes-" + d };
+                case 3 -> new String[] { null, "c" };
+                case 4 -> new String[] { null };
+                case 5 -> new String[0];
+                default -> new String[] { "c", "b-" + (d % 5) };
+            };
+        }
+        for (boolean max : new boolean[] { true, false }) {
+            assertLoaderMatches(
+                docs,
+                fieldName -> max
+                    ? new MvMaxBytesRefsFromBinaryBlockLoader(fieldName, BinaryDocValuesFormat.COLUMNAR_PAYLOAD)
+                    : new MvMinBytesRefsFromBinaryBlockLoader(fieldName, BinaryDocValuesFormat.COLUMNAR_PAYLOAD),
+                extremes(docs, max)
+            );
+        }
+    }
+
+    /** What a scan over the values would decide, which is what the ordinals have to agree with. */
+    private static List<Object> extremes(String[][] docs, boolean max) {
+        final List<Object> expected = new ArrayList<>();
+        for (String[] slots : docs) {
+            String best = null;
+            for (String slot : slots) {
+                if (slot == null) {
+                    continue;
+                }
+                if (best == null || (max ? slot.compareTo(best) > 0 : slot.compareTo(best) < 0)) {
+                    best = slot;
+                }
+            }
+            expected.add(best == null ? null : new BytesRef(best));
+        }
+        return expected;
+    }
+
+    private void assertLoaderMatches(
+        String[][] docs,
+        Function<String, BlockDocValuesReader.DocValuesBlockLoader> loaders,
+        List<Object> expected
+    ) throws IOException {
+        final FieldType type = columnarBinaryFieldType();
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig().setCodec(columnarCodec()))) {
+                for (String[] slots : docs) {
+                    final Document doc = new Document();
+                    doc.add(new Field(FIELD, encode(slots), type));
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final LeafReaderContext leaf = reader.leaves().get(0);
+                assertThat("the field is a column", leaf.reader().getBinaryDocValues(FIELD), instanceOf(StringColumnSource.class));
+                final var loader = loaders.apply(FIELD);
+                final TestBlock block = (TestBlock) loader.reader(NOOP, leaf).read(TestBlock.factory(), docs(0, docs.length), 0, false);
+                assertEquals("positions", docs.length, block.size());
+                for (int d = 0; d < docs.length; d++) {
+                    assertEquals("document " + d + " of " + Arrays.toString(docs[d]), expected.get(d), block.get(d));
+                }
+            }
+        }
+    }
+
+    private static BlockLoader.Docs docs(int from, int count) {
+        return new BlockLoader.Docs() {
+            @Override
+            public int count() {
+                return count;
+            }
+
+            @Override
+            public int get(int i) {
+                return from + i;
+            }
+
+            @Override
+            public boolean mayContainDuplicates() {
+                return false;
+            }
+        };
+    }
+
+    /** Every doc-values field through the columnar format, which is what makes the field a column. */
+    private static Codec columnarCodec() {
+        final Codec base = TestUtil.getDefaultCodec();
+        final DocValuesFormat columnar = new ColumNARDocValuesFormat();
+        return new FilterCodec(base.getName(), base) {
+            private final DocValuesFormat perField = new PerFieldDocValuesFormat() {
+                @Override
+                public DocValuesFormat getDocValuesFormatForField(String field) {
+                    return columnar;
+                }
+            };
+
+            @Override
+            public DocValuesFormat docValuesFormat() {
+                return perField;
+            }
+        };
+    }
+
+    private static FieldType columnarBinaryFieldType() {
+        final FieldType type = new FieldType();
+        type.setDocValuesType(DocValuesType.BINARY);
+        type.putAttribute(ColumNARDocValuesFormat.TYPE_ATTRIBUTE, ColumnarFieldType.STRING.name());
+        type.freeze();
+        return type;
+    }
+
+    private static BytesRef encode(String[] slots) {
+        final List<BytesRef> refs = new ArrayList<>(slots.length);
+        for (String slot : slots) {
+            refs.add(slot == null ? null : new BytesRef(slot));
+        }
+        return BytesRef.deepCopyOf(new StringBinaryPayload.Builder().encode(refs));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordFunctionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordFunctionTests.java
@@ -30,12 +30,16 @@ import org.elasticsearch.columnar.string.StringBinaryPayload;
 import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.index.mapper.blockloader.MockWarnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.ByteLengthFromBytesRefDocValuesBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromBinaryBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.fn.Utf8CodePointsFromOrdsBlockLoader;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -103,6 +107,53 @@ public class ColumnarKeywordFunctionTests extends ESTestCase {
             expected.add(best == null ? null : new BytesRef(best));
         }
         return expected;
+    }
+
+    /**
+     * BYTE_LENGTH and LENGTH, which answer only for a document holding exactly one value and warn for one holding
+     * more. The arity comes from the column - how many slots a document has and which of them are null - so a payload
+     * is never decoded to count. Every arity is here: none, one, and several, by both nulls and real values.
+     */
+    public void testLengthFunctions() throws IOException {
+        final String[][] docs = new String[between(200, 800)][];
+        for (int d = 0; d < docs.length; d++) {
+            docs[d] = switch (d % 8) {
+                case 0 -> new String[] { "abc" };                     // one value
+                case 1 -> new String[] { "\u00e9\u00e8" };                    // two code points, four bytes
+                case 2 -> new String[] { null, "one-left" };          // one value after the nulls go
+                case 3 -> new String[] { "a", "b" };                  // several: no answer, and a warning
+                case 4 -> new String[] { null };                      // none
+                case 5 -> new String[0];                              // none
+                case 6 -> new String[] { "" };                        // one value, of no bytes
+                default -> new String[] { "term-" + (d % 5) };
+            };
+        }
+        for (boolean bytes : new boolean[] { true, false }) {
+            final List<Object> expected = new ArrayList<>();
+            for (String[] slots : docs) {
+                String only = null;
+                int nonNull = 0;
+                for (String slot : slots) {
+                    if (slot != null) {
+                        nonNull++;
+                        only = slot;
+                    }
+                }
+                expected.add(nonNull != 1 ? null : bytes ? new BytesRef(only).length : only.codePointCount(0, only.length()));
+            }
+            assertLoaderMatches(
+                docs,
+                fieldName -> bytes
+                    ? new ByteLengthFromBytesRefDocValuesBlockLoader(new MockWarnings(), fieldName, BinaryDocValuesFormat.COLUMNAR_PAYLOAD)
+                    : new Utf8CodePointsFromOrdsBlockLoader(
+                        new MockWarnings(),
+                        fieldName,
+                        ByteSizeValue.ofKb(1),
+                        BinaryDocValuesFormat.COLUMNAR_PAYLOAD
+                    ),
+                expected
+            );
+        }
     }
 
     private void assertLoaderMatches(

--- a/server/src/test/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortFieldTests.java
@@ -9,6 +9,10 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.BinaryDocValues;
@@ -20,7 +24,12 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.ColumNARDocValuesFormat;
+import org.elasticsearch.columnar.ColumnarFieldType;
+import org.elasticsearch.columnar.numeric.NumericPipeline;
+import org.elasticsearch.columnar.string.StringColumnSource;
 import org.elasticsearch.index.mapper.ColumnarBinaryDocValuesField;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
@@ -32,6 +41,7 @@ import java.io.IOException;
 import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
 import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.COLUMNAR_PAYLOAD;
 import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
 
@@ -467,6 +477,107 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
                 assertEquals(new BytesRef("omega"), advanced.binaryValue());
             }
         }
+    }
+
+    /**
+     * The sort key taken from a real column rather than from a payload. A column answers {@code extreme} itself,
+     * over ordinals where it keeps a dictionary, so the sort key never goes through the payload the other tests
+     * feed in - and it has to be the same key either way, for every shape a document takes.
+     */
+    public void testColumnarColumnAgreesWithThePayload() throws IOException {
+        final String[][] docs = new String[between(200, 600)][];
+        for (int d = 0; d < docs.length; d++) {
+            docs[d] = switch (d % 7) {
+                case 0 -> new String[] { "term-" + (d % 5) };
+                case 1 -> new String[] { "term-" + (d % 5), "term-" + ((d + 3) % 5) };
+                // A value the dictionary will not name, so the extreme is decided by bytes rather than by ordinal.
+                case 2 -> new String[] { "escaped-" + d, "term-1" };
+                case 3 -> new String[] { null, "term-2" };
+                case 4 -> new String[] { null };
+                case 5 -> new String[0];
+                default -> null;
+            };
+        }
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null).setCodec(columnarCodec()))) {
+            for (String[] slots : docs) {
+                final LuceneDocument doc = new LuceneDocument();
+                if (slots != null) {
+                    if (slots.length == 0) {
+                        ColumnarBinaryDocValuesField.recordEmptyArray(doc, "name");
+                    }
+                    for (String slot : slots) {
+                        if (slot == null) {
+                            ColumnarBinaryDocValuesField.recordNull(doc, "name");
+                        } else {
+                            ColumnarBinaryDocValuesField.recordValue(doc, "name", new BytesRef(slot), ValueOrdering.UNSORTED);
+                        }
+                    }
+                }
+                w.addDocument(doc);
+            }
+            w.forceMerge(1);
+            try (DirectoryReader reader = DirectoryReader.open(w)) {
+                final LeafReader leaf = getOnlyLeafReader(reader);
+                assertThat(
+                    "the field has to be a column, or this reads the same payload path as every other test here",
+                    leaf.getBinaryDocValues("name"),
+                    instanceOf(StringColumnSource.class)
+                );
+                for (boolean maxMode : new boolean[] { false, true }) {
+                    final BinaryDocValues keys = columnarSortKeys(leaf, maxMode);
+                    for (int d = 0; d < docs.length; d++) {
+                        final BytesRef expected = expectedExtreme(docs[d], maxMode);
+                        if (keys.advanceExact(d) == false) {
+                            assertNull("doc " + d + " maxMode=" + maxMode + " read as missing", expected);
+                            continue;
+                        }
+                        assertEquals("doc " + d + " maxMode=" + maxMode, expected, keys.binaryValue());
+                    }
+                }
+            }
+        }
+    }
+
+    /** The extreme non-null value of a document, worked out from the values themselves. */
+    private static BytesRef expectedExtreme(String[] slots, boolean maxMode) {
+        if (slots == null) {
+            return null;
+        }
+        BytesRef best = null;
+        for (String slot : slots) {
+            if (slot == null) {
+                continue;
+            }
+            final BytesRef candidate = new BytesRef(slot);
+            if (best == null || (maxMode ? candidate.compareTo(best) > 0 : candidate.compareTo(best) < 0)) {
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    private static Codec columnarCodec() {
+        final Codec base = TestUtil.getDefaultCodec();
+        // The type is injected rather than read from a field attribute: these documents are built through
+        // ColumnarBinaryDocValuesField, which is the mapper's field and carries no codec attribute.
+        final DocValuesFormat columnar = new ColumNARDocValuesFormat(
+            (fieldName, fieldType) -> NumericPipeline::defaultPipeline,
+            field -> ColumnarFieldType.STRING,
+            ColumNARDocValuesFormat.DEFAULT_BLOCK_SIZE
+        );
+        return new FilterCodec(base.getName(), base) {
+            private final DocValuesFormat perField = new PerFieldDocValuesFormat() {
+                @Override
+                public DocValuesFormat getDocValuesFormatForField(String field) {
+                    return columnar;
+                }
+            };
+
+            @Override
+            public DocValuesFormat docValuesFormat() {
+                return perField;
+            }
+        };
     }
 
     private static BinaryDocValues columnarSortKeys(LeafReader leaf, boolean maxMode) throws IOException {


### PR DESCRIPTION
`MV_MIN`, `MV_MAX`, `LENGTH`, `BYTE_LENGTH` and the query sort on a keyword field each read a document's binary payload and decode every value in it. Where the field is stored as a ColumNAR column they can ask the column instead.

`StringColumnSource` gains two questions. `extreme` returns the largest or smallest value a document holds: a dictionary column decides it over ordinals, since the dictionary is in term order, and resolves only the value that wins. A null is no value and is passed over; an escaped value sorts wherever its bytes do, which its ordinal does not say, so a document holding one is decided by comparing bytes after all.

`nonNullValues` returns how many non-null values a document holds, capped at two, which is all the single-value functions need. It answers from what the column already records, how many slots a document has and which of them are null, so nothing is decoded to count and only the single value that survives is read.

A segment that arrives as an overlay rather than as a column still reads its payload.
