### PR TITLE
Fix rounding in ES|QL variance state merging

### DIFF
--- a/docs/changelog/158769.yaml
+++ b/docs/changelog/158769.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 158668
+pr: 158769
+summary: Fix rounding in ES|QL variance state merging
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WelfordAlgorithm.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WelfordAlgorithm.java
@@ -67,9 +67,10 @@ public final class WelfordAlgorithm {
             count = countValue;
             return;
         }
-        double delta = mean - meanValue;
+        double delta = meanValue - mean;
         m2 += m2Value + delta * delta * count * countValue / (count + countValue);
-        mean = (mean * count + meanValue * countValue) / (count + countValue);
+        // A weighted sum can round identical means differently and introduce variance in subsequent merges.
+        mean += delta * ((double) countValue / (count + countValue));
         count += countValue;
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/WelfordAlgorithmTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/WelfordAlgorithmTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.test.ESTestCase;
+
+/** Tests that merging partial results preserves the variance of the input values. */
+public class WelfordAlgorithmTests extends ESTestCase {
+
+    /** Identical values must retain zero variance even when their partial means are large. */
+    public void testCombineConstantValues() {
+        for (double value : new double[] { -5118973529465149924L, 5118973529465149924L, Double.MAX_VALUE, -Double.MAX_VALUE }) {
+            var combined = new WelfordAlgorithm();
+            // These partition sizes reproduce rounding in the weighted sum of the first two means.
+            for (int count : new int[] { 2, 15, 4 }) {
+                var partial = new WelfordAlgorithm();
+                for (int i = 0; i < count; i++) {
+                    partial.add(value);
+                }
+                combined.add(partial.mean(), partial.m2(), partial.count());
+            }
+            assertEquals(0.0, combined.evaluate(true), 0.0);
+            assertEquals(0.0, combined.evaluate(false), 0.0);
+            assertEquals(value, combined.mean(), 0.0);
+            assertEquals(21L, combined.count());
+        }
+    }
+
+    /** Unequal partition sizes must weight both the mean and the variance correctly. */
+    public void testCombineDifferentValues() {
+        var combined = new WelfordAlgorithm();
+        for (double[] values : new double[][] { { 2, 4, 4 }, { 4, 5, 5, 7, 9 } }) {
+            var partial = new WelfordAlgorithm();
+            for (double value : values) {
+                partial.add(value);
+            }
+            combined.add(partial.mean(), partial.m2(), partial.count());
+        }
+        assertEquals(8L, combined.count());
+        assertEquals(5.0, combined.mean(), 1e-12);
+        assertEquals(4.0, combined.evaluate(false), 1e-12);
+        assertEquals(2.0, combined.evaluate(true), 1e-12);
+    }
+}


### PR DESCRIPTION
Merging partial ES|QL aggregation results could produce a nonzero `STD_DEV` or `VARIANCE` for identical values. The weighted-sum mean calculation introduced rounding error for large values. Later merges treated that error as real variation.

The reported query returned `825.2` instead of `21` because this produced a standard deviation of approximately `402.1`. Different merge orders exposed the discrepancy between standard and columnar indices.

Update the merged mean using the difference between partial means. Equal means now remain unchanged. The fix applies to grouped and ungrouped aggregations.

Closes #158668