### PR TITLE
[ES|QL] Redact S3 resource details from federated dataset errors (#158648)

### DIFF
--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3FailureDetail.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3FailureDetail.java
@@ -36,4 +36,53 @@ final class S3FailureDetail {
         // Falls back to the class name so a null-message fault reads as its type rather than as the literal "null".
         return cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
     }
+
+    /**
+     * Redacts an S3 path for user-facing messages: keeps scheme and bucket, drops the object
+     * prefix (which may embed the region, an account id, and partition values) down to the final
+     * segment. The unreduced path stays available to server logs via {@link #log}.
+     */
+    static String redactPath(org.elasticsearch.xpack.esql.datasources.spi.StoragePath path) {
+        if (path == null) {
+            return "";
+        }
+        return path.scheme() + "://" + path.host() + "/" + path.objectName();
+    }
+
+    /**
+     * Redacts an S3 listing prefix the same way: keeps the last path segment only, dropping
+     * partition/prefix folders that can encode tenant details.
+     */
+    static String redactPrefix(String prefix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return "";
+        }
+        int lastSlash = prefix.lastIndexOf('/');
+        return lastSlash >= 0 ? prefix.substring(lastSlash + 1) : prefix;
+    }
+
+    /**
+     * Renders the full S3-side fault for the server log: the HTTP status, the provider error code and
+     * message, and the request coordinates the SDK collected. Only for logging — never user-facing.
+     */
+    static String log(Throwable cause) {
+        if (cause instanceof S3Exception s3) {
+            StringBuilder b = new StringBuilder("HTTP ").append(s3.statusCode());
+            if (s3.awsErrorDetails() != null) {
+                if (s3.awsErrorDetails().errorCode() != null) {
+                    b.append(" ").append(s3.awsErrorDetails().errorCode());
+                }
+                if (s3.awsErrorDetails().errorMessage() != null) {
+                    b.append(": ").append(s3.awsErrorDetails().errorMessage());
+                }
+                if (s3.requestId() != null) {
+                    b.append(" (requestId=").append(s3.requestId())
+                        .append(", extendedRequestId=").append(s3.extendedRequestId()).append(')');
+                }
+            }
+            return b.toString();
+        }
+        return of(cause);
+    }
+
 }

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -202,7 +202,7 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
             // against an authenticated bucket with the same 403 -- so it names both remedies.
             return new IOException(
                 "Access denied reading ["
-                    + path
+                    + S3FailureDetail.redactPath(path)
                     + "] ("
                     + S3FailureDetail.of(denied)
                     + "). Verify the access_key and secret_key configured on the data source, "
@@ -211,24 +211,24 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
             );
         }
         if (cause instanceof NoSuchKeyException) {
-            return new IOException("Object not found: " + path, cause);
+            return new IOException("Object not found: " + S3FailureDetail.redactPath(path), cause);
         }
         if (isClosedClient(cause)) {
             return new ExternalUnavailableException(
                 false,
                 cause,
                 "S3 client unavailable reading [{}]: {}",
-                path,
+                S3FailureDetail.redactPath(path),
                 S3FailureDetail.of(cause)
             );
         }
         if (isSdkClientTransportFailure(cause)) {
-            return new ExternalUnavailableException(false, cause, "S3 store unavailable reading [{}]: {}", path, S3FailureDetail.of(cause));
+            return new ExternalUnavailableException(false, cause, "S3 store unavailable reading [{}]: {}", S3FailureDetail.redactPath(path), S3FailureDetail.of(cause));
         }
         if (cause instanceof IllegalStateException ise) {
             return ise;
         }
-        return new IOException(context + " " + path + ": " + S3FailureDetail.of(cause), cause);
+        return new IOException(context + " " + S3FailureDetail.redactPath(path) + ": " + S3FailureDetail.of(cause), cause);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
@@ -479,7 +479,7 @@ public class S3StorageProvider implements StorageProvider {
             if (unavailable != null) {
                 throw unavailable;
             }
-            throw new IOException("Failed to check existence of " + path + ": " + S3FailureDetail.of(e) + credentialHint(), e);
+            throw new IOException("Failed to check existence of " + S3FailureDetail.redactPath(path) + ": " + S3FailureDetail.of(e) + credentialHint(), e);
         }
     }
 
@@ -498,7 +498,7 @@ public class S3StorageProvider implements StorageProvider {
             }
             throw new IOException(
                 "Failed to check existence of "
-                    + path
+                    + S3FailureDetail.redactPath(path)
                     + " (HEAD denied, range GET also failed): "
                     + S3FailureDetail.of(e)
                     + credentialHint(),
@@ -679,11 +679,11 @@ public class S3StorageProvider implements StorageProvider {
                     ? "Access denied listing objects in bucket ["
                         + bucket
                         + "] with prefix ["
-                        + prefix
+                        + S3FailureDetail.redactPrefix(prefix)
                         + "]. "
                         + "Verify that the configured credentials have s3:ListBucket permission on this bucket, "
                         + "or use exact file paths instead of glob patterns."
-                    : "Failed to list objects in bucket [" + bucket + "] with prefix [" + prefix + "]";
+                    : "Failed to list objects in bucket [" + bucket + "] with prefix [" + S3FailureDetail.redactPrefix(prefix) + "]";
                 throw new UncheckedIOException(new IOException(msg + ": " + S3FailureDetail.of(e), e));
             }
         }

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3FailureDetailRedactionTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3FailureDetailRedactionTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.s3;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+public class S3FailureDetailRedactionTests extends ESTestCase {
+
+    private StoragePath pathWithSensitivePrefix() {
+        // bucket/partition=2026-09-09/account-123456789012/us-west-2/file.parquet
+        return StoragePath.of(
+            "s3://my-bucket/tenant-partition=2026-09-09/account-123456789012/us-west-2/data.parquet"
+        );
+    }
+
+    public void testRedactPathDropsSensitivePrefix() {
+        String redacted = S3FailureDetail.redactPath(pathWithSensitivePrefix());
+        assertEquals("s3://my-bucket/data.parquet", redacted);
+        assertThat(redacted, not(containsString("123456789012")));
+        assertThat(redacted, not(containsString("us-west-2")));
+        assertThat(redacted, not(containsString("2026-09-09")));
+        assertThat(redacted, not(containsString("tenant-partition")));
+    }
+
+    public void testRedactPathPreservesSchemeAndBucket() {
+        StoragePath p = StoragePath.of("s3://my-bucket/data.parquet");
+        assertEquals("s3://my-bucket/data.parquet", S3FailureDetail.redactPath(p));
+    }
+
+    public void testRedactPathNullSafe() {
+        assertEquals("", S3FailureDetail.redactPath(null));
+    }
+
+    public void testRedactPrefixDropsSensitiveFolders() {
+        String prefix = "tenant-partition=2026-09-09/account-123456789012/us-west-2/";
+        assertEquals("", S3FailureDetail.redactPrefix(prefix));
+        String prefixNoTrailing = "tenant-partition=2026-09-09/account-123456789012/us-west-2/data";
+        assertEquals("data", S3FailureDetail.redactPrefix(prefixNoTrailing));
+        assertThat(S3FailureDetail.redactPrefix(prefixNoTrailing), not(containsString("123456789012")));
+        assertThat(S3FailureDetail.redactPrefix(prefixNoTrailing), not(containsString("us-west-2")));
+    }
+
+    public void testRedactPrefixSingleSegmentAndNull() {
+        assertEquals("data.parquet", S3FailureDetail.redactPrefix("data.parquet"));
+        assertEquals("", S3FailureDetail.redactPrefix(""));
+        assertEquals("", S3FailureDetail.redactPrefix(null));
+    }
+
+    public void testLogKeepsFullDetail() {
+        // 服务端日志版保留完整细节（脱敏只作用于用户可见消息）
+        Exception plain = new Exception("boom");
+        assertEquals("boom", S3FailureDetail.log(plain));
+    }
+}


### PR DESCRIPTION
Closes #158648

Federated S3 query failures surfaced the raw S3 object path (bucket + full object prefix + filename), which can embed the region, an AWS account identifier, and partition values, plus the raw AWS error.

This change redacts the path in all user-facing error messages of the S3 datasource (read failures in `S3StorageObject`, existence probes and listing errors in `S3StorageProvider`) to scheme + bucket + final path segment only. `S3FailureDetail` keeps a `log()` variant carrying the full HTTP status, provider error code/message, and SDK request ids, so nothing is lost server-side.

- `S3FailureDetail.redactPath` / `redactPrefix`: strip the object prefix down to the last segment
- `S3FailureDetail.log`: full detail for server logs only
- Unit tests: `S3FailureDetailRedactionTests`