### PR TITLE
[9.4] Fix synthetic _id getMax on relocation prewarm (#158537)

### DIFF
--- a/docs/changelog/158537.yaml
+++ b/docs/changelog/158537.yaml
@@ -1,0 +1,5 @@
+pr: 158537
+summary: Fix synthetic `_id` `Terms#getMax` crash during relocation id-lookup prewarm
+area: Codec
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/DelegatingBloomFilterFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/DelegatingBloomFilterFieldsProducer.java
@@ -95,6 +95,18 @@ public class DelegatingBloomFilterFieldsProducer extends FieldsProducer {
         final BloomFilter bloomFilter = idBloomFilterSupplier.createBloomFilterInstance();
         return new FilterLeafReader.FilterTerms(terms) {
             @Override
+            public BytesRef getMin() throws IOException {
+                // FilterTerms does not delegate getMin/getMax; without this, Lucene's default getMax binary-searches
+                // via seekCeil with incomplete probes and breaks synthetic _id terms (see TSDBSyntheticIdFieldsProducer).
+                return terms.getMin();
+            }
+
+            @Override
+            public BytesRef getMax() throws IOException {
+                return terms.getMax();
+            }
+
+            @Override
             public TermsEnum iterator() throws IOException {
                 return new LazyFilterTermsEnum() {
                     private TermsEnum termsEnum;

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES85BloomFilterPostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES85BloomFilterPostingsFormat.java
@@ -257,6 +257,18 @@ public class ES85BloomFilterPostingsFormat extends PostingsFormat {
             this.bloomFilterSize = bloomFilterSize;
         }
 
+        @Override
+        public BytesRef getMin() throws IOException {
+            // FilterTerms does not delegate getMin/getMax; without this, Lucene's default getMax binary-searches
+            // via seekCeil with incomplete probes and breaks synthetic _id terms (see TSDBSyntheticIdFieldsProducer).
+            return in.getMin();
+        }
+
+        @Override
+        public BytesRef getMax() throws IOException {
+            return in.getMax();
+        }
+
         private boolean mayContainTerm(BytesRef term) throws IOException {
             final int hash = hashTerm(term) % bloomFilterSize;
             final int pos = hash >> 3;

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES87BloomFilterPostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES87BloomFilterPostingsFormat.java
@@ -416,6 +416,18 @@ public class ES87BloomFilterPostingsFormat extends PostingsFormat {
             this.bloomFilterSize = bloomFilterSize;
         }
 
+        @Override
+        public BytesRef getMin() throws IOException {
+            // FilterTerms does not delegate getMin/getMax; without this, Lucene's default getMax binary-searches
+            // via seekCeil with incomplete probes and breaks synthetic _id terms (see TSDBSyntheticIdFieldsProducer).
+            return in.getMin();
+        }
+
+        @Override
+        public BytesRef getMax() throws IOException {
+            return in.getMax();
+        }
+
         private boolean mayContainTerm(BytesRef term) throws IOException {
             hashTerm(term, hashes);
             for (int hash : hashes) {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
@@ -86,6 +86,34 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
             }
 
             @Override
+            public BytesRef getMin() throws IOException {
+                // Prefer an explicit min over the default Terms#getMin walk so bloom-filter wrappers that
+                // delegate here (and checkIndex / relocation prewarm) never rely on incomplete seekCeil probes.
+                var docValues = new TSDBSyntheticIdDocValuesHolder(fieldInfos, docValuesProducer);
+                for (int doc = 0; doc < maxDocs; doc++) {
+                    if (docValues.hasTsIdDocValue(doc)) {
+                        return docValues.docSyntheticId(doc);
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public BytesRef getMax() throws IOException {
+                // Documents are sorted by _tsid ascending then @timestamp descending, so the last document
+                // with a _tsid holds the lexicographically largest synthetic _id. Override the default
+                // Terms#getMax binary search: its incomplete probe keys are not valid synthetic ids and
+                // trip extractTimestampFromSyntheticId when seekCeil matches a _tsid.
+                var docValues = new TSDBSyntheticIdDocValuesHolder(fieldInfos, docValuesProducer);
+                for (int doc = maxDocs - 1; doc >= 0; doc--) {
+                    if (docValues.hasTsIdDocValue(doc)) {
+                        return docValues.docSyntheticId(doc);
+                    }
+                }
+                return null;
+            }
+
+            @Override
             public int getDocCount() {
                 return maxDocs; // All docs have a synthetic id
             }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
@@ -591,6 +591,38 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
         });
     }
 
+    public void testGetMinAndGetMax() throws IOException {
+        // Reproduces the node crash observed during a serverless primary-shard relocation. On the relocation target,
+        // IndexEngine#prewarmIdLookups calls Terms#getMax() on the _id field. Lucene's default getMax() drills into the
+        // terms with incomplete probe keys via seekCeil(). When a probe's _tsid matches an indexed one,
+        // SyntheticIdTermsEnum#seekCeil used to call extractTimestampFromSyntheticId() on the probe, whose trailing
+        // 8 bytes are not a real (Long.MAX_VALUE - timestamp) delta, so the decoded delta is negative and tripped
+        // `assert timestamp >= 0`. The uncaught-exception handler turned that into a node exit.
+        runTest(false, (writer, parser) -> {
+            indexMultiBlockSegment(writer, parser);
+            try (var reader = DirectoryReader.open(writer)) {
+                assertThat(reader.leaves(), hasSize(1));
+                var terms = reader.leaves().getFirst().reader().terms(IdFieldMapper.NAME);
+                assertNotNull(terms);
+
+                BytesRef expectedMin = null;
+                BytesRef expectedMax = null;
+                var iter = terms.iterator();
+                for (BytesRef term = iter.next(); term != null; term = iter.next()) {
+                    if (expectedMin == null) {
+                        expectedMin = BytesRef.deepCopyOf(term);
+                    }
+                    expectedMax = BytesRef.deepCopyOf(term);
+                }
+                assertThat(expectedMin, notNullValue());
+                assertThat(expectedMax, notNullValue());
+
+                assertThat(terms.getMin(), equalTo(expectedMin));
+                assertThat(terms.getMax(), equalTo(expectedMax));
+            }
+        });
+    }
+
     public void testSortedDeleteTermsResolveAcrossSkipperBlocks() throws IOException {
         // We rely on skippers being enabled
         runTest(false, (writer, parser) -> {
@@ -615,6 +647,7 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
 
     public void testConcurrentSeekExactRandomDirectory() throws IOException {
         final var directory = newDirectory();
+        // Synthetic _id terms report docFreq/totalTermFreq as 0 (postings are synthesized), which CheckIndex rejects.
         directory.setCheckIndexOnClose(false);
         doTestConcurrentSeekExact(directory);
     }
@@ -668,6 +701,7 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
      */
     public static void runTestWithRandomDocs(CheckedBiConsumer<IndexWriter, TreeMap<BytesRef, Doc>, IOException> test) throws IOException {
         final var directory = newDirectory();
+        // Synthetic _id terms report docFreq/totalTermFreq as 0 (postings are synthesized), which CheckIndex rejects.
         directory.setCheckIndexOnClose(false);
         runTestWithRandomDocs(directory, test);
     }
@@ -763,10 +797,7 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
     private static void runTest(boolean disableSkippers, CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test)
         throws IOException {
         final var directory = newDirectory();
-        // Checking the index on close requires to support Terms#getMin()/getMax() methods on invalid (or incomplete) terms, something
-        // that is not supported in TSDBSyntheticIdFieldsProducer today.
-        //
-        // TODO would be nice to enable check-index-on-close
+        // Synthetic _id terms report docFreq/totalTermFreq as 0 (postings are synthesized), which CheckIndex rejects.
         directory.setCheckIndexOnClose(false);
         runTest(disableSkippers, directory, test);
     }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix synthetic _id getMax on relocation prewarm (#158537)