### PR TITLE
[8.19] [ESQL] Do not reverse crlf (#158745)

### DIFF
--- a/docs/changelog/158745.yaml
+++ b/docs/changelog/158745.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158745
+summary: When reversing strings, treat Carriage Return Line Feed as a single control character, in line with UTF guidelines
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
@@ -109,6 +109,11 @@ public class Reverse extends UnaryScalarFunction {
             ) {
                 return false;
             }
+            // A carriage return followed by a line feed is a single grapheme cluster, so reversing
+            // the bytes would wrongly split it into "\n\r". Fall back to the grapheme-aware path.
+            if (ref.bytes[i] == '\r' && i + 1 < end && ref.bytes[i + 1] == '\n') {
+                return false;
+            }
         }
         return true;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReverseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReverseTests.java
@@ -47,6 +47,12 @@ public class ReverseTests extends AbstractScalarFunctionTestCase {
         return new Reverse(source, args.get(0));
     }
 
+    public void testReverseKeepsCarriageReturnLineFeedTogether() {
+        // "\r\n" is a single grapheme cluster. Even though the input is single-byte and would
+        // otherwise take the byte-reversal fast path, reversing must keep "\r\n" intact rather than flip it to "\n\r".
+        assertThat(Reverse.process(new BytesRef("foo\r\nbar")).utf8ToString(), equalTo("rab\r\noof"));
+    }
+
     private static TestCaseSupplier makeSupplier(TestCaseSupplier.TypedDataSupplier fieldSupplier) {
         return new TestCaseSupplier(fieldSupplier.name(), List.of(fieldSupplier.type()), () -> {
             var fieldTypedData = fieldSupplier.get();


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ESQL] Do not reverse crlf (#158745)