### PR TITLE
[ESQL] ESQL:DS: Read Parquet footers past cache cap

### DIFF
--- a/docs/changelog/158778.yaml
+++ b/docs/changelog/158778.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158778
+summary: Read Parquet footers larger than the footer-cache entry cap
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheSettings;
@@ -198,9 +199,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
     /**
      * Sanity cap on a trailer-declared footer GET ({@code F+8}). Larger than this is an invalid
      * Parquet file (HTTP 400) and is rejected before the second GET. Not a cache size and not a
-     * data-page limit. Aligns with Trino's 15 MB footer-read cap and the Parquet sliding-window max.
+     * data-page limit. Same value as {@link ExternalSourceSettings#BLOB_STORE_GET_SIZE_BYTES} so
+     * an exact-range footer GET stays inside the {@code C × B} in-flight GET accounting.
      */
-    static final int MAX_FOOTER_READ_BYTES = 16 * 1024 * 1024;
+    static final int MAX_FOOTER_READ_BYTES = ExternalSourceSettings.BLOB_STORE_GET_SIZE_BYTES;
 
     /** Clears both footer caches held by this reader. Intended for test isolation only. */
     void clearFooterCachesForTests() {
@@ -411,7 +413,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
 
     /**
      * Test constructor that lowers the sanity GET cap so tests can reject an oversized trailer
-     * without allocating a 16 MiB declared footer.
+     * without allocating a production-sized declared footer.
      */
     ParquetFormatReader(BlockFactory blockFactory, int maxFooterReadBytes) {
         this(
@@ -1199,7 +1201,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         ioBreaker.addEstimateBytesAndMaybeBreak(n, "parquet footer copy");
         byte[] copy;
         try {
-            copy = new byte[n];
+            copy = UninitializedArrays.newByteArray(n);
             bb.get(copy);
         } catch (Throwable t) {
             ioBreaker.addWithoutBreaking(-n);
@@ -1225,10 +1227,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
      * deliberate: it does not depend on the {@link FooterByteCache} surviving between the async read
      * and the parse (a wide concurrent discovery could otherwise evict the tail against the cache's
      * byte budget and force a blocking re-read on the executor thread). The bytes are additionally
-     * offered to the cache best-effort so a later split-discovery pass can reuse them, but correctness
-     * never depends on that. Callers of this listener seed {@link #parsedFooters} after a successful
-     * metadata convert or range extract. {@code release} uncharges the GET (or the heap copy) after
-     * parse, success or failure.
+     * offered to the cache best-effort after a successful parse so a later split-discovery pass can
+     * reuse them, but correctness never depends on that. Callers of this listener seed
+     * {@link #parsedFooters} after a successful metadata convert or range extract. {@code release}
+     * uncharges the GET (or the heap copy) after parse, success or failure.
      */
     private void parseTailOnExecutor(
         StorageObject object,
@@ -1243,8 +1245,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             executor.execute(() -> {
                 boolean closed = false;
                 try {
-                    footerBytes.put(cacheKey, tailBytes);
                     ParquetMetadata footer = parseParsedFooterFromTail(object, length, tailBytes);
+                    footerBytes.put(cacheKey, tailBytes);
                     release.close();
                     closed = true;
                     listener.onResponse(footer);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -37,6 +37,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
@@ -48,6 +49,7 @@ import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.compute.data.Utf8Sanitizer;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -107,6 +109,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
@@ -143,6 +146,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
      * {@link ParquetStorageObjectAdapter} this reader creates.
      */
     private final FooterByteCache footerBytes;
+
+    /**
+     * Sanity cap on trailer-declared footer GETs. Production uses {@link #MAX_FOOTER_READ_BYTES};
+     * tests may lower it via the package-private constructor.
+     */
+    private final int maxFooterReadBytes;
 
     /**
      * Node-wide cap on retained Parquet I/O bytes ({@code heap / 8}). Shared by every derived
@@ -185,6 +194,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
 
     /** Length of the Parquet trailer: 4-byte footer length + 4-byte magic. */
     private static final int PARQUET_TRAILER_BYTES = 8;
+
+    /**
+     * Sanity cap on a trailer-declared footer GET ({@code F+8}). Larger than this is an invalid
+     * Parquet file (HTTP 400) and is rejected before the second GET. Not a cache size and not a
+     * data-page limit. Aligns with Trino's 15 MB footer-read cap and the Parquet sliding-window max.
+     */
+    static final int MAX_FOOTER_READ_BYTES = 16 * 1024 * 1024;
 
     /** Clears both footer caches held by this reader. Intended for test isolation only. */
     void clearFooterCachesForTests() {
@@ -365,7 +381,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             Set.of(),
             FooterByteCache.fromSettings(settings),
             ParsedFooterCache.fromSettings(settings, ParquetFormatReader::estimateFooterWeightBytes),
-            ParquetIoWatermark.forHeap()
+            ParquetIoWatermark.forHeap(),
+            MAX_FOOTER_READ_BYTES
         );
     }
 
@@ -387,7 +404,29 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             Set.of(),
             FooterByteCache.fromSettings(Settings.EMPTY),
             ParsedFooterCache.fromSettings(Settings.EMPTY, ParquetFormatReader::estimateFooterWeightBytes),
-            ParquetIoWatermark.forHeap()
+            ParquetIoWatermark.forHeap(),
+            MAX_FOOTER_READ_BYTES
+        );
+    }
+
+    /**
+     * Test constructor that lowers the sanity GET cap so tests can reject an oversized trailer
+     * without allocating a 16 MiB declared footer.
+     */
+    ParquetFormatReader(BlockFactory blockFactory, int maxFooterReadBytes) {
+        this(
+            blockFactory,
+            FilterCompat.NOOP,
+            null,
+            false,
+            true,
+            null,
+            Map.of(),
+            Set.of(),
+            FooterByteCache.fromSettings(Settings.EMPTY),
+            ParsedFooterCache.fromSettings(Settings.EMPTY, ParquetFormatReader::estimateFooterWeightBytes),
+            ParquetIoWatermark.forHeap(),
+            maxFooterReadBytes
         );
     }
 
@@ -402,7 +441,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         Set<String> declaredTypeColumns,
         FooterByteCache footerBytes,
         ParsedFooterCache<ParquetMetadata> parsedFooters,
-        ParquetIoWatermark ioWatermark
+        ParquetIoWatermark ioWatermark,
+        int maxFooterReadBytes
     ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
@@ -418,6 +458,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             throw new IllegalArgumentException("ioWatermark");
         }
         this.ioWatermark = ioWatermark;
+        this.maxFooterReadBytes = maxFooterReadBytes;
     }
 
     /**
@@ -438,7 +479,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredTypeColumns,
             footerBytes,
             parsedFooters,
-            ioWatermark
+            ioWatermark,
+            maxFooterReadBytes
         );
     }
 
@@ -459,7 +501,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredTypeColumns,
             footerBytes,
             parsedFooters,
-            ioWatermark
+            ioWatermark,
+            maxFooterReadBytes
         );
     }
 
@@ -480,7 +523,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 declaredTypeColumns,
                 footerBytes,
                 parsedFooters,
-                ioWatermark
+                ioWatermark,
+                maxFooterReadBytes
             );
         }
         if (pushedFilter instanceof FilterCompat.Filter filter) {
@@ -495,7 +539,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 declaredTypeColumns,
                 footerBytes,
                 parsedFooters,
-                ioWatermark
+                ioWatermark,
+                maxFooterReadBytes
             );
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
@@ -510,7 +555,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 declaredTypeColumns,
                 footerBytes,
                 parsedFooters,
-                ioWatermark
+                ioWatermark,
+                maxFooterReadBytes
             );
         }
         return this;
@@ -529,7 +575,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredTypeColumns,
             footerBytes,
             parsedFooters,
-            ioWatermark
+            ioWatermark,
+            maxFooterReadBytes
         );
     }
 
@@ -556,7 +603,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredTypeColumns,
             footerBytes,
             parsedFooters,
-            ioWatermark
+            ioWatermark,
+            maxFooterReadBytes
         );
     }
 
@@ -584,7 +632,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             Set.copyOf(physicalDeclaredColumns),
             footerBytes,
             parsedFooters,
-            ioWatermark
+            ioWatermark,
+            maxFooterReadBytes
         );
     }
 
@@ -604,7 +653,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             declaredTypeColumns,
             footerBytes,
             parsedFooters,
-            watermark
+            watermark,
+            maxFooterReadBytes
         );
     }
 
@@ -735,13 +785,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         } catch (IOException e) {
             throw ParquetReadFailures.wrap(e, "Could not read [" + uri + "] as a Parquet file");
         } catch (RuntimeException e) {
-            if (e instanceof CircuitBreakingException) {
-                throw e;
-            }
-            if (e instanceof ElasticsearchException) {
-                throw e;
-            }
-            throw newInvalidParquetFileException(uri, e);
+            throw rethrowStructuralFooterFailure(uri, e);
         }
     }
 
@@ -860,6 +904,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         return new IllegalArgumentException("Could not read [" + uri + "] as a Parquet file: " + detail, e);
     }
 
+    /**
+     * parquet-mr signals a malformed file as a generic {@link RuntimeException}. Circuit-breaker
+     * trips and other {@link ElasticsearchException}s must stay unwrapped so they remain HTTP 429
+     * (or their own status) rather than becoming an invalid-file 400.
+     */
+    private static RuntimeException rethrowStructuralFooterFailure(String uri, RuntimeException e) {
+        if (e instanceof CircuitBreakingException || e instanceof ElasticsearchException) {
+            return e;
+        }
+        return newInvalidParquetFileException(uri, e);
+    }
+
     private static IllegalArgumentException invalidParquet(String uri, String detail) {
         return new IllegalArgumentException("Could not read [" + uri + "] as a Parquet file: " + detail);
     }
@@ -903,8 +959,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
      * {@code (path, length)} key {@link #loadFooter} uses. If the parsed footer is already cached,
      * {@link #loadFooterAsync} completes from it on {@code executor} with no I/O.
      * <p>
-     * Anomalies (short file, missing {@code PAR1}, short GET, footer larger than the file) complete
-     * {@code listener} with {@link #newInvalidParquetFileException} and never call
+     * Anomalies (short file, missing {@code PAR1}, short GET, footer larger than the file or
+     * {@link #MAX_FOOTER_READ_BYTES}) complete {@code listener} with
+     * {@link #newInvalidParquetFileException} and never call
      * {@link #metadata(StorageObject)} or {@code adapter.newStream()}. Encrypted {@code PARE}
      * footers take that failure path too.
      * <p>
@@ -968,9 +1025,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
     }
 
     /**
-     * Prefetches the Parquet footer tail via {@link StorageObject#readBytesAsync} and hands the bytes
-     * to {@link #completeFromAvailableTail}. A short GET fails the listener; it does not fall back to
-     * a stream parse.
+     * Prefetches the Parquet footer tail via {@link StorageObject#readBytesAsync} and hands the
+     * buffer to {@link #completeFromAvailableTail}. A short GET fails the listener; it does not
+     * fall back to a stream parse. The GET stays charged until parse finishes (or this path fails).
      */
     private void prefetchAndParseFooterAsync(
         StorageObject object,
@@ -983,25 +1040,32 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         DirectBufferFactory factory = DirectBufferFactory.forBreaker(blockFactory.breaker());
 
         object.readBytesAsync(length - tailLen, tailLen, factory, executor, ActionListener.wrap(tail -> {
-            final byte[] tailBytes;
+            boolean transferred = false;
             try {
-                tailBytes = copyToArray(tail);
+                int remaining = tail.buffer().remaining();
+                if (remaining != tailLen) {
+                    listener.onFailure(invalidParquetShortRead(object, tailLen, remaining));
+                    return;
+                }
+                transferred = true;
+                completeFromAvailableTail(object, length, cacheKey, tail, executor, listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
             } finally {
-                tail.close();
+                if (transferred == false) {
+                    tail.close();
+                }
             }
-            if (tailBytes.length != tailLen) {
-                listener.onFailure(invalidParquetShortRead(object, tailLen, tailBytes.length));
-                return;
-            }
-            completeFromAvailableTail(object, length, cacheKey, tailBytes, executor, listener);
         }, listener::onFailure));
     }
 
     /**
      * Parses {@code tailBytes} when they already cover {@code F+8}, otherwise issues an exact-range
-     * {@link StorageObject#readBytesAsync} for the footer region. Regions larger than
-     * {@link FooterByteCache#maxEntryBytes()} fail closed; they do not GET and do not fall back to
-     * {@code adapter.newStream()}.
+     * {@link StorageObject#readBytesAsync} for the footer region. Trailer-declared regions larger
+     * than {@link #MAX_FOOTER_READ_BYTES} (or a lowered test cap) fail as an invalid Parquet file
+     * before the second GET; they do not fall back to {@code adapter.newStream()}. Regions larger
+     * than {@link FooterByteCache#maxEntryBytes()} are still read and parsed, then skipped by
+     * {@link FooterByteCache#put}.
      */
     private void completeFromAvailableTail(
         StorageObject object,
@@ -1011,48 +1075,145 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         Executor executor,
         ActionListener<LoadedFooter> listener
     ) {
-        int footerLength = footerLengthFromTrailer(tailBytes);
+        int footerLength = footerLengthFromTrailer(ByteBuffer.wrap(tailBytes));
+        if (rejectDeclaredFooter(object, length, footerLength, listener)) {
+            return;
+        }
+        long footerRegion = (long) footerLength + PARQUET_TRAILER_BYTES;
+        ActionListener<ParquetMetadata> parsed = listener.map(footer -> new LoadedFooter(cacheKey, footer));
+        if (footerRegion <= tailBytes.length) {
+            parseTailOnExecutor(object, length, tailBytes, () -> {}, cacheKey, executor, parsed);
+            return;
+        }
+        readExactFooterAndParse(object, length, cacheKey, (int) footerRegion, executor, parsed);
+    }
+
+    /**
+     * Same as {@link #completeFromAvailableTail(StorageObject, long, FooterByteCache.Key, byte[], Executor, ActionListener)}
+     * but keeps {@code tail} charged until parse (or closes it before an exact-range GET).
+     */
+    private void completeFromAvailableTail(
+        StorageObject object,
+        long length,
+        FooterByteCache.Key cacheKey,
+        DirectReadBuffer tail,
+        Executor executor,
+        ActionListener<LoadedFooter> listener
+    ) {
+        boolean transferred = false;
+        try {
+            int footerLength = footerLengthFromTrailer(tail.buffer());
+            if (rejectDeclaredFooter(object, length, footerLength, listener)) {
+                return;
+            }
+            long footerRegion = (long) footerLength + PARQUET_TRAILER_BYTES;
+            ActionListener<ParquetMetadata> parsed = listener.map(footer -> new LoadedFooter(cacheKey, footer));
+            if (footerRegion <= tail.buffer().remaining()) {
+                ChargedFooterBytes charged = bytesForParse(tail);
+                transferred = true;
+                if (charged.reusedHeapArray() == false) {
+                    tail.close();
+                }
+                parseTailOnExecutor(object, length, charged.bytes(), charged.release(), cacheKey, executor, parsed);
+                return;
+            }
+            transferred = true;
+            tail.close();
+            readExactFooterAndParse(object, length, cacheKey, (int) footerRegion, executor, parsed);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        } finally {
+            if (transferred == false) {
+                tail.close();
+            }
+        }
+    }
+
+    /** {@code true} if {@code listener} was failed because the declared footer is invalid. */
+    private boolean rejectDeclaredFooter(StorageObject object, long length, int footerLength, ActionListener<LoadedFooter> listener) {
         if (footerLength <= 0) {
             listener.onFailure(invalidParquet(object.path().toString(), "is not a Parquet file. Expected magic number at tail"));
-            return;
+            return true;
         }
         long footerRegion = (long) footerLength + PARQUET_TRAILER_BYTES;
         if (footerRegion > Integer.MAX_VALUE || footerRegion > length) {
             listener.onFailure(
                 invalidParquet(object.path().toString(), "footer length " + footerLength + " exceeds file length " + length)
             );
-            return;
+            return true;
         }
-        if (footerRegion > footerBytes.maxEntryBytes()) {
+        if (footerRegion > maxFooterReadBytes) {
             listener.onFailure(
-                invalidParquet(
-                    object.path().toString(),
-                    "footer length " + footerLength + " exceeds maximum " + footerBytes.maxEntryBytes()
-                )
+                invalidParquet(object.path().toString(), "footer length " + footerLength + " exceeds maximum " + maxFooterReadBytes)
             );
-            return;
+            return true;
         }
-        ActionListener<ParquetMetadata> parsed = listener.map(footer -> new LoadedFooter(cacheKey, footer));
-        if (footerRegion <= tailBytes.length) {
-            parseTailOnExecutor(object, length, tailBytes, cacheKey, executor, parsed);
-            return;
-        }
-        int exactLen = (int) footerRegion;
+        return false;
+    }
+
+    private void readExactFooterAndParse(
+        StorageObject object,
+        long length,
+        FooterByteCache.Key cacheKey,
+        int exactLen,
+        Executor executor,
+        ActionListener<ParquetMetadata> parsed
+    ) {
         DirectBufferFactory factory = DirectBufferFactory.forBreaker(blockFactory.breaker());
         object.readBytesAsync(length - exactLen, exactLen, factory, executor, ActionListener.wrap(footerBuf -> {
-            final byte[] footerBytes;
+            boolean transferred = false;
             try {
-                footerBytes = copyToArray(footerBuf);
+                int remaining = footerBuf.buffer().remaining();
+                if (remaining != exactLen) {
+                    parsed.onFailure(invalidParquetShortRead(object, exactLen, remaining));
+                    return;
+                }
+                ChargedFooterBytes charged = bytesForParse(footerBuf);
+                transferred = true;
+                if (charged.reusedHeapArray() == false) {
+                    footerBuf.close();
+                }
+                parseTailOnExecutor(object, length, charged.bytes(), charged.release(), cacheKey, executor, parsed);
+            } catch (Exception e) {
+                parsed.onFailure(e);
             } finally {
-                footerBuf.close();
+                if (transferred == false) {
+                    footerBuf.close();
+                }
             }
-            if (footerBytes.length != exactLen) {
-                listener.onFailure(invalidParquetShortRead(object, exactLen, footerBytes.length));
-                return;
-            }
-            parseTailOnExecutor(object, length, footerBytes, cacheKey, executor, parsed);
-        }, listener::onFailure));
+        }, parsed::onFailure));
     }
+
+    /**
+     * Heap wrap of the GET (production): reuse {@code array()} so parse stays on the request
+     * breaker; {@code owned} is closed after parse. Otherwise charge a copy, then the caller
+     * closes the GET buffer and this releasable uncharges the copy after parse.
+     */
+    private ChargedFooterBytes bytesForParse(DirectReadBuffer owned) {
+        ByteBuffer bb = owned.buffer().duplicate();
+        if (bb.hasArray() && bb.arrayOffset() == 0 && bb.position() == 0 && bb.remaining() == bb.array().length) {
+            return new ChargedFooterBytes(bb.array(), owned, true);
+        }
+        CircuitBreaker ioBreaker = LocalCircuitBreaker.forAsyncIo(blockFactory.breaker());
+        int n = bb.remaining();
+        ioBreaker.addEstimateBytesAndMaybeBreak(n, "parquet footer copy");
+        byte[] copy;
+        try {
+            copy = new byte[n];
+            bb.get(copy);
+        } catch (Throwable t) {
+            ioBreaker.addWithoutBreaking(-n);
+            throw t;
+        }
+        AtomicBoolean released = new AtomicBoolean();
+        return new ChargedFooterBytes(copy, () -> {
+            if (released.compareAndSet(false, true)) {
+                ioBreaker.addWithoutBreaking(-n);
+            }
+        }, false);
+    }
+
+    private record ChargedFooterBytes(byte[] bytes, Releasable release, boolean reusedHeapArray) {}
 
     private static IllegalArgumentException invalidParquetShortRead(StorageObject object, int expected, int actual) {
         return invalidParquet(object.path().toString(), "short read of footer: expected " + expected + " bytes, got " + actual);
@@ -1066,24 +1227,43 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
      * byte budget and force a blocking re-read on the executor thread). The bytes are additionally
      * offered to the cache best-effort so a later split-discovery pass can reuse them, but correctness
      * never depends on that. Callers of this listener seed {@link #parsedFooters} after a successful
-     * metadata convert or range extract.
+     * metadata convert or range extract. {@code release} uncharges the GET (or the heap copy) after
+     * parse, success or failure.
      */
     private void parseTailOnExecutor(
         StorageObject object,
         long length,
         byte[] tailBytes,
+        Releasable release,
         FooterByteCache.Key cacheKey,
         Executor executor,
         ActionListener<ParquetMetadata> listener
     ) {
-        executor.execute(() -> {
+        try {
+            executor.execute(() -> {
+                boolean closed = false;
+                try {
+                    footerBytes.put(cacheKey, tailBytes);
+                    ParquetMetadata footer = parseParsedFooterFromTail(object, length, tailBytes);
+                    release.close();
+                    closed = true;
+                    listener.onResponse(footer);
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                } finally {
+                    if (closed == false) {
+                        release.close();
+                    }
+                }
+            });
+        } catch (Exception e) {
             try {
-                footerBytes.put(cacheKey, tailBytes);
-                listener.onResponse(parseParsedFooterFromTail(object, length, tailBytes));
-            } catch (Exception e) {
-                listener.onFailure(e);
+                release.close();
+            } catch (Exception closeEx) {
+                e.addSuppressed(closeEx);
             }
-        });
+            listener.onFailure(e);
+        }
     }
 
     /**
@@ -1092,7 +1272,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
      * {@link #parsedFooters} after a successful {@link #buildFooterMetadata} or
      * {@link #rangesFromFooter} so a convert/extract failure does not occupy an LRU slot.
      * Malformed footers surface as the same invalid-Parquet {@link IllegalArgumentException}
-     * the synchronous path produces.
+     * the synchronous path produces. {@link CircuitBreakingException} and other
+     * {@link ElasticsearchException}s pass through.
      */
     private ParquetMetadata parseParsedFooterFromTail(StorageObject object, long length, byte[] tailBytes) throws IOException {
         TailBackedInputFile inputFile = new TailBackedInputFile(length, tailBytes);
@@ -1102,7 +1283,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
             try {
                 footer = ParquetFileReader.readFooter(inputFile, options, stream);
             } catch (RuntimeException e) {
-                throw newInvalidParquetFileException(object.path().toString(), e);
+                throw rethrowStructuralFooterFailure(object.path().toString(), e);
             }
             validateFooterIntegrity(object.path().toString(), footer.getFileMetaData().getSchema(), footer.getBlocks());
             return footer;
@@ -1238,32 +1419,28 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         public void close() {}
     }
 
-    /** Copies the readable region ({@code position()}..{@code limit()}) of a direct buffer into a heap array. */
-    private static byte[] copyToArray(DirectReadBuffer buffer) {
-        ByteBuffer bb = buffer.buffer().duplicate();
-        byte[] bytes = new byte[bb.remaining()];
-        bb.get(bytes);
-        return bytes;
-    }
-
     /**
-     * Reads the Parquet footer length from a byte array that ends at the file's final byte, i.e. the
-     * last 8 bytes are the trailer {@code [footerLength:int32-le][PAR1]}. Returns {@code -1} when the
-     * trailing magic is absent (foreign/encrypted footer, truncated file) so the async caller can
-     * fail rather than trusting a bogus length. Encrypted {@code PARE} footers take that path.
+     * Reads the Parquet footer length from a buffer that ends at the file's final byte, i.e. the
+     * last 8 readable bytes are the trailer {@code [footerLength:int32-le][PAR1]}. Returns {@code -1}
+     * when the trailing magic is absent (foreign/encrypted footer, truncated file) so the async
+     * caller can fail rather than trusting a bogus length. Encrypted {@code PARE} footers take that
+     * path.
      */
-    private static int footerLengthFromTrailer(byte[] tail) {
-        int n = tail.length;
+    private static int footerLengthFromTrailer(ByteBuffer tail) {
+        ByteBuffer bb = tail.duplicate();
+        int n = bb.remaining();
         if (n < PARQUET_TRAILER_BYTES) {
             return -1;
         }
+        int pos = bb.position();
         for (int i = 0; i < PARQUET_MAGIC.length; i++) {
-            if (tail[n - PARQUET_MAGIC.length + i] != PARQUET_MAGIC[i]) {
+            if (bb.get(pos + n - PARQUET_MAGIC.length + i) != PARQUET_MAGIC[i]) {
                 return -1;
             }
         }
-        int base = n - PARQUET_TRAILER_BYTES;
-        return (tail[base] & 0xFF) | ((tail[base + 1] & 0xFF) << 8) | ((tail[base + 2] & 0xFF) << 16) | ((tail[base + 3] & 0xFF) << 24);
+        int base = pos + n - PARQUET_TRAILER_BYTES;
+        return (bb.get(base) & 0xFF) | ((bb.get(base + 1) & 0xFF) << 8) | ((bb.get(base + 2) & 0xFF) << 16) | ((bb.get(base + 3) & 0xFF)
+            << 24);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1004,21 +1004,22 @@ public class ParquetFormatReaderTests extends ESTestCase {
     }
 
     /**
-     * Trailer {@code F+8} above {@link FooterByteCache#maxEntryBytes()} fails closed: prefetch only,
-     * no exact-range GET of the oversized region, no {@code newStream}.
+     * Trailer {@code F+8} above {@link FooterByteCache#maxEntryBytes()} is still fetched via an
+     * exact-range GET (read-and-discard). Zeros fail inside parquet-mr; the cache is not populated;
+     * {@code newStream} is never used. Cache size is pinned in settings so a tiny test heap cannot
+     * drop {@code maxEntryBytes} to {@code ≤} the 64 KiB prefetch window.
      */
-    public void testAsyncRejectsFooterLargerThanCacheEntryWithoutStream() throws Exception {
-        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+    public void testAsyncReadsFooterLargerThanCacheEntryThenDiscards() throws Exception {
+        // 512 KiB budget → maxEntry = budget/4 = 128 KiB, which is above the 64 KiB prefetch.
+        Settings settings = Settings.builder().put("esql.external.cache.footer.size", "512kb").build();
+        ParquetFormatReader reader = new ParquetFormatReader(settings, blockFactory);
         reader.clearFooterCachesForTests();
         long cap = reader.footerByteCacheForTests().maxEntryBytes();
-        int footerLength = Math.toIntExact(cap + 1);
-        int fileLen = Math.toIntExact((long) footerLength + 8 + 16);
-        byte[] data = new byte[fileLen];
-        ByteBuffer.wrap(data, fileLen - 8, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(footerLength);
-        data[fileLen - 4] = 'P';
-        data[fileLen - 3] = 'A';
-        data[fileLen - 2] = 'R';
-        data[fileLen - 1] = '1';
+        assertEquals(128 * 1024L, cap);
+        int footerRegion = Math.toIntExact(cap + 1);
+        int footerLength = footerRegion - 8;
+        int fileLen = footerRegion + 16;
+        byte[] data = syntheticParquetTail(fileLen, footerLength);
 
         ExecutorService probePool = Executors.newFixedThreadPool(2);
         AtomicInteger asyncReadCount = new AtomicInteger();
@@ -1029,16 +1030,48 @@ public class ParquetFormatReaderTests extends ESTestCase {
             PlainActionFuture<SourceMetadata> meta = new PlainActionFuture<>();
             reader.metadataAsync(asyncObject, probePool, meta);
             Exception metaEx = expectThrows(Exception.class, () -> meta.actionGet(30, TimeUnit.SECONDS));
-            assertThat(ExceptionsHelper.stackTrace(metaEx), containsString("Could not read"));
-            assertThat(ExceptionsHelper.stackTrace(metaEx), containsString("exceeds maximum"));
-            assertEquals("oversized footer must not issue an exact-range GET", 1, asyncReadCount.get());
-            assertThat(reads.get(0)[1], lessThan((long) footerLength + 8));
+            assertThat(ExceptionsHelper.stackTrace(metaEx), not(containsString("exceeds maximum")));
+            assertEquals("oversized-for-cache footer must still issue an exact-range GET", 2, asyncReadCount.get());
+            assertEquals(ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES, reads.get(0)[1]);
+            assertEquals(footerRegion, reads.get(1)[1]);
             assertEquals(0, streamCount.get());
+            assertNull(reader.footerByteCacheForTests().get(FooterByteCache.Key.keyFor(asyncObject)));
 
             PlainActionFuture<List<RangeAwareFormatReader.SplitRange>> ranges = new PlainActionFuture<>();
             reader.discoverSplitRangesAsync(asyncObject, probePool, ranges);
             Exception rangeEx = expectThrows(Exception.class, () -> ranges.actionGet(30, TimeUnit.SECONDS));
-            assertThat(ExceptionsHelper.stackTrace(rangeEx), containsString("exceeds maximum"));
+            assertThat(ExceptionsHelper.stackTrace(rangeEx), not(containsString("exceeds maximum")));
+            assertEquals(4, asyncReadCount.get());
+            assertEquals(0, streamCount.get());
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
+    /**
+     * Trailer {@code F+8} above the sanity GET cap fails before the second GET. Message names the cap.
+     */
+    public void testAsyncRejectsFooterLargerThanSanityGetCapWithoutSecondRead() throws Exception {
+        int cap = 1024;
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, cap);
+        reader.clearFooterCachesForTests();
+        int footerRegion = cap + 1;
+        int footerLength = footerRegion - 8;
+        byte[] data = syntheticParquetTail(footerRegion + 16, footerLength);
+
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        AtomicInteger streamCount = new AtomicInteger();
+        try {
+            StorageObject asyncObject = createAsyncStorageObject(data, probePool, asyncReadCount, null, streamCount);
+            PlainActionFuture<SourceMetadata> meta = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, meta);
+            Exception metaEx = expectThrows(Exception.class, () -> meta.actionGet(30, TimeUnit.SECONDS));
+            Throwable cause = ExceptionsHelper.unwrapCause(metaEx);
+            assertThat(cause, instanceOf(java.lang.IllegalArgumentException.class));
+            assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(cause));
+            assertThat(cause.getMessage(), containsString("exceeds maximum " + cap));
+            assertEquals("sanity-cap reject must not issue an exact-range GET", 1, asyncReadCount.get());
             assertEquals(0, streamCount.get());
         } finally {
             probePool.shutdownNow();
@@ -1391,8 +1424,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
     /**
      * No-buffer-leak (success): every {@link DirectReadBuffer} handed to {@code metadataAsync} —
      * both the tail prefetch and the second full-footer read of a wide footer — must be closed by the
-     * reader once its bytes have been copied out. A file wide enough to force the two-read path
-     * exercises both allocations.
+     * reader after parse. A file wide enough to force the two-read path exercises both allocations.
      */
     public void testMetadataAsyncReleasesBuffersOnSuccess() throws Exception {
         int columns = 2000;
@@ -1417,7 +1449,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             future.actionGet(30, TimeUnit.SECONDS);
 
             assertThat("both reads must allocate a buffer", allocated.get(), equalTo(2));
-            assertEquals("every prefetched buffer must be released after its bytes are copied", 0, openBuffers.get());
+            assertEquals("every prefetched buffer must be released after parse", 0, openBuffers.get());
         } finally {
             probePool.shutdownNow();
         }
@@ -1457,12 +1489,123 @@ public class ParquetFormatReaderTests extends ESTestCase {
     }
 
     /**
-     * Short {@code readBytesAsync} must fail, not fall back to {@code newStream}. The SPI permits
-     * returning fewer bytes than requested; treating those bytes as a file suffix would misalign
-     * every footer offset. The mock returns a short buffer whose trailing 8 bytes forge a
-     * valid-looking Parquet trailer — enough to send an unguarded path into {@code parseTailOnExecutor}
-     * with a misaligned window.
+     * Exact-range GET of {@code F+8} that does not fit the request breaker is a
+     * {@link CircuitBreakingException} (HTTP 429), not an invalid-file 400. Charge returns to 0.
      */
+    public void testMetadataAsyncExactRangeGetTripsBreakerAs429() throws Exception {
+        int footerRegion = 200 * 1024;
+        byte[] data = syntheticParquetTail(footerRegion + 16, footerRegion - 8);
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofBytes(100 * 1024));
+        var limitedFactory = new BlockFactory(breaker, this.blockFactory.bigArrays());
+        ParquetFormatReader reader = new ParquetFormatReader(limitedFactory);
+        reader.clearFooterCachesForTests();
+
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        List<long[]> reads = new CopyOnWriteArrayList<>();
+        try {
+            StorageObject asyncObject = createAsyncStorageObject(data, probePool, asyncReadCount, reads);
+            PlainActionFuture<SourceMetadata> meta = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, meta);
+            Exception metaEx = expectThrows(Exception.class, () -> meta.actionGet(30, TimeUnit.SECONDS));
+            assertThat(metaEx, instanceOf(CircuitBreakingException.class));
+            assertEquals(RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(metaEx));
+            assertEquals(0, breaker.getUsed());
+            assertEquals(2, asyncReadCount.get());
+            assertEquals(ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES, reads.get(0)[1]);
+            assertEquals(footerRegion, reads.get(1)[1]);
+
+            PlainActionFuture<List<RangeAwareFormatReader.SplitRange>> ranges = new PlainActionFuture<>();
+            reader.discoverSplitRangesAsync(asyncObject, probePool, ranges);
+            Exception rangeEx = expectThrows(Exception.class, () -> ranges.actionGet(30, TimeUnit.SECONDS));
+            assertThat(rangeEx, instanceOf(CircuitBreakingException.class));
+            assertEquals(RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(rangeEx));
+            assertEquals(0, breaker.getUsed());
+            assertEquals(4, asyncReadCount.get());
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
+    /**
+     * Successful two-GET wide footer: GET charge and parquet-mr allocator charge return to 0.
+     */
+    public void testMetadataAsyncTwoGetWideFooterReleasesBreaker() throws Exception {
+        int columns = 2000;
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < columns; i++) {
+            builder.optional(PrimitiveType.PrimitiveTypeName.INT64).named("col_" + i);
+        }
+        byte[] parquetData = createParquetFile(builder.named("wide_schema"), factory -> {
+            Group g = factory.newGroup();
+            g.add("col_0", 1L);
+            return List.of(g);
+        });
+
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        var limitedFactory = new BlockFactory(breaker, this.blockFactory.bigArrays());
+        ParquetFormatReader reader = new ParquetFormatReader(limitedFactory);
+        reader.clearFooterCachesForTests();
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        try {
+            StorageObject asyncObject = createAsyncStorageObject(parquetData, probePool, asyncReadCount, null);
+            PlainActionFuture<SourceMetadata> future = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, future);
+            future.actionGet(30, TimeUnit.SECONDS);
+            assertEquals(2, asyncReadCount.get());
+            assertEquals(0, breaker.getUsed());
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
+    /**
+     * GET of {@code F+8} fits, but parquet-mr's {@link CircuitBreakerByteBufferAllocator} trips
+     * during {@code readFooter}. That must stay a {@link CircuitBreakingException} (HTTP 429), not
+     * an invalid-file 400 from {@code parseParsedFooterFromTail}.
+     */
+    public void testMetadataAsyncParseTimeBreakerStays429() throws Exception {
+        int columns = 2000;
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < columns; i++) {
+            builder.optional(PrimitiveType.PrimitiveTypeName.INT64).named("col_" + i);
+        }
+        byte[] parquetData = createParquetFile(builder.named("wide_schema"), factory -> {
+            Group g = factory.newGroup();
+            g.add("col_0", 1L);
+            return List.of(g);
+        });
+        int footerRegion = parquetFooterRegion(parquetData);
+        assertThat(
+            "fixture must take the two-GET path so the exact-range GET is what fills the breaker",
+            (long) footerRegion,
+            greaterThan((long) ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES)
+        );
+
+        // Limit equals F+8: prefetch (64 KiB) and the exact GET both fit; the next parquet-mr
+        // allocate during readFooter does not.
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofBytes(footerRegion));
+        var limitedFactory = new BlockFactory(breaker, this.blockFactory.bigArrays());
+        ParquetFormatReader reader = new ParquetFormatReader(limitedFactory);
+        reader.clearFooterCachesForTests();
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        try {
+            StorageObject asyncObject = createAsyncStorageObject(parquetData, probePool, asyncReadCount, null);
+            PlainActionFuture<SourceMetadata> meta = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, meta);
+            Exception metaEx = expectThrows(Exception.class, () -> meta.actionGet(30, TimeUnit.SECONDS));
+            assertThat(metaEx, instanceOf(CircuitBreakingException.class));
+            assertEquals(RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(metaEx));
+            assertThat(ExceptionsHelper.stackTrace(metaEx), not(containsString("Could not read")));
+            assertEquals(2, asyncReadCount.get());
+            assertEquals(0, breaker.getUsed());
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
     public void testMetadataAsyncShortReadDoesNotFallBackToStream() throws Exception {
         MessageType schema = Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.INT64)
@@ -1520,7 +1663,24 @@ public class ParquetFormatReaderTests extends ESTestCase {
                     ActionListener<DirectReadBuffer> listener
                 ) {
                     asyncReadCount.incrementAndGet();
-                    probePool.execute(() -> listener.onResponse(new DirectReadBuffer(ByteBuffer.wrap(shortBuffer), () -> {})));
+                    probePool.execute(() -> {
+                        DirectReadBuffer drb = null;
+                        try {
+                            drb = factory.allocateWritableWindow((int) length);
+                            ByteBuffer buf = drb.buffer();
+                            int n = Math.min(shortBuffer.length, buf.remaining());
+                            buf.put(shortBuffer, 0, n);
+                            buf.position(0).limit(n);
+                            DirectReadBuffer delivered = drb;
+                            drb = null;
+                            listener.onResponse(delivered);
+                        } catch (Exception e) {
+                            if (drb != null) {
+                                drb.close();
+                            }
+                            listener.onFailure(e);
+                        }
+                    });
                 }
 
                 @Override
@@ -6452,6 +6612,49 @@ public class ParquetFormatReaderTests extends ESTestCase {
         };
     }
 
+    /** Trailer {@code F+8} from the last eight bytes of a Parquet file. */
+    private static int parquetFooterRegion(byte[] parquet) {
+        int footerLength = ByteBuffer.wrap(parquet, parquet.length - 8, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        return footerLength + 8;
+    }
+
+    /** Trailing {@code PAR1} plus little-endian footer length; rest zeros. */
+    private static byte[] syntheticParquetTail(int fileLen, int footerLength) {
+        byte[] data = new byte[fileLen];
+        ByteBuffer.wrap(data, fileLen - 8, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(footerLength);
+        data[fileLen - 4] = 'P';
+        data[fileLen - 3] = 'A';
+        data[fileLen - 2] = 'R';
+        data[fileLen - 1] = '1';
+        return data;
+    }
+
+    /**
+     * Allocates through {@code factory} (so a {@link LimitedBreaker} can trip) and fills a suffix of
+     * {@code data}. The delivered buffer has {@code remaining()} equal to the bytes copied, matching
+     * the {@link StorageObject#readBytesAsync} contract.
+     */
+    private static DirectReadBuffer allocateFilledWindow(byte[] data, long position, long length, DirectBufferFactory factory)
+        throws IOException {
+        int pos = (int) position;
+        int len = (int) Math.min(length, Math.max(0, (long) data.length - pos));
+        DirectReadBuffer drb = factory.allocateWritableWindow((int) length);
+        try {
+            ByteBuffer buf = drb.buffer();
+            if (len > 0) {
+                buf.put(data, pos, len);
+            }
+            buf.position(0).limit(len);
+            DirectReadBuffer delivered = drb;
+            drb = null;
+            return delivered;
+        } finally {
+            if (drb != null) {
+                drb.close();
+            }
+        }
+    }
+
     private static StorageObject createAsyncStorageObject(
         byte[] data,
         ExecutorService pool,
@@ -6509,11 +6712,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
                 }
                 pool.execute(() -> {
                     try {
-                        int pos = (int) position;
-                        int len = (int) Math.min(length, data.length - position);
-                        byte[] slice = new byte[len];
-                        System.arraycopy(data, pos, slice, 0, len);
-                        listener.onResponse(new DirectReadBuffer(ByteBuffer.wrap(slice), () -> {}));
+                        listener.onResponse(allocateFilledWindow(data, position, length, factory));
                     } catch (Exception e) {
                         listener.onFailure(e);
                     }
@@ -6584,13 +6783,16 @@ public class ParquetFormatReaderTests extends ESTestCase {
                         return;
                     }
                     try {
-                        int pos = (int) position;
-                        int len = (int) Math.min(length, data.length - position);
-                        byte[] slice = new byte[len];
-                        System.arraycopy(data, pos, slice, 0, len);
+                        DirectReadBuffer inner = allocateFilledWindow(data, position, length, factory);
                         allocated.incrementAndGet();
                         openBuffers.incrementAndGet();
-                        listener.onResponse(new DirectReadBuffer(ByteBuffer.wrap(slice), openBuffers::decrementAndGet));
+                        listener.onResponse(new DirectReadBuffer(inner.buffer(), () -> {
+                            try {
+                                inner.close();
+                            } finally {
+                                openBuffers.decrementAndGet();
+                            }
+                        }));
                     } catch (Exception e) {
                         listener.onFailure(e);
                     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1049,6 +1049,61 @@ public class ParquetFormatReaderTests extends ESTestCase {
     }
 
     /**
+     * Valid footer with {@code F+8} above {@link FooterByteCache#maxEntryBytes()} parses, metadata
+     * succeeds, the byte cache stays empty ({@code put} skips), and a second {@code metadataAsync}
+     * is a parsed-cache hit with no further GETs.
+     */
+    public void testAsyncReadsValidFooterLargerThanCacheEntryThenHitsParsedCache() throws Exception {
+        int columns = 2000;
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < columns; i++) {
+            builder.optional(PrimitiveType.PrimitiveTypeName.INT64).named("col_" + i);
+        }
+        byte[] parquetData = createParquetFile(builder.named("wide_schema"), factory -> {
+            Group g = factory.newGroup();
+            g.add("col_0", 1L);
+            return List.of(g);
+        });
+        int footerRegion = parquetFooterRegion(parquetData);
+        // 256 KiB budget → maxEntry = 64 KiB, at the prefetch window so a wide footer is over cap.
+        Settings settings = Settings.builder().put("esql.external.cache.footer.size", "256kb").build();
+        ParquetFormatReader reader = new ParquetFormatReader(settings, blockFactory);
+        reader.clearFooterCachesForTests();
+        long cap = reader.footerByteCacheForTests().maxEntryBytes();
+        assertEquals(64 * 1024L, cap);
+        assertThat("fixture must exceed byte-cache admission and take the two-GET path", (long) footerRegion, greaterThan(cap));
+        assertThat((long) footerRegion, greaterThan((long) ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES));
+
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        AtomicInteger streamCount = new AtomicInteger();
+        try {
+            StorageObject asyncObject = createAsyncStorageObject(parquetData, probePool, asyncReadCount, null, streamCount);
+            FooterByteCache.Key key = FooterByteCache.Key.keyFor(asyncObject);
+            PlainActionFuture<SourceMetadata> meta = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, meta);
+            SourceMetadata first = meta.actionGet(30, TimeUnit.SECONDS);
+            assertEquals(columns, first.schema().size());
+            assertEquals(2, asyncReadCount.get());
+            assertEquals(0, streamCount.get());
+            assertNull(reader.footerByteCacheForTests().get(key));
+            ParquetMetadata parsed = reader.parsedFooterForTests(key);
+            assertNotNull(parsed);
+
+            PlainActionFuture<SourceMetadata> again = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, again);
+            SourceMetadata second = again.actionGet(30, TimeUnit.SECONDS);
+            assertEquals(first.schema().size(), second.schema().size());
+            assertEquals("parsed-cache hit must not issue another GET", 2, asyncReadCount.get());
+            assertEquals(0, streamCount.get());
+            assertNull(reader.footerByteCacheForTests().get(key));
+            assertSame(parsed, reader.parsedFooterForTests(key));
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
+    /**
      * Trailer {@code F+8} above the sanity GET cap fails before the second GET. Message names the cap.
      */
     public void testAsyncRejectsFooterLargerThanSanityGetCapWithoutSecondRead() throws Exception {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
@@ -63,11 +63,11 @@ import java.util.concurrent.ExecutionException;
 public class FooterByteCache {
 
     /**
-     * Default max single-entry admission (4 MiB). Oversized footers may still be returned to the
+     * Default max single-entry admission (2 MiB). Oversized footers may still be returned to the
      * caller; {@link #put} skips them and {@link #getOrLoad} evicts them so they do not occupy the
      * LRU. This is not a read limit.
      */
-    public static final long DEFAULT_MAX_ENTRY_BYTES = 4L * 1024 * 1024;
+    public static final long DEFAULT_MAX_ENTRY_BYTES = 2L * 1024 * 1024;
 
     /**
      * Cache key identifying a file by its storage path and total length. Uses {@code (path, length)}
@@ -111,7 +111,7 @@ public class FooterByteCache {
      */
     public static FooterByteCache fromSettings(Settings settings) {
         long maxBytes = ExternalSourceCacheSettings.FOOTER_CACHE_SIZE.get(settings).getBytes();
-        // The budget is heap-relative, so on small heaps a fixed 4 MiB ceiling would let a single
+        // The budget is heap-relative, so on small heaps a fixed 2 MiB ceiling would let a single
         // entry evict most of the cache. Never admit an entry larger than a quarter of the budget.
         long maxEntryBytes = Math.max(1L, Math.min(DEFAULT_MAX_ENTRY_BYTES, maxBytes / 4));
         return new FooterByteCache(maxBytes, maxEntryBytes, ExternalSourceCacheSettings.FOOTER_CACHE_TTL.get(settings));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
@@ -62,8 +62,12 @@ import java.util.concurrent.ExecutionException;
  */
 public class FooterByteCache {
 
-    /** Default max single entry (2 MiB). Prevents caching unusually large footers. */
-    public static final long DEFAULT_MAX_ENTRY_BYTES = 2L * 1024 * 1024;
+    /**
+     * Default max single-entry admission (4 MiB). Oversized footers may still be returned to the
+     * caller; {@link #put} skips them and {@link #getOrLoad} evicts them so they do not occupy the
+     * LRU. This is not a read limit.
+     */
+    public static final long DEFAULT_MAX_ENTRY_BYTES = 4L * 1024 * 1024;
 
     /**
      * Cache key identifying a file by its storage path and total length. Uses {@code (path, length)}
@@ -107,7 +111,7 @@ public class FooterByteCache {
      */
     public static FooterByteCache fromSettings(Settings settings) {
         long maxBytes = ExternalSourceCacheSettings.FOOTER_CACHE_SIZE.get(settings).getBytes();
-        // The budget is heap-relative, so on small heaps a fixed 2 MiB ceiling would let a single
+        // The budget is heap-relative, so on small heaps a fixed 4 MiB ceiling would let a single
         // entry evict most of the cache. Never admit an entry larger than a quarter of the budget.
         long maxEntryBytes = Math.max(1L, Math.min(DEFAULT_MAX_ENTRY_BYTES, maxBytes / 4));
         return new FooterByteCache(maxBytes, maxEntryBytes, ExternalSourceCacheSettings.FOOTER_CACHE_TTL.get(settings));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCacheTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCacheTests.java
@@ -202,7 +202,7 @@ public class FooterByteCacheTests extends ESTestCase {
     }
 
     public void testFromSettingsClampsMaxEntryToBudgetFraction() {
-        // The budget is heap-relative, so a fixed 4 MiB entry ceiling would let one entry evict
+        // The budget is heap-relative, so a fixed 2 MiB entry ceiling would let one entry evict
         // nearly the whole cache on a small heap. Entries are capped at a quarter of the budget.
         Settings settings = Settings.builder().put("esql.external.cache.footer.size", "1mb").build();
         FooterByteCache small = FooterByteCache.fromSettings(settings);
@@ -213,7 +213,7 @@ public class FooterByteCacheTests extends ESTestCase {
         Settings settings = Settings.builder().put("esql.external.cache.footer.size", "32mb").build();
         FooterByteCache large = FooterByteCache.fromSettings(settings);
         assertEquals(FooterByteCache.DEFAULT_MAX_ENTRY_BYTES, large.maxEntryBytes());
-        assertEquals(4L * 1024 * 1024, large.maxEntryBytes());
+        assertEquals(2L * 1024 * 1024, large.maxEntryBytes());
     }
 
     public void testNonPositiveBudgetIsRejectedAtSettingsParseTime() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCacheTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCacheTests.java
@@ -202,11 +202,18 @@ public class FooterByteCacheTests extends ESTestCase {
     }
 
     public void testFromSettingsClampsMaxEntryToBudgetFraction() {
-        // The budget is heap-relative, so a fixed 2 MiB entry ceiling would let one entry evict
+        // The budget is heap-relative, so a fixed 4 MiB entry ceiling would let one entry evict
         // nearly the whole cache on a small heap. Entries are capped at a quarter of the budget.
         Settings settings = Settings.builder().put("esql.external.cache.footer.size", "1mb").build();
         FooterByteCache small = FooterByteCache.fromSettings(settings);
         assertEquals(256 * 1024L, small.maxEntryBytes());
+    }
+
+    public void testFromSettingsClampsMaxEntryToDefaultWhenBudgetIsLarge() {
+        Settings settings = Settings.builder().put("esql.external.cache.footer.size", "32mb").build();
+        FooterByteCache large = FooterByteCache.fromSettings(settings);
+        assertEquals(FooterByteCache.DEFAULT_MAX_ENTRY_BYTES, large.maxEntryBytes());
+        assertEquals(4L * 1024 * 1024, large.maxEntryBytes());
     }
 
     public void testNonPositiveBudgetIsRejectedAtSettingsParseTime() {


### PR DESCRIPTION
Oversized footers were rejected as invalid files. Fetch F+8,
parse, then skip cache put. 16 MiB sanity cap stays 400;
breaker trips stay 429.