### PR TITLE
Unmuting test that was fixed in a backport

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -477,9 +477,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.BulkFailureRetryIT
   method: testBulkFailureRetries
   issue: https://github.com/elastic/elasticsearch/issues/158127
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=update_by_query/10_basic/Response for version conflict with conflicts=proceed}
-  issue: https://github.com/elastic/elasticsearch/issues/158337
 - class: org.elasticsearch.common.LocalTimeOffsetTests
   method: testOverlap
   issue: https://github.com/elastic/elasticsearch/issues/158343


### PR DESCRIPTION
This unmutes `update_by_query/10_basic/Response for version conflict with conflicts=proceed`, which was fixed in #158587 and backported to 9.5 in #158756. The test was only muted on the 9.5 branch.