### PR TITLE
[Draft] Fix testConcurrentSnapshotDeleteAndDeleteIndex

### DIFF
--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -217,7 +217,7 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
         @Override
         public void scheduleNow(Runnable task) {
             if (task.toString().contains("processPendingDeletes[")) {
-               logger.debug("--> dropping {} to avoid wall-clock shard-lock wait on DTQ", task);
+                logger.debug("--> dropping {} to avoid wall-clock shard-lock wait on DTQ", task);
                 return;
             }
             super.scheduleNow(task);

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -217,7 +217,7 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
         @Override
         public void scheduleNow(Runnable task) {
             if (task.toString().contains("processPendingDeletes[")) {
-                logger.debug("--> dropping {} to avoid wall-clock shard-lock wait on DTQ", task);
+                logger.debug("--> dropping {} to avoid possible deadlock", task);
                 return;
             }
             super.scheduleNow(task);

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -214,6 +214,15 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
             return new StatelessDeterministicThreadPool(runnableWrapper);
         }
 
+        @Override
+        public void scheduleNow(Runnable task) {
+            if (task.toString().contains("processPendingDeletes[")) {
+               logger.debug("--> dropping {} to avoid wall-clock shard-lock wait on DTQ", task);
+                return;
+            }
+            super.scheduleNow(task);
+        }
+
         private class StatelessDeterministicThreadPool extends DeterministicThreadPool {
 
             protected StatelessDeterministicThreadPool(Function<Runnable, Runnable> runnableWrapper) {


### PR DESCRIPTION
There is a test failure https://github.com/elastic/elasticsearch/issues/154784 with more information about the issue and potential fixes.

This is option 1 for the direction of the fix, dropping the pending deletes task so that it never hits a deadlock. This is safe because the test does not assert on store deletions and matches production behaviour

Option 2 is https://github.com/elastic/elasticsearch/pull/158765