### PR TITLE
Optimize FlatBytesRefPartitionedHashKeys for fixed-length keys

### DIFF
--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
@@ -1131,20 +1131,24 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
                 }
                 final int base = p * PARTITION_WRITE_BATCH;
                 final int keyBase = partitionCounts[p];
-                if (fixedLength < 0) {
-                    ensureOffsetCapacity(breaker, p, keyBase + c + 1);
-                }
-                for (int i = 0; i < c; i++) {
-                    final int id = idOffset + (positions[base + i] & 0xFFFF);
-                    bytesRefs.get(id, scratch);
-                    ensureDataCapacity(breaker, p, partitionDataUsed[p] + scratch.length);
-                    if (fixedLength < 0) {
-                        partitionOffsets[p][keyBase + i] = partitionDataUsed[p];
+                if (fixedLength >= 0) {
+                    for (int i = 0; i < c; i++) {
+                        final int id = idOffset + (positions[base + i] & 0xFFFF);
+                        bytesRefs.get(id, scratch);
+                        ensureDataCapacity(breaker, p, partitionDataUsed[p] + scratch.length);
+                        System.arraycopy(scratch.bytes, scratch.offset, partitionData[p], partitionDataUsed[p], scratch.length);
+                        partitionDataUsed[p] += scratch.length;
                     }
-                    System.arraycopy(scratch.bytes, scratch.offset, partitionData[p], partitionDataUsed[p], scratch.length);
-                    partitionDataUsed[p] += scratch.length;
-                }
-                if (fixedLength < 0) {
+                } else {
+                    ensureOffsetCapacity(breaker, p, keyBase + c + 1);
+                    for (int i = 0; i < c; i++) {
+                        final int id = idOffset + (positions[base + i] & 0xFFFF);
+                        bytesRefs.get(id, scratch);
+                        ensureDataCapacity(breaker, p, partitionDataUsed[p] + scratch.length);
+                        partitionOffsets[p][keyBase + i] = partitionDataUsed[p];
+                        System.arraycopy(scratch.bytes, scratch.offset, partitionData[p], partitionDataUsed[p], scratch.length);
+                        partitionDataUsed[p] += scratch.length;
+                    }
                     partitionOffsets[p][keyBase + c] = partitionDataUsed[p];
                 }
             }
@@ -1177,13 +1181,13 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
             final byte[] data = partitionData[partition];
             if (data != null) {
                 partitionData[partition] = null;
-                long freed = data.length;
+                long bytes = data.length;
                 if (partitionOffsets != null) {
                     final int[] offsets = partitionOffsets[partition];
                     partitionOffsets[partition] = null;
-                    freed += (long) offsets.length * Integer.BYTES;
+                    bytes += (long) offsets.length * Integer.BYTES;
                 }
-                breaker.addWithoutBreaking(-freed);
+                breaker.addWithoutBreaking(-bytes);
             }
         }
 

--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
@@ -128,7 +128,7 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      * Creates a new {@link BytesRefSwissHash} that manages its own {@link BytesRefArray}.
      */
     BytesRefSwissHash(PageCacheRecycler recycler, CircuitBreaker breaker, BigArrays bigArrays) {
-        this(recycler, breaker, bigArrays, new BytesRefArray(PageCacheRecycler.PAGE_SIZE_IN_BYTES, bigArrays), true, PAGED_PARTITION_THRESHOLD_BYTES);
+        this(recycler, breaker, bigArrays, PAGED_PARTITION_THRESHOLD_BYTES);
     }
 
     /**

--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
@@ -128,14 +128,7 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      * Creates a new {@link BytesRefSwissHash} that manages its own {@link BytesRefArray}.
      */
     BytesRefSwissHash(PageCacheRecycler recycler, CircuitBreaker breaker, BigArrays bigArrays) {
-        this(
-            recycler,
-            breaker,
-            bigArrays,
-            new BytesRefArray(PageCacheRecycler.PAGE_SIZE_IN_BYTES, bigArrays),
-            true,
-            PAGED_PARTITION_THRESHOLD_BYTES
-        );
+        this(recycler, breaker, bigArrays, new BytesRefArray(PageCacheRecycler.PAGE_SIZE_IN_BYTES, bigArrays), true, PAGED_PARTITION_THRESHOLD_BYTES);
     }
 
     /**
@@ -448,6 +441,20 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
             for (int i = 0; i < len; i++) {
                 key.offset = offsets[i];
                 key.length = offsets[i + 1] - offsets[i];
+                final long hash = hash64(key);
+                final int id = add(key, hash);
+                ids[i] = id >= 0 ? id : -1 - id;
+            }
+            return size == preSize + len;
+        }
+
+        boolean mergeKeys(byte[] data, int fixedLength, int len, int[] ids) {
+            final BytesRef key = new BytesRef();
+            key.bytes = data;
+            key.length = fixedLength;
+            final int preSize = size;
+            for (int i = 0; i < len; i++) {
+                key.offset = i * fixedLength;
                 final long hash = hash64(key);
                 final int id = add(key, hash);
                 ids[i] = id >= 0 ? id : -1 - id;
@@ -822,6 +829,31 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
             return size == preSize + len;
         }
 
+        boolean mergeKeys(byte[] data, int fixedLength, int len, int[] ids) {
+            final BytesRef key = new BytesRef();
+            key.bytes = data;
+            key.length = fixedLength;
+            final int preSize = size;
+            if (preSize == 0) {
+                for (int id = 0; id < len; id++) {
+                    key.offset = id * fixedLength;
+                    final long hash64 = hash64(key);
+                    insert(hash(hash64), control(hash64), (int) bytesRefs.size());
+                    bytesRefs.append(key);
+                    ids[id] = id;
+                }
+                size = len;
+                return true;
+            }
+            for (int i = 0; i < len; i++) {
+                key.offset = i * fixedLength;
+                final long hash64 = hash64(key);
+                final int id = addImpl(key, hash64);
+                ids[i] = id >= 0 ? id : -1 - id;
+            }
+            return size == preSize + len;
+        }
+
         void clear() {
             Arrays.fill(controlData, EMPTY);
             insertProbes = 0;
@@ -960,7 +992,7 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
         assert ownsBytesRefs : "splitPartition is only valid when this hash owns its BytesRefArray; ids are non-consecutive when shared";
         final long totalKeyBytes = bytesRefs.totalBytes();
         final BytesRefPartitionedHashKeys partitionedKeys = totalKeyBytes <= pagedPartitionBytesThreshold
-            ? new FlatBytesRefPartitionedHashKeys(breaker, size, totalKeyBytes)
+            ? new FlatBytesRefPartitionedHashKeys(breaker, size, totalKeyBytes, bytesRefs.fixedLength())
             : new PagedBytesRefPartitionedHashKeys(bigArrays, size, totalKeyBytes);
         final int[] partitionOffsets = partitionedKeys.partitionCounts;
         boolean success = false;
@@ -1005,6 +1037,11 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
         ensureCapacity(needed);
         if (keys instanceof FlatBytesRefPartitionedHashKeys flat) {
             assert flat.partitionData[partitionIndex] != null : "partition [" + partitionIndex + "] was already released";
+            if (flat.fixedLength >= 0) {
+                return smallCore != null
+                    ? smallCore.mergeKeys(flat.partitionData[partitionIndex], flat.fixedLength, keysInPartition, resultIds)
+                    : bigCore.mergeKeys(flat.partitionData[partitionIndex], flat.fixedLength, keysInPartition, resultIds);
+            }
             if (smallCore != null) {
                 return smallCore.mergeKeys(
                     flat.partitionData[partitionIndex],
@@ -1052,24 +1089,35 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
     }
 
     static final class FlatBytesRefPartitionedHashKeys extends BytesRefPartitionedHashKeys {
+        final int fixedLength;
         final int[] partitionDataUsed;
         byte[][] partitionData;
         int[][] partitionOffsets;
 
-        FlatBytesRefPartitionedHashKeys(CircuitBreaker breaker, int totalKeys, long totalKeyBytes) {
+        FlatBytesRefPartitionedHashKeys(CircuitBreaker breaker, int totalKeys, long totalKeyBytes, int fixedLength) {
+            this.fixedLength = fixedLength;
             final int avgKeysPerPartition = Math.max(Math.ceilDiv(totalKeys, NUM_PARTITIONS), 1);
             final int avgBytesPerPartition = (int) Math.ceilDiv(totalKeyBytes, NUM_PARTITIONS);
             final int initialBytes = ArrayUtil.oversize(avgBytesPerPartition, 1);
-            final int initialOffsets = ArrayUtil.oversize(avgKeysPerPartition + 1, Integer.BYTES);
-            long usedBytes = (long) NUM_PARTITIONS * Integer.BYTES + (long) NUM_PARTITIONS * initialBytes + (long) NUM_PARTITIONS
-                * initialOffsets * Integer.BYTES;
-            breaker.addEstimateBytesAndMaybeBreak(usedBytes, "BytesRefSwissHash#partition");
             partitionDataUsed = new int[NUM_PARTITIONS];
             partitionData = new byte[NUM_PARTITIONS][];
-            partitionOffsets = new int[NUM_PARTITIONS][];
-            for (int p = 0; p < NUM_PARTITIONS; p++) {
-                partitionData[p] = new byte[initialBytes];
-                partitionOffsets[p] = new int[initialOffsets];
+            if (fixedLength < 0) {
+                final int initialOffsets = ArrayUtil.oversize(avgKeysPerPartition + 1, Integer.BYTES);
+                long usedBytes = (long) NUM_PARTITIONS * Integer.BYTES + (long) NUM_PARTITIONS * initialBytes + (long) NUM_PARTITIONS
+                    * initialOffsets * Integer.BYTES;
+                breaker.addEstimateBytesAndMaybeBreak(usedBytes, "BytesRefSwissHash#partition");
+                partitionOffsets = new int[NUM_PARTITIONS][];
+                for (int p = 0; p < NUM_PARTITIONS; p++) {
+                    partitionData[p] = new byte[initialBytes];
+                    partitionOffsets[p] = new int[initialOffsets];
+                }
+            } else {
+                long usedBytes = (long) NUM_PARTITIONS * Integer.BYTES + (long) NUM_PARTITIONS * initialBytes;
+                breaker.addEstimateBytesAndMaybeBreak(usedBytes, "BytesRefSwissHash#partition");
+                partitionOffsets = null;
+                for (int p = 0; p < NUM_PARTITIONS; p++) {
+                    partitionData[p] = new byte[initialBytes];
+                }
             }
         }
 
@@ -1083,16 +1131,22 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
                 }
                 final int base = p * PARTITION_WRITE_BATCH;
                 final int keyBase = partitionCounts[p];
-                ensureOffsetCapacity(breaker, p, keyBase + c + 1);
+                if (fixedLength < 0) {
+                    ensureOffsetCapacity(breaker, p, keyBase + c + 1);
+                }
                 for (int i = 0; i < c; i++) {
                     final int id = idOffset + (positions[base + i] & 0xFFFF);
                     bytesRefs.get(id, scratch);
                     ensureDataCapacity(breaker, p, partitionDataUsed[p] + scratch.length);
-                    partitionOffsets[p][keyBase + i] = partitionDataUsed[p];
+                    if (fixedLength < 0) {
+                        partitionOffsets[p][keyBase + i] = partitionDataUsed[p];
+                    }
                     System.arraycopy(scratch.bytes, scratch.offset, partitionData[p], partitionDataUsed[p], scratch.length);
                     partitionDataUsed[p] += scratch.length;
                 }
-                partitionOffsets[p][keyBase + c] = partitionDataUsed[p];
+                if (fixedLength < 0) {
+                    partitionOffsets[p][keyBase + c] = partitionDataUsed[p];
+                }
             }
         }
 
@@ -1122,10 +1176,14 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
         public void releasePartition(CircuitBreaker breaker, int partition) {
             final byte[] data = partitionData[partition];
             if (data != null) {
-                final int[] offsets = partitionOffsets[partition];
                 partitionData[partition] = null;
-                partitionOffsets[partition] = null;
-                breaker.addWithoutBreaking(-data.length - (long) offsets.length * Integer.BYTES);
+                long freed = data.length;
+                if (partitionOffsets != null) {
+                    final int[] offsets = partitionOffsets[partition];
+                    partitionOffsets[partition] = null;
+                    freed += (long) offsets.length * Integer.BYTES;
+                }
+                breaker.addWithoutBreaking(-freed);
             }
         }
 
@@ -1137,9 +1195,11 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
                 if (data != null) {
                     bytes += data.length;
                 }
-                final int[] offsets = partitionOffsets[p];
-                if (offsets != null) {
-                    bytes += (long) offsets.length * Integer.BYTES;
+                if (partitionOffsets != null) {
+                    final int[] offsets = partitionOffsets[p];
+                    if (offsets != null) {
+                        bytes += (long) offsets.length * Integer.BYTES;
+                    }
                 }
             }
             partitionData = null;

--- a/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashPartitionTests.java
+++ b/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashPartitionTests.java
@@ -45,13 +45,8 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
         var recycler = new BytesRefSwissHashTests.TestRecycler();
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(100)).withCircuitBreaking();
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-        runPartitionTest(
-            recycler,
-            bigArrays,
-            breaker,
-            BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
-            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES
-        );
+        runPartitionTest(recycler, bigArrays, breaker, BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
+            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES, false);
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 
@@ -59,13 +54,8 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
         var recycler = new BytesRefSwissHashTests.TestRecycler();
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(100)).withCircuitBreaking();
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-        runPartitionTestFixedLength(
-            recycler,
-            bigArrays,
-            breaker,
-            BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
-            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES
-        );
+        runPartitionTest(recycler, bigArrays, breaker, BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
+            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES, true);
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 
@@ -73,67 +63,8 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
         var recycler = new BytesRefSwissHashTests.TestRecycler();
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(100)).withCircuitBreaking();
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-        runPartitionTest(recycler, bigArrays, breaker, BytesRefSwissHash.PagedBytesRefPartitionedHashKeys.class, 0L);
+        runPartitionTest(recycler, bigArrays, breaker, BytesRefSwissHash.PagedBytesRefPartitionedHashKeys.class, 0L, false);
         assertThat(breaker.getUsed(), equalTo(0L));
-    }
-
-    private void runPartitionTestFixedLength(
-        BytesRefSwissHashTests.TestRecycler recycler,
-        BigArrays bigArrays,
-        CircuitBreaker breaker,
-        Class<? extends BytesRefSwissHash.BytesRefPartitionedHashKeys> expectedType,
-        long pagedPartitionBytesThreshold
-    ) {
-        final int keyLength = randomIntBetween(1, 32);
-        final int partitionSize = randomIntBetween(128, 10 * 1024);
-        var hash1 = new BytesRefSwissHash(recycler, breaker, bigArrays, pagedPartitionBytesThreshold);
-        SumAgg agg1 = new SumAgg(breaker);
-        var hash2 = new BytesRefSwissHash(recycler, breaker, bigArrays, pagedPartitionBytesThreshold);
-        SumAgg agg2 = new SumAgg(breaker);
-        List<PartitionedKeyAndAggs> gens = new ArrayList<>();
-        try {
-            int numBlocks = between(1, 1000);
-            for (int i = 0; i < numBlocks; i++) {
-                final int positions = between(1, 2048);
-                final BytesRef[] keys = new BytesRef[positions];
-                for (int v = 0; v < positions; v++) {
-                    final byte[] bytes = new byte[keyLength];
-                    random().nextBytes(bytes);
-                    keys[v] = new BytesRef(bytes);
-                }
-                final int[] values = new int[positions];
-                for (int v = 0; v < positions; v++) {
-                    values[v] = randomIntBetween(-1000, 1000);
-                }
-                addInput(hash1, agg1, keys, values);
-                addInput(hash2, agg2, keys, values);
-
-                if (hash2.size() >= partitionSize) {
-                    PartitionedKeyAndAggs gen = partition(breaker, hash2, hash2.size, agg2);
-                    assertThat(gen.keys(), instanceOf(expectedType));
-                    gens.add(gen);
-                    hash2.clear();
-                    agg2.clear();
-                }
-            }
-            if (hash2.size > 0) {
-                PartitionedKeyAndAggs gen = partition(breaker, hash2, hash2.size, agg2);
-                assertThat(gen.keys(), instanceOf(expectedType));
-                gens.add(gen);
-                hash2.clear();
-                agg2.clear();
-            }
-            var result1 = emit(hash1, agg1);
-            hash1.close();
-            hash1 = null;
-            agg1.close();
-            agg1 = null;
-            var results2 = combinePartitions(breaker, hash2, agg2, gens);
-            assertThat(result1, equalTo(results2));
-        } finally {
-            Releasables.close(hash1, hash2, agg1, agg2);
-            gens.forEach(g -> g.release(breaker));
-        }
     }
 
     private void runPartitionTest(
@@ -141,8 +72,10 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
         BigArrays bigArrays,
         CircuitBreaker breaker,
         Class<? extends BytesRefSwissHash.BytesRefPartitionedHashKeys> expectedType,
-        long pagedPartitionBytesThreshold
+        long pagedPartitionBytesThreshold,
+        boolean fixedLength
     ) {
+        final int keyLength = fixedLength ? randomIntBetween(1, 32) : -1;
         final int partitionSize = randomIntBetween(128, 10 * 1024);
         var hash1 = new BytesRefSwissHash(recycler, breaker, bigArrays, pagedPartitionBytesThreshold);
         SumAgg agg1 = new SumAgg(breaker);
@@ -154,9 +87,9 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
             for (int i = 0; i < numBlocks; i++) {
                 final int positions = between(1, 2048);
                 final BytesRef[] keys = new BytesRef[positions];
-                boolean collisions = randomBoolean();
+                boolean collisions = fixedLength == false && randomBoolean();
                 for (int v = 0; v < positions; v++) {
-                    final int len = collisions ? randomIntBetween(1, 3) : randomIntBetween(10, 20);
+                    final int len = fixedLength ? keyLength : collisions ? randomIntBetween(1, 3) : randomIntBetween(10, 20);
                     final byte[] bytes = new byte[len];
                     random().nextBytes(bytes);
                     keys[v] = new BytesRef(bytes);

--- a/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashPartitionTests.java
+++ b/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashPartitionTests.java
@@ -45,8 +45,14 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
         var recycler = new BytesRefSwissHashTests.TestRecycler();
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(100)).withCircuitBreaking();
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-        runPartitionTest(recycler, bigArrays, breaker, BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
-            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES, false);
+        runPartitionTest(
+            recycler,
+            bigArrays,
+            breaker,
+            BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
+            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES,
+            false
+        );
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 
@@ -54,8 +60,14 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
         var recycler = new BytesRefSwissHashTests.TestRecycler();
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(100)).withCircuitBreaking();
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-        runPartitionTest(recycler, bigArrays, breaker, BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
-            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES, true);
+        runPartitionTest(
+            recycler,
+            bigArrays,
+            breaker,
+            BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
+            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES,
+            true
+        );
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 

--- a/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashPartitionTests.java
+++ b/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashPartitionTests.java
@@ -55,12 +55,85 @@ public class BytesRefSwissHashPartitionTests extends PartitionedHashTestCase {
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 
+    public void testPartitionFlatFixedLength() {
+        var recycler = new BytesRefSwissHashTests.TestRecycler();
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(100)).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        runPartitionTestFixedLength(
+            recycler,
+            bigArrays,
+            breaker,
+            BytesRefSwissHash.FlatBytesRefPartitionedHashKeys.class,
+            BytesRefSwissHash.PAGED_PARTITION_THRESHOLD_BYTES
+        );
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
     public void testPartitionPaged() {
         var recycler = new BytesRefSwissHashTests.TestRecycler();
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(100)).withCircuitBreaking();
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
         runPartitionTest(recycler, bigArrays, breaker, BytesRefSwissHash.PagedBytesRefPartitionedHashKeys.class, 0L);
         assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    private void runPartitionTestFixedLength(
+        BytesRefSwissHashTests.TestRecycler recycler,
+        BigArrays bigArrays,
+        CircuitBreaker breaker,
+        Class<? extends BytesRefSwissHash.BytesRefPartitionedHashKeys> expectedType,
+        long pagedPartitionBytesThreshold
+    ) {
+        final int keyLength = randomIntBetween(1, 32);
+        final int partitionSize = randomIntBetween(128, 10 * 1024);
+        var hash1 = new BytesRefSwissHash(recycler, breaker, bigArrays, pagedPartitionBytesThreshold);
+        SumAgg agg1 = new SumAgg(breaker);
+        var hash2 = new BytesRefSwissHash(recycler, breaker, bigArrays, pagedPartitionBytesThreshold);
+        SumAgg agg2 = new SumAgg(breaker);
+        List<PartitionedKeyAndAggs> gens = new ArrayList<>();
+        try {
+            int numBlocks = between(1, 1000);
+            for (int i = 0; i < numBlocks; i++) {
+                final int positions = between(1, 2048);
+                final BytesRef[] keys = new BytesRef[positions];
+                for (int v = 0; v < positions; v++) {
+                    final byte[] bytes = new byte[keyLength];
+                    random().nextBytes(bytes);
+                    keys[v] = new BytesRef(bytes);
+                }
+                final int[] values = new int[positions];
+                for (int v = 0; v < positions; v++) {
+                    values[v] = randomIntBetween(-1000, 1000);
+                }
+                addInput(hash1, agg1, keys, values);
+                addInput(hash2, agg2, keys, values);
+
+                if (hash2.size() >= partitionSize) {
+                    PartitionedKeyAndAggs gen = partition(breaker, hash2, hash2.size, agg2);
+                    assertThat(gen.keys(), instanceOf(expectedType));
+                    gens.add(gen);
+                    hash2.clear();
+                    agg2.clear();
+                }
+            }
+            if (hash2.size > 0) {
+                PartitionedKeyAndAggs gen = partition(breaker, hash2, hash2.size, agg2);
+                assertThat(gen.keys(), instanceOf(expectedType));
+                gens.add(gen);
+                hash2.clear();
+                agg2.clear();
+            }
+            var result1 = emit(hash1, agg1);
+            hash1.close();
+            hash1 = null;
+            agg1.close();
+            agg1 = null;
+            var results2 = combinePartitions(breaker, hash2, agg2, gens);
+            assertThat(result1, equalTo(results2));
+        } finally {
+            Releasables.close(hash1, hash2, agg1, agg2);
+            gens.forEach(g -> g.release(breaker));
+        }
     }
 
     private void runPartitionTest(

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -288,6 +288,11 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
         return lastOffset;
     }
 
+    /** Returns the fixed byte length of all entries, or {@code -1} if entry lengths vary. */
+    public int fixedLength() {
+        return fixedLength;
+    }
+
     @Override
     public void close() {
         decRef();


### PR DESCRIPTION
When BytesRefArray already tracks a uniform fixed length (as in PackedValuesBlockHash over all fixed-width columns), expose that via fixedLength() and use it in FlatBytesRefPartitionedHashKeys to skip offset array allocation entirely. The combine path dispatches to new mergeKeys overloads that compute key boundaries as i*fixedLength rather than looking up a stored offset, eliminating both the memory and the bookkeeping overhead on the split side.

#### BytesRefSwissHashPartitionBenchmark results for fixed length keys:

| keyBytes | workers | cardinality | baseline (ms/op) | PR (ms/op) | delta |
|---|---|---|---|---|---|
| 32 | 1 | 1,000,000 | 97.71 | 92.35 | -5.5% |
| 32 | 1 | 10,000,000 | 931.87 | 912.79 | -2.0% |
| 32 | 1 | 100,000,000 | 7372.46 | 7147.61 | -3.0% |
| 32 | 4 | 1,000,000 | 31.86 | 31.01 | -2.7% |
| 32 | 4 | 10,000,000 | 220.74 | 211.51 | -4.2% |
| 32 | 4 | 100,000,000 | 2321.36 | 2273.21 | -2.1% |
| 32 | 8 | 1,000,000 | 17.50 | 16.37 | -6.5% |
| 32 | 8 | 10,000,000 | 143.11 | 141.58 | -1.1% |
| 32 | 8 | 100,000,000 | 1781.85 | 1795.73 | +0.8% |
| 8 | 1 | 1,000,000 | 71.44 | 72.87 | +2.0% |
| 8 | 1 | 10,000,000 | 588.99 | 562.33 | -4.5% |
| 8 | 1 | 100,000,000 | 5688.78 | 5670.37 | -0.3% |
| 8 | 4 | 1,000,000 | 27.04 | 25.50 | -5.7% |
| 8 | 4 | 10,000,000 | 174.88 | 170.34 | -2.6% |
| 8 | 4 | 100,000,000 | 1541.13 | 1494.49 | -3.0% |
| 8 | 8 | 1,000,000 | 14.80 | 13.87 | -6.3% |
| 8 | 8 | 10,000,000 | 113.50 | 111.67 | -1.6% |
| 8 | 8 | 100,000,000 | 974.64 | 910.06 | -6.6% |
