### PR TITLE
Fix testConcurrentSnapshotDeleteAndDeleteIndex

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -418,6 +418,39 @@ public class SnapshotResiliencyTestHelper {
             TransportInterceptor createTransportInterceptor(DiscoveryNode node);
         }
 
+        // There is a deadlock condition where processPendingDeletes awaits on shard snapshots which may be scheduled
+        // after the processPendingDeletes task. In production these tasks run on different threadpools, and processPendingDeletes
+        // waits for 30 minutes. To simulate that here, we reschedule the processPendingDeletes task into the future each time we encounter
+        // it until it is the last task in the queue.
+        private Function<Runnable, Runnable> deferProcessPendingDeletes(Function<Runnable, Runnable> runnableWrapper) {
+            return runnable -> {
+                final Runnable wrapped = runnableWrapper.apply(runnable);
+                if (isProcessPendingDeletes(runnable) == false) {
+                    return wrapped;
+                }
+                return new Runnable() {
+                    @Override
+                    public void run() {
+                        if (deterministicTaskQueue.hasRunnableTasks()) {
+                            logger.debug("--> deferring {} because other DTQ tasks may hold shard locks", runnable);
+                            deterministicTaskQueue.scheduleAt(deterministicTaskQueue.getCurrentTimeMillis() + 1, this);
+                            return;
+                        }
+                        wrapped.run();
+                    }
+
+                    @Override
+                    public String toString() {
+                        return wrapped.toString();
+                    }
+                };
+            };
+        }
+
+        private static boolean isProcessPendingDeletes(Runnable task) {
+            return task.toString().contains("processPendingDeletes[");
+        }
+
         public class TestClusterNode {
 
             protected final ProjectResolver projectResolver = TestProjectResolvers.DEFAULT_PROJECT_ONLY;
@@ -500,7 +533,9 @@ public class SnapshotResiliencyTestHelper {
                 this.environment = createEnvironment(node.getName(), tempDir, nodeSettings(node));
                 this.settings = environment.settings();
                 this.pluginsService = createPluginsService(settings, environment);
-                this.threadPool = deterministicTaskQueue.getThreadPool(runnable -> DeterministicTaskQueue.onNodeLog(this.node, runnable));
+                this.threadPool = deterministicTaskQueue.getThreadPool(
+                    deferProcessPendingDeletes(runnable -> DeterministicTaskQueue.onNodeLog(this.node, runnable))
+                );
                 this.masterService = new FakeThreadPoolMasterService(node.getName(), threadPool, deterministicTaskQueue::scheduleNow);
                 this.client = new NodeClient(settings, threadPool, projectResolver);
                 this.usageService = new UsageService();

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -211,40 +211,7 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
 
         @Override
         public ThreadPool getThreadPool(Function<Runnable, Runnable> runnableWrapper) {
-            return new StatelessDeterministicThreadPool(deferProcessPendingDeletes(runnableWrapper));
-        }
-
-        // There is a deadlock condition where processPendingDeletes awaits on shard snapshots which may be scheduled
-        // after the processPendingDeletes task. In production these tasks run on different threadpools, and processPendingDeletes
-        // waits for 30 minutes. To simulate that here, we reschedule the processPendingDeletes task into the future each time we encounter
-        // it until it is the last task in the queue.
-        private Function<Runnable, Runnable> deferProcessPendingDeletes(Function<Runnable, Runnable> runnableWrapper) {
-            return runnable -> {
-                final Runnable wrapped = runnableWrapper.apply(runnable);
-                if (isProcessPendingDeletes(runnable) == false) {
-                    return wrapped;
-                }
-                return new Runnable() {
-                    @Override
-                    public void run() {
-                        if (hasRunnableTasks()) {
-                            logger.debug("--> deferring {} because other DTQ tasks may hold shard locks", runnable);
-                            scheduleAt(getCurrentTimeMillis() + 1, this);
-                            return;
-                        }
-                        wrapped.run();
-                    }
-
-                    @Override
-                    public String toString() {
-                        return wrapped.toString();
-                    }
-                };
-            };
-        }
-
-        private static boolean isProcessPendingDeletes(Runnable task) {
-            return task.toString().contains("processPendingDeletes[");
+            return new StatelessDeterministicThreadPool(runnableWrapper);
         }
 
         private class StatelessDeterministicThreadPool extends DeterministicThreadPool {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -211,35 +211,36 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
 
         @Override
         public ThreadPool getThreadPool(Function<Runnable, Runnable> runnableWrapper) {
-            return new StatelessDeterministicThreadPool(runnableWrapper);
+            return new StatelessDeterministicThreadPool(deferProcessPendingDeletes(runnableWrapper));
         }
 
-        @Override
-        public void scheduleNow(Runnable task) {
-            if (isProcessPendingDeletes(task) == false) {
-                super.scheduleNow(task);
-                return;
-            }
-            // processPendingDeletes uses Semaphore.tryAcquire with a 30-minute wall-clock timeout.
-            // Under DTQ this can block the only thread while shard snapshots that still hold the lock
-            // sit in the runnable queue, so the suite times out. Re-enqueue until no other runnable
-            // work remains, matching production where generic and snapshot run on different threads.
-            super.scheduleNow(new Runnable() {
-                @Override
-                public void run() {
-                    if (hasRunnableTasks()) {
-                        logger.debug("--> deferring {} because other DTQ tasks may hold shard locks", task);
-                        scheduleAt(getCurrentTimeMillis() + 1, this);
-                        return;
+        // There is a deadlock condition where processPendingDeletes awaits on shard snapshots which may be scheduled
+        // after the processPendingDeletes task. In production these tasks run on different threadpools, and processPendingDeletes
+        // waits for 30 minutes. To simulate that here, we reschedule the processPendingDeletes task into the future each time we encounter
+        // it until it is the last task in the queue.
+        private Function<Runnable, Runnable> deferProcessPendingDeletes(Function<Runnable, Runnable> runnableWrapper) {
+            return runnable -> {
+                final Runnable wrapped = runnableWrapper.apply(runnable);
+                if (isProcessPendingDeletes(runnable) == false) {
+                    return wrapped;
+                }
+                return new Runnable() {
+                    @Override
+                    public void run() {
+                        if (hasRunnableTasks()) {
+                            logger.debug("--> deferring {} because other DTQ tasks may hold shard locks", runnable);
+                            scheduleAt(getCurrentTimeMillis() + 1, this);
+                            return;
+                        }
+                        wrapped.run();
                     }
-                    task.run();
-                }
 
-                @Override
-                public String toString() {
-                    return task.toString();
-                }
-            });
+                    @Override
+                    public String toString() {
+                        return wrapped.toString();
+                    }
+                };
+            };
         }
 
         private static boolean isProcessPendingDeletes(Runnable task) {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -214,6 +214,38 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
             return new StatelessDeterministicThreadPool(runnableWrapper);
         }
 
+        @Override
+        public void scheduleNow(Runnable task) {
+            if (isProcessPendingDeletes(task) == false) {
+                super.scheduleNow(task);
+                return;
+            }
+            // processPendingDeletes uses Semaphore.tryAcquire with a 30-minute wall-clock timeout.
+            // Under DTQ this can block the only thread while shard snapshots that still hold the lock
+            // sit in the runnable queue, so the suite times out. Re-enqueue until no other runnable
+            // work remains, matching production where generic and snapshot run on different threads.
+            super.scheduleNow(new Runnable() {
+                @Override
+                public void run() {
+                    if (hasRunnableTasks()) {
+                        logger.debug("--> deferring {} because other DTQ tasks may hold shard locks", task);
+                        scheduleAt(getCurrentTimeMillis() + 1, this);
+                        return;
+                    }
+                    task.run();
+                }
+
+                @Override
+                public String toString() {
+                    return task.toString();
+                }
+            });
+        }
+
+        private static boolean isProcessPendingDeletes(Runnable task) {
+            return task.toString().contains("processPendingDeletes[");
+        }
+
         private class StatelessDeterministicThreadPool extends DeterministicThreadPool {
 
             protected StatelessDeterministicThreadPool(Function<Runnable, Runnable> runnableWrapper) {


### PR DESCRIPTION
There is a deadlock condition where `processPendingDeletes` awaits on shard snapshots which may be scheduled
after the `processPendingDeletes` task on the DTQ. In production, these tasks run on different threadpools (`processPendingDeletes` on `generic` and the shard snapshots on `snapshot`). The `processPendingDeletes` has a 30 minute wait for all shard snapshots to complete. This isn't possible in the test since all tasks are queued sequentially and a deadlock occurs. To simulate the production flow, this fix reschedules the `processPendingDeletes` task into the future each time we encounter it until it is the last task in the queue, thus avoiding any possibility of deadlock. This applies to both the stateful and stateless tests. 

Closes: https://github.com/elastic/elasticsearch/issues/154784