### PR TITLE
[Docs] Document ServiceNow expand_role_members setting (8.19)

### DIFF
--- a/docs/reference/connector/docs/connectors-servicenow.asciidoc
+++ b/docs/reference/connector/docs/connectors-servicenow.asciidoc
@@ -96,6 +96,14 @@ Enable document level security::
 Restrict access to documents based on a user's permissions.
 Refer to <<es-connectors-servicenow-dls>> for more details.
 
+Expand role members::
+Available when document level security is enabled.
+When enabled, ServiceNow role members are written individually onto each document's access control list.
+Disable this for large tenants to store compact `role_id:` tokens on documents instead; membership is resolved during access control syncs.
+Default value is `true`.
+Changing this setting requires a full content sync and access control sync.
+Introduced in 8.19.22.
+
 [discrete#es-connectors-servicenow-documents-syncs]
 ===== Documents and syncs
 
@@ -143,6 +151,10 @@ For default services, connectors use the following roles to find users who have 
 |===
 
 For services other than these defaults, the connector iterates over access controls with `read` operations and finds the respective roles for those services.
+
+When **Expand role members** is disabled, content documents store compact `role_id:` tokens instead of individual user identifiers.
+Access control syncs enrich identity documents with role memberships from `sys_user_has_role` so DLS term overlap still resolves access.
+Tables with no read ACL entries or with a `public` read role omit `_allow_access_control`, making documents world-readable through DLS.
 
 [IMPORTANT]
 ====
@@ -338,6 +350,14 @@ Default value is `False`.
 Restrict access to documents based on a user's permissions.
 Refer to <<es-connectors-servicenow-client-dls>> for more details.
 
+`expand_role_members`::
+Available when document level security is enabled.
+When enabled, ServiceNow role members are written individually onto each document's access control list.
+Disable this for large tenants to store compact `role_id:` tokens on documents instead; membership is resolved during access control syncs.
+Default value is `True`.
+Changing this setting requires a full content sync and access control sync.
+Introduced in 8.19.22.
+
 [discrete#es-connectors-servicenow-client-documents-syncs]
 ===== Documents and syncs
 
@@ -385,6 +405,10 @@ For default services, connectors use the following roles to find users who have 
 |===
 
 For services other than these defaults, the connector iterates over access controls with `read` operations and finds the respective roles for those services.
+
+When **Expand role members** is disabled, content documents store compact `role_id:` tokens instead of individual user identifiers.
+Access control syncs enrich identity documents with role memberships from `sys_user_has_role` so DLS term overlap still resolves access.
+Tables with no read ACL entries or with a `public` read role omit `_allow_access_control`, making documents world-readable through DLS.
 
 [IMPORTANT]
 ====

--- a/docs/reference/connector/docs/connectors-servicenow.asciidoc
+++ b/docs/reference/connector/docs/connectors-servicenow.asciidoc
@@ -99,7 +99,8 @@ Refer to <<es-connectors-servicenow-dls>> for more details.
 Expand role members::
 Available when document level security is enabled.
 When enabled, ServiceNow role members are written individually onto each document's access control list.
-Disable this for large tenants to store compact `role_id:` tokens on documents instead; membership is resolved during access control syncs.
+For large tenants, turn this off to store compact `role_id:` tokens on documents instead.
+Membership is resolved during access control syncs.
 Default value is `true`.
 Changing this setting requires a full content sync and access control sync.
 Introduced in 8.19.22.
@@ -353,7 +354,8 @@ Refer to <<es-connectors-servicenow-client-dls>> for more details.
 `expand_role_members`::
 Available when document level security is enabled.
 When enabled, ServiceNow role members are written individually onto each document's access control list.
-Disable this for large tenants to store compact `role_id:` tokens on documents instead; membership is resolved during access control syncs.
+For large tenants, turn this off to store compact `role_id:` tokens on documents instead.
+Membership is resolved during access control syncs.
 Default value is `True`.
 Changing this setting requires a full content sync and access control sync.
 Introduced in 8.19.22.


### PR DESCRIPTION
Backport of #158796 to `8.19`.

Documents the `expand_role_members` configuration field from [elastic/connectors#4392](https://github.com/elastic/connectors/pull/4392) and [elastic/kibana#288071](https://github.com/elastic/kibana/pull/288071).

Part of [elastic/chat-program#47](https://github.com/elastic/chat-program/issues/47).

Because `8.19` uses legacy asciidoc docs (with separate managed/native and self-managed configuration sections), the field is documented in **both** sections of `connectors-servicenow.asciidoc`:
- Managed (native) section: **Expand role members** UI toggle
- Self-managed section: `expand_role_members` config key

Both sections also describe compact role-based DLS behavior in **Document level security**. Introduced in 8.19.22.

Docs-only change; no code or console snippets affected.

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [ ] If submitting code, have you built your formula locally prior to submission with `gradle check`? (N/A — docs-only change)
- [ ] If submitting code, is your pull request against main? (This is a backport of #158796 to 8.19.)
- [x] If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?