### PR TITLE
Support addExact/min/max in primitive grouping aggregation

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -87,6 +87,7 @@ public class GroupingAggregatorImplementer {
     private final List<TypeMirror> warnExceptions;
     private final ExecutableElement init;
     private final ExecutableElement combine;
+    private final boolean combineOnState;
     private final ExecutableElement prepareEvaluateIntermediate;
     private final ExecutableElement prepareEvaluateFinal;
     private final List<Parameter> createParameters;
@@ -128,6 +129,13 @@ public class GroupingAggregatorImplementer {
             requireName("combine"),
             combineArgs(aggState)
         );
+        this.combineOnState = aggState.declaredType().isPrimitive()
+            && optionalStaticMethod(
+                declarationType,
+                requireVoidType(),
+                requireName("combine"),
+                requireArgs(requireType(aggState.type()), requireType(TypeName.INT), requireAnyType("<aggregation input column type>"))
+            ) != null;
         this.prepareEvaluateIntermediate = optionalStaticMethod(
             declarationType,
             requireType(GROUPING_AGGREGATOR_FUNCTION_PREPARED_FOR_EVALUATION),
@@ -584,7 +592,7 @@ public class GroupingAggregatorImplementer {
         StringBuilder pattern = new StringBuilder();
         List<Object> params = new ArrayList<>();
 
-        if (returnType.isPrimitive()) {
+        if (returnType.isPrimitive() && combineOnState == false) {
             pattern.append("state.set(groupId, $T.combine(state.getOrDefault(groupId)");
             params.add(declarationType);
         } else {
@@ -606,7 +614,7 @@ public class GroupingAggregatorImplementer {
         if (positionParamIndex >= aggParams.size()) {
             pattern.append(", valuesPosition");
         }
-        if (returnType.isPrimitive()) {
+        if (returnType.isPrimitive() && combineOnState == false) {
             pattern.append(")");
         }
         pattern.append(")");
@@ -759,12 +767,21 @@ public class GroupingAggregatorImplementer {
                     warningsBlock(builder, () -> {
                         var name = intermediateState.get(0).name();
                         var vectorAccessor = vectorAccessorName(intermediateState.get(0).elementType());
-                        builder.addStatement(
-                            "state.set(groupId, $T.combine(state.getOrDefault(groupId), $L.$L(valuesPosition)))",
-                            declarationType,
-                            name,
-                            vectorAccessor
-                        );
+                        if (combineOnState) {
+                            builder.addStatement(
+                                "$T.combine(state, groupId, $L.$L(valuesPosition))",
+                                declarationType,
+                                name,
+                                vectorAccessor
+                            );
+                        } else {
+                            builder.addStatement(
+                                "state.set(groupId, $T.combine(state.getOrDefault(groupId), $L.$L(valuesPosition)))",
+                                declarationType,
+                                name,
+                                vectorAccessor
+                            );
+                        }
                     });
                     builder.endControlFlow();
                 } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/BooleanArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/BooleanArrayState.java
@@ -78,8 +78,24 @@ final class BooleanArrayState extends AbstractArrayState implements GroupingAggr
         trackGroupId(groupId);
     }
 
-    boolean getOrDefault(int groupId) {
-        return groupId < capacity ? get(groupId) : init;
+    void min(int groupId, boolean value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        if (value == false) {
+            pages[groupId >>> PAGE_SHIFT][(groupId & PAGE_MASK) >>> 6] &= ~(1L << groupId);
+        }
+        trackGroupId(groupId);
+    }
+
+    void max(int groupId, boolean value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        if (value) {
+            pages[groupId >>> PAGE_SHIFT][(groupId & PAGE_MASK) >>> 6] |= 1L << groupId;
+        }
+        trackGroupId(groupId);
     }
 
     Block toValuesBlock(org.elasticsearch.compute.data.IntVector selected, DriverContext driverContext) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/DoubleArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/DoubleArrayState.java
@@ -83,6 +83,26 @@ final class DoubleArrayState extends AbstractArrayState implements GroupingAggre
         trackGroupId(groupId);
     }
 
+    void min(int groupId, double value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final double[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.min(page[index], value);
+        trackGroupId(groupId);
+    }
+
+    void max(int groupId, double value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final double[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.max(page[index], value);
+        trackGroupId(groupId);
+    }
+
     Block toValuesBlock(org.elasticsearch.compute.data.IntVector selected, DriverContext driverContext) {
         if (false == trackingGroupIds()) {
             try (var builder = driverContext.blockFactory().newDoubleVectorFixedBuilder(selected.getPositionCount())) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/FloatArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/FloatArrayState.java
@@ -71,8 +71,24 @@ final class FloatArrayState extends AbstractArrayState implements GroupingAggreg
         trackGroupId(groupId);
     }
 
-    float getOrDefault(int groupId) {
-        return groupId < capacity ? get(groupId) : init;
+    void min(int groupId, float value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final float[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.min(page[index], value);
+        trackGroupId(groupId);
+    }
+
+    void max(int groupId, float value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final float[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.max(page[index], value);
+        trackGroupId(groupId);
     }
 
     Block toValuesBlock(org.elasticsearch.compute.data.IntVector selected, DriverContext driverContext) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IntArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IntArrayState.java
@@ -71,8 +71,24 @@ final class IntArrayState extends AbstractArrayState implements GroupingAggregat
         trackGroupId(groupId);
     }
 
-    int getOrDefault(int groupId) {
-        return groupId < capacity ? get(groupId) : init;
+    void min(int groupId, int value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final int[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.min(page[index], value);
+        trackGroupId(groupId);
+    }
+
+    void max(int groupId, int value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final int[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.max(page[index], value);
+        trackGroupId(groupId);
     }
 
     Block toValuesBlock(org.elasticsearch.compute.data.IntVector selected, DriverContext driverContext) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/LongArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/LongArrayState.java
@@ -71,15 +71,33 @@ final class LongArrayState extends AbstractArrayState implements GroupingAggrega
         trackGroupId(groupId);
     }
 
-    long getOrDefault(int groupId) {
-        return groupId < capacity ? get(groupId) : init;
-    }
-
-    void increment(int groupId, long value) {
+    void addExact(int groupId, long value) {
         if (groupId >= capacity) {
             grow(groupId + 1);
         }
-        pages[groupId >>> PAGE_SHIFT][groupId & PAGE_MASK] += value;
+        final long[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.addExact(page[index], value);
+        trackGroupId(groupId);
+    }
+
+    void min(int groupId, long value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final long[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.min(page[index], value);
+        trackGroupId(groupId);
+    }
+
+    void max(int groupId, long value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final long[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.max(page[index], value);
         trackGroupId(groupId);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBooleanGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBooleanGroupingAggregatorFunction.java
@@ -125,7 +125,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           boolean vValue = vBlock.getBoolean(vOffset);
-          state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxBooleanAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -142,7 +142,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         boolean vValue = vVector.getBoolean(valuesPosition);
-        state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxBooleanAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -189,7 +189,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), max.getBoolean(valuesPosition)));
+          MaxBooleanAggregator.combine(state, groupId, max.getBoolean(valuesPosition));
         }
       }
     }
@@ -212,7 +212,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           boolean vValue = vBlock.getBoolean(vOffset);
-          state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxBooleanAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -229,7 +229,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         boolean vValue = vVector.getBoolean(valuesPosition);
-        state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxBooleanAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -276,7 +276,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), max.getBoolean(valuesPosition)));
+          MaxBooleanAggregator.combine(state, groupId, max.getBoolean(valuesPosition));
         }
       }
     }
@@ -293,7 +293,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         boolean vValue = vBlock.getBoolean(vOffset);
-        state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxBooleanAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -303,7 +303,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       boolean vValue = vVector.getBoolean(valuesPosition);
-      state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+      MaxBooleanAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -343,7 +343,7 @@ public final class MaxBooleanGroupingAggregatorFunction implements GroupingAggre
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MaxBooleanAggregator.combine(state.getOrDefault(groupId), max.getBoolean(valuesPosition)));
+        MaxBooleanAggregator.combine(state, groupId, max.getBoolean(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
@@ -127,7 +127,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxDoubleAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -144,7 +144,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         double vValue = vVector.getDouble(valuesPosition);
-        state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxDoubleAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -191,7 +191,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), max.getDouble(valuesPosition)));
+          MaxDoubleAggregator.combine(state, groupId, max.getDouble(valuesPosition));
         }
       }
     }
@@ -214,7 +214,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxDoubleAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -231,7 +231,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         double vValue = vVector.getDouble(valuesPosition);
-        state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxDoubleAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -278,7 +278,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), max.getDouble(valuesPosition)));
+          MaxDoubleAggregator.combine(state, groupId, max.getDouble(valuesPosition));
         }
       }
     }
@@ -295,7 +295,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxDoubleAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -305,7 +305,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       double vValue = vVector.getDouble(valuesPosition);
-      state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+      MaxDoubleAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -345,7 +345,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), max.getDouble(valuesPosition)));
+        MaxDoubleAggregator.combine(state, groupId, max.getDouble(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxFloatGroupingAggregatorFunction.java
@@ -127,7 +127,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxFloatAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -144,7 +144,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         float vValue = vVector.getFloat(valuesPosition);
-        state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxFloatAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -191,7 +191,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), max.getFloat(valuesPosition)));
+          MaxFloatAggregator.combine(state, groupId, max.getFloat(valuesPosition));
         }
       }
     }
@@ -214,7 +214,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxFloatAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -231,7 +231,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         float vValue = vVector.getFloat(valuesPosition);
-        state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxFloatAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -278,7 +278,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), max.getFloat(valuesPosition)));
+          MaxFloatAggregator.combine(state, groupId, max.getFloat(valuesPosition));
         }
       }
     }
@@ -295,7 +295,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxFloatAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -305,7 +305,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       float vValue = vVector.getFloat(valuesPosition);
-      state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+      MaxFloatAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -345,7 +345,7 @@ public final class MaxFloatGroupingAggregatorFunction implements GroupingAggrega
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MaxFloatAggregator.combine(state.getOrDefault(groupId), max.getFloat(valuesPosition)));
+        MaxFloatAggregator.combine(state, groupId, max.getFloat(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
@@ -126,7 +126,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           int vValue = vBlock.getInt(vOffset);
-          state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxIntAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -143,7 +143,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int vValue = vVector.getInt(valuesPosition);
-        state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -190,7 +190,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), max.getInt(valuesPosition)));
+          MaxIntAggregator.combine(state, groupId, max.getInt(valuesPosition));
         }
       }
     }
@@ -213,7 +213,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           int vValue = vBlock.getInt(vOffset);
-          state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxIntAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -230,7 +230,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int vValue = vVector.getInt(valuesPosition);
-        state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -277,7 +277,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), max.getInt(valuesPosition)));
+          MaxIntAggregator.combine(state, groupId, max.getInt(valuesPosition));
         }
       }
     }
@@ -294,7 +294,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         int vValue = vBlock.getInt(vOffset);
-        state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -304,7 +304,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       int vValue = vVector.getInt(valuesPosition);
-      state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), vValue));
+      MaxIntAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -344,7 +344,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), max.getInt(valuesPosition)));
+        MaxIntAggregator.combine(state, groupId, max.getInt(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
@@ -127,7 +127,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           long vValue = vBlock.getLong(vOffset);
-          state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxLongAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -144,7 +144,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         long vValue = vVector.getLong(valuesPosition);
-        state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -191,7 +191,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), max.getLong(valuesPosition)));
+          MaxLongAggregator.combine(state, groupId, max.getLong(valuesPosition));
         }
       }
     }
@@ -214,7 +214,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           long vValue = vBlock.getLong(vOffset);
-          state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), vValue));
+          MaxLongAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -231,7 +231,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         long vValue = vVector.getLong(valuesPosition);
-        state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -278,7 +278,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), max.getLong(valuesPosition)));
+          MaxLongAggregator.combine(state, groupId, max.getLong(valuesPosition));
         }
       }
     }
@@ -295,7 +295,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         long vValue = vBlock.getLong(vOffset);
-        state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        MaxLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -305,7 +305,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       long vValue = vVector.getLong(valuesPosition);
-      state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), vValue));
+      MaxLongAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -345,7 +345,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), max.getLong(valuesPosition)));
+        MaxLongAggregator.combine(state, groupId, max.getLong(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBooleanGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBooleanGroupingAggregatorFunction.java
@@ -125,7 +125,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           boolean vValue = vBlock.getBoolean(vOffset);
-          state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinBooleanAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -142,7 +142,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         boolean vValue = vVector.getBoolean(valuesPosition);
-        state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinBooleanAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -189,7 +189,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), min.getBoolean(valuesPosition)));
+          MinBooleanAggregator.combine(state, groupId, min.getBoolean(valuesPosition));
         }
       }
     }
@@ -212,7 +212,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           boolean vValue = vBlock.getBoolean(vOffset);
-          state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinBooleanAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -229,7 +229,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         boolean vValue = vVector.getBoolean(valuesPosition);
-        state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinBooleanAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -276,7 +276,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), min.getBoolean(valuesPosition)));
+          MinBooleanAggregator.combine(state, groupId, min.getBoolean(valuesPosition));
         }
       }
     }
@@ -293,7 +293,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         boolean vValue = vBlock.getBoolean(vOffset);
-        state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinBooleanAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -303,7 +303,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       boolean vValue = vVector.getBoolean(valuesPosition);
-      state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), vValue));
+      MinBooleanAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -343,7 +343,7 @@ public final class MinBooleanGroupingAggregatorFunction implements GroupingAggre
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MinBooleanAggregator.combine(state.getOrDefault(groupId), min.getBoolean(valuesPosition)));
+        MinBooleanAggregator.combine(state, groupId, min.getBoolean(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleGroupingAggregatorFunction.java
@@ -127,7 +127,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinDoubleAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -144,7 +144,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         double vValue = vVector.getDouble(valuesPosition);
-        state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinDoubleAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -191,7 +191,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), min.getDouble(valuesPosition)));
+          MinDoubleAggregator.combine(state, groupId, min.getDouble(valuesPosition));
         }
       }
     }
@@ -214,7 +214,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinDoubleAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -231,7 +231,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         double vValue = vVector.getDouble(valuesPosition);
-        state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinDoubleAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -278,7 +278,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), min.getDouble(valuesPosition)));
+          MinDoubleAggregator.combine(state, groupId, min.getDouble(valuesPosition));
         }
       }
     }
@@ -295,7 +295,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinDoubleAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -305,7 +305,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       double vValue = vVector.getDouble(valuesPosition);
-      state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), vValue));
+      MinDoubleAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -345,7 +345,7 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MinDoubleAggregator.combine(state.getOrDefault(groupId), min.getDouble(valuesPosition)));
+        MinDoubleAggregator.combine(state, groupId, min.getDouble(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinFloatGroupingAggregatorFunction.java
@@ -127,7 +127,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinFloatAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -144,7 +144,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         float vValue = vVector.getFloat(valuesPosition);
-        state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinFloatAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -191,7 +191,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), min.getFloat(valuesPosition)));
+          MinFloatAggregator.combine(state, groupId, min.getFloat(valuesPosition));
         }
       }
     }
@@ -214,7 +214,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinFloatAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -231,7 +231,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         float vValue = vVector.getFloat(valuesPosition);
-        state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinFloatAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -278,7 +278,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), min.getFloat(valuesPosition)));
+          MinFloatAggregator.combine(state, groupId, min.getFloat(valuesPosition));
         }
       }
     }
@@ -295,7 +295,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinFloatAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -305,7 +305,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       float vValue = vVector.getFloat(valuesPosition);
-      state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), vValue));
+      MinFloatAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -345,7 +345,7 @@ public final class MinFloatGroupingAggregatorFunction implements GroupingAggrega
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MinFloatAggregator.combine(state.getOrDefault(groupId), min.getFloat(valuesPosition)));
+        MinFloatAggregator.combine(state, groupId, min.getFloat(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
@@ -126,7 +126,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           int vValue = vBlock.getInt(vOffset);
-          state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinIntAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -143,7 +143,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int vValue = vVector.getInt(valuesPosition);
-        state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -190,7 +190,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), min.getInt(valuesPosition)));
+          MinIntAggregator.combine(state, groupId, min.getInt(valuesPosition));
         }
       }
     }
@@ -213,7 +213,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           int vValue = vBlock.getInt(vOffset);
-          state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinIntAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -230,7 +230,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int vValue = vVector.getInt(valuesPosition);
-        state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -277,7 +277,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), min.getInt(valuesPosition)));
+          MinIntAggregator.combine(state, groupId, min.getInt(valuesPosition));
         }
       }
     }
@@ -294,7 +294,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         int vValue = vBlock.getInt(vOffset);
-        state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -304,7 +304,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       int vValue = vVector.getInt(valuesPosition);
-      state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), vValue));
+      MinIntAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -344,7 +344,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), min.getInt(valuesPosition)));
+        MinIntAggregator.combine(state, groupId, min.getInt(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
@@ -127,7 +127,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           long vValue = vBlock.getLong(vOffset);
-          state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinLongAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -144,7 +144,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         long vValue = vVector.getLong(valuesPosition);
-        state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -191,7 +191,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), min.getLong(valuesPosition)));
+          MinLongAggregator.combine(state, groupId, min.getLong(valuesPosition));
         }
       }
     }
@@ -214,7 +214,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           long vValue = vBlock.getLong(vOffset);
-          state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), vValue));
+          MinLongAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -231,7 +231,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         long vValue = vVector.getLong(valuesPosition);
-        state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -278,7 +278,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), min.getLong(valuesPosition)));
+          MinLongAggregator.combine(state, groupId, min.getLong(valuesPosition));
         }
       }
     }
@@ -295,7 +295,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         long vValue = vBlock.getLong(vOffset);
-        state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        MinLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -305,7 +305,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       long vValue = vVector.getLong(valuesPosition);
-      state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), vValue));
+      MinLongAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -345,7 +345,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), min.getLong(valuesPosition)));
+        MinLongAggregator.combine(state, groupId, min.getLong(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
@@ -128,7 +128,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           int vValue = vBlock.getInt(vOffset);
-          state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), vValue));
+          SumIntAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -145,7 +145,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int vValue = vVector.getInt(valuesPosition);
-        state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        SumIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -192,7 +192,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), sum.getLong(valuesPosition)));
+          SumIntAggregator.combine(state, groupId, sum.getLong(valuesPosition));
         }
       }
     }
@@ -215,7 +215,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           int vValue = vBlock.getInt(vOffset);
-          state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), vValue));
+          SumIntAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -232,7 +232,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int vValue = vVector.getInt(valuesPosition);
-        state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        SumIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -279,7 +279,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), sum.getLong(valuesPosition)));
+          SumIntAggregator.combine(state, groupId, sum.getLong(valuesPosition));
         }
       }
     }
@@ -296,7 +296,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         int vValue = vBlock.getInt(vOffset);
-        state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), vValue));
+        SumIntAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -306,7 +306,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       int vValue = vVector.getInt(valuesPosition);
-      state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), vValue));
+      SumIntAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -346,7 +346,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), sum.getLong(valuesPosition)));
+        SumIntAggregator.combine(state, groupId, sum.getLong(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumOverflowingLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumOverflowingLongGroupingAggregatorFunction.java
@@ -128,7 +128,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           long vValue = vBlock.getLong(vOffset);
-          state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), vValue));
+          SumOverflowingLongAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -145,7 +145,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         long vValue = vVector.getLong(valuesPosition);
-        state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        SumOverflowingLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -192,7 +192,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), sum.getLong(valuesPosition)));
+          SumOverflowingLongAggregator.combine(state, groupId, sum.getLong(valuesPosition));
         }
       }
     }
@@ -215,7 +215,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           long vValue = vBlock.getLong(vOffset);
-          state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), vValue));
+          SumOverflowingLongAggregator.combine(state, groupId, vValue);
         }
       }
     }
@@ -232,7 +232,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         long vValue = vVector.getLong(valuesPosition);
-        state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        SumOverflowingLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -279,7 +279,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
         if (seen.getBoolean(valuesPosition)) {
-          state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), sum.getLong(valuesPosition)));
+          SumOverflowingLongAggregator.combine(state, groupId, sum.getLong(valuesPosition));
         }
       }
     }
@@ -296,7 +296,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         long vValue = vBlock.getLong(vOffset);
-        state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), vValue));
+        SumOverflowingLongAggregator.combine(state, groupId, vValue);
       }
     }
   }
@@ -306,7 +306,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
       long vValue = vVector.getLong(valuesPosition);
-      state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), vValue));
+      SumOverflowingLongAggregator.combine(state, groupId, vValue);
     }
   }
 
@@ -346,7 +346,7 @@ public final class SumOverflowingLongGroupingAggregatorFunction implements Group
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
       if (seen.getBoolean(valuesPosition)) {
-        state.set(groupId, SumOverflowingLongAggregator.combine(state.getOrDefault(groupId), sum.getLong(valuesPosition)));
+        SumOverflowingLongAggregator.combine(state, groupId, sum.getLong(valuesPosition));
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxBooleanAggregator.java
@@ -22,4 +22,8 @@ class MaxBooleanAggregator {
     public static boolean combine(boolean current, boolean v) {
         return current || v;
     }
+
+    public static void combine(BooleanArrayState state, int groupId, boolean v) {
+        state.max(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregator.java
@@ -22,4 +22,8 @@ class MaxDoubleAggregator {
     public static double combine(double current, double v) {
         return Math.max(current, v);
     }
+
+    public static void combine(DoubleArrayState state, int groupId, double v) {
+        state.max(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxFloatAggregator.java
@@ -22,4 +22,8 @@ class MaxFloatAggregator {
     public static float combine(float current, float v) {
         return Math.max(current, v);
     }
+
+    public static void combine(FloatArrayState state, int groupId, float v) {
+        state.max(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxIntAggregator.java
@@ -22,4 +22,8 @@ class MaxIntAggregator {
     public static int combine(int current, int v) {
         return Math.max(current, v);
     }
+
+    public static void combine(IntArrayState state, int groupId, int v) {
+        state.max(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxLongAggregator.java
@@ -22,4 +22,8 @@ class MaxLongAggregator {
     public static long combine(long current, long v) {
         return Math.max(current, v);
     }
+
+    public static void combine(LongArrayState state, int groupId, long v) {
+        state.max(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinBooleanAggregator.java
@@ -22,4 +22,8 @@ class MinBooleanAggregator {
     public static boolean combine(boolean current, boolean v) {
         return current && v;
     }
+
+    public static void combine(BooleanArrayState state, int groupId, boolean v) {
+        state.min(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinDoubleAggregator.java
@@ -22,4 +22,8 @@ class MinDoubleAggregator {
     public static double combine(double current, double v) {
         return Math.min(current, v);
     }
+
+    public static void combine(DoubleArrayState state, int groupId, double v) {
+        state.min(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinFloatAggregator.java
@@ -22,4 +22,8 @@ class MinFloatAggregator {
     public static float combine(float current, float v) {
         return Math.min(current, v);
     }
+
+    public static void combine(FloatArrayState state, int groupId, float v) {
+        state.min(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinIntAggregator.java
@@ -22,4 +22,8 @@ class MinIntAggregator {
     public static int combine(int current, int v) {
         return Math.min(current, v);
     }
+
+    public static void combine(IntArrayState state, int groupId, int v) {
+        state.min(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinLongAggregator.java
@@ -23,4 +23,7 @@ class MinLongAggregator {
         return Math.min(current, v);
     }
 
+    public static void combine(LongArrayState state, int groupId, long v) {
+        state.min(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/SumIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/SumIntAggregator.java
@@ -26,4 +26,12 @@ class SumIntAggregator {
     public static long combine(long current, long v) {
         return Math.addExact(current, v);
     }
+
+    public static void combine(LongArrayState state, int groupId, int v) {
+        state.addExact(groupId, v);
+    }
+
+    public static void combine(LongArrayState state, int groupId, long v) {
+        state.addExact(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/SumOverflowingLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/SumOverflowingLongAggregator.java
@@ -32,4 +32,8 @@ class SumOverflowingLongAggregator {
     public static long combine(long current, long v) {
         return Math.addExact(current, v);
     }
+
+    public static void combine(LongArrayState state, int groupId, long v) {
+        state.addExact(groupId, v);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ArrayState.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ArrayState.java.st
@@ -119,11 +119,11 @@ $else$
     }
 $endif$
 
+$if(double)$
     $type$ getOrDefault(int groupId) {
         return groupId < capacity ? get(groupId) : init;
     }
 
-$if(long||double)$
     void increment(int groupId, $type$ value) {
         if (groupId >= capacity) {
             grow(groupId + 1);
@@ -131,7 +131,51 @@ $if(long||double)$
         pages[groupId >>> PAGE_SHIFT][groupId & PAGE_MASK] += value;
         trackGroupId(groupId);
     }
+
 $endif$
+$if(long)$
+    void addExact(int groupId, $type$ value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+        final $type$[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.addExact(page[index], value);
+        trackGroupId(groupId);
+    }
+$endif$
+
+    void min(int groupId, $type$ value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+$if(boolean)$
+        if (value == false) {
+            pages[groupId >>> PAGE_SHIFT][(groupId & PAGE_MASK) >>> 6] &= ~(1L << groupId);
+        }
+$else$
+        final $type$[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.min(page[index], value);
+$endif$
+        trackGroupId(groupId);
+    }
+
+    void max(int groupId, $type$ value) {
+        if (groupId >= capacity) {
+            grow(groupId + 1);
+        }
+$if(boolean)$
+        if (value) {
+            pages[groupId >>> PAGE_SHIFT][(groupId & PAGE_MASK) >>> 6] |= 1L << groupId;
+        }
+$else$
+        final $type$[] page = pages[groupId >>> PAGE_SHIFT];
+        final int index = groupId & PAGE_MASK;
+        page[index] = Math.max(page[index], value);
+$endif$
+        trackGroupId(groupId);
+    }
 
     Block toValuesBlock(org.elasticsearch.compute.data.IntVector selected, DriverContext driverContext) {
         if (false == trackingGroupIds()) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/ArrayStateUpdateTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/ArrayStateUpdateTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.test.BlockTestUtils;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.junit.After;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ArrayStateUpdateTests extends ComputeTestCase {
+    @ParametersFactory
+    public static List<Object[]> params() {
+        List<Object[]> params = new ArrayList<>();
+        for (ElementType type : List.of(ElementType.INT, ElementType.LONG, ElementType.FLOAT, ElementType.DOUBLE, ElementType.BOOLEAN)) {
+            for (int groups : new int[] { 1, 100, 10_000, BooleanArrayState.PAGE_SIZE }) {
+                params.add(new Object[] { type, groups });
+            }
+        }
+        return params;
+    }
+
+    private final ElementType type;
+    private final int groups;
+    private final List<Releasable> states = new ArrayList<>();
+
+    public ArrayStateUpdateTests(@Name("type") ElementType type, @Name("groups") int groups) {
+        this.type = type;
+        this.groups = groups;
+    }
+
+    @After
+    public void closeStates() {
+        Releasables.close(states);
+    }
+
+    public void testMin() {
+        boolean tracking = randomBoolean();
+        Object init = switch (type) {
+            case INT -> Integer.MAX_VALUE;
+            case LONG -> Long.MAX_VALUE;
+            case FLOAT -> Float.POSITIVE_INFINITY;
+            case DOUBLE -> Double.POSITIVE_INFINITY;
+            case BOOLEAN -> true;
+            default -> throw new IllegalArgumentException(type.toString());
+        };
+        AbstractArrayState state = newState(init);
+        if (tracking) {
+            state.enableGroupIdTracking(new SeenGroupIds.Empty());
+        }
+        Object[] expected = new Object[groups];
+        for (int i = 0; i < groups * 3; i++) {
+            int groupId = randomInt(groups - 1);
+            Object value = BlockTestUtils.randomValue(type);
+            min(state, groupId, value);
+            Object current = expected[groupId] == null ? init : expected[groupId];
+            expected[groupId] = switch (type) {
+                case INT -> Math.min((Integer) current, (Integer) value);
+                case LONG -> Math.min((Long) current, (Long) value);
+                case FLOAT -> Math.min((Float) current, (Float) value);
+                case DOUBLE -> Math.min((Double) current, (Double) value);
+                case BOOLEAN -> (Boolean) current && (Boolean) value;
+                default -> throw new IllegalArgumentException(type.toString());
+            };
+        }
+        assertValues(state, expected, tracking);
+    }
+
+    public void testMax() {
+        boolean tracking = randomBoolean();
+        Object init = switch (type) {
+            case INT -> Integer.MIN_VALUE;
+            case LONG -> Long.MIN_VALUE;
+            case FLOAT -> -Float.MAX_VALUE;
+            case DOUBLE -> -Double.MAX_VALUE;
+            case BOOLEAN -> false;
+            default -> throw new IllegalArgumentException(type.toString());
+        };
+        AbstractArrayState state = newState(init);
+        if (tracking) {
+            state.enableGroupIdTracking(new SeenGroupIds.Empty());
+        }
+        Object[] expected = new Object[groups];
+        for (int i = 0; i < groups * 3; i++) {
+            int groupId = randomInt(groups - 1);
+            Object value = BlockTestUtils.randomValue(type);
+            max(state, groupId, value);
+            Object current = expected[groupId] == null ? init : expected[groupId];
+            expected[groupId] = switch (type) {
+                case INT -> Math.max((Integer) current, (Integer) value);
+                case LONG -> Math.max((Long) current, (Long) value);
+                case FLOAT -> Math.max((Float) current, (Float) value);
+                case DOUBLE -> Math.max((Double) current, (Double) value);
+                case BOOLEAN -> (Boolean) current || (Boolean) value;
+                default -> throw new IllegalArgumentException(type.toString());
+            };
+        }
+        assertValues(state, expected, tracking);
+    }
+
+    public void testAddExact() {
+        assumeTrue("addExact is only for long", type == ElementType.LONG);
+        boolean tracking = randomBoolean();
+        LongArrayState state = (LongArrayState) newState(0L);
+        if (tracking) {
+            state.enableGroupIdTracking(new SeenGroupIds.Empty());
+        }
+        Object[] expected = new Object[groups];
+        for (int i = 0; i < groups * 3; i++) {
+            int groupId = randomInt(groups - 1);
+            long value = randomLongBetween(-1_000_000, 1_000_000);
+            state.addExact(groupId, value);
+            long current = expected[groupId] == null ? 0L : (Long) expected[groupId];
+            expected[groupId] = current + value;
+        }
+        assertValues(state, expected, tracking);
+
+        int groupId = randomInt(groups - 1);
+        state.set(groupId, Long.MAX_VALUE);
+        expectThrows(ArithmeticException.class, () -> state.addExact(groupId, 1));
+        assertThat(state.get(groupId), equalTo(Long.MAX_VALUE));
+    }
+
+    private void assertValues(AbstractArrayState state, Object[] expected, boolean tracking) {
+        for (int groupId = 0; groupId < groups; groupId++) {
+            if (expected[groupId] != null) {
+                assertTrue(state.hasValue(groupId));
+                assertThat(get(state, groupId), equalTo(expected[groupId]));
+            } else if (tracking) {
+                assertFalse(state.hasValue(groupId));
+            }
+        }
+    }
+
+    private AbstractArrayState newState(Object init) {
+        BlockFactory blockFactory = blockFactory();
+        AbstractArrayState state = switch (type) {
+            case INT -> new IntArrayState(blockFactory.bigArrays(), blockFactory.breaker(), (Integer) init);
+            case LONG -> new LongArrayState(blockFactory.bigArrays(), blockFactory.breaker(), (Long) init);
+            case FLOAT -> new FloatArrayState(blockFactory.bigArrays(), blockFactory.breaker(), (Float) init);
+            case DOUBLE -> new DoubleArrayState(blockFactory.bigArrays(), blockFactory.breaker(), (Double) init);
+            case BOOLEAN -> new BooleanArrayState(blockFactory.bigArrays(), blockFactory.breaker(), (Boolean) init);
+            default -> throw new IllegalArgumentException(type.toString());
+        };
+        states.add(state);
+        return state;
+    }
+
+    private void min(AbstractArrayState state, int groupId, Object value) {
+        switch (type) {
+            case INT -> ((IntArrayState) state).min(groupId, (Integer) value);
+            case LONG -> ((LongArrayState) state).min(groupId, (Long) value);
+            case FLOAT -> ((FloatArrayState) state).min(groupId, (Float) value);
+            case DOUBLE -> ((DoubleArrayState) state).min(groupId, (Double) value);
+            case BOOLEAN -> ((BooleanArrayState) state).min(groupId, (Boolean) value);
+            default -> throw new IllegalArgumentException(type.toString());
+        }
+    }
+
+    private void max(AbstractArrayState state, int groupId, Object value) {
+        switch (type) {
+            case INT -> ((IntArrayState) state).max(groupId, (Integer) value);
+            case LONG -> ((LongArrayState) state).max(groupId, (Long) value);
+            case FLOAT -> ((FloatArrayState) state).max(groupId, (Float) value);
+            case DOUBLE -> ((DoubleArrayState) state).max(groupId, (Double) value);
+            case BOOLEAN -> ((BooleanArrayState) state).max(groupId, (Boolean) value);
+            default -> throw new IllegalArgumentException(type.toString());
+        }
+    }
+
+    private Object get(AbstractArrayState state, int groupId) {
+        return switch (type) {
+            case INT -> ((IntArrayState) state).get(groupId);
+            case LONG -> ((LongArrayState) state).get(groupId);
+            case FLOAT -> ((FloatArrayState) state).get(groupId);
+            case DOUBLE -> ((DoubleArrayState) state).get(groupId);
+            case BOOLEAN -> ((BooleanArrayState) state).get(groupId);
+            default -> throw new IllegalArgumentException(type.toString());
+        };
+    }
+}


### PR DESCRIPTION
Follow-up of #158698

Today, for sum/min/max aggregations, accumulate runs in two hops: read the value, perform addExact/min/max, then write it back. Each hop resolves the page again: a capacity check, a page index computation and bounds checks.

This is a small improvement (10-15%), but it will help the partitioning work.

```
-- new
Benchmark                                    (distribution)   (groups)  Mode  Cnt     Score    Error  Units
SumIntGroupingAggregatorBenchmark.benchmark      sequential      10000  avgt    6     0.034 ±  0.001  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential     100000  avgt    6     0.258 ±  0.184  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential    1000000  avgt    6     1.699 ±  0.069  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential   10000000  avgt    6    17.039 ±  0.095  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential  100000000  avgt    6   173.939 ±  7.296  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random      10000  avgt    6     0.033 ±  0.001  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random     100000  avgt    6     0.338 ±  0.137  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random    1000000  avgt    6     3.670 ±  0.515  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random   10000000  avgt    6   136.072 ±  1.973  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random  100000000  avgt    6  1678.543 ± 79.292  ms/op
```

```
-- old
Benchmark                                    (distribution)   (groups)  Mode  Cnt     Score    Error  Units
SumIntGroupingAggregatorBenchmark.benchmark      sequential      10000  avgt    6     0.047 ±  0.002  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential     100000  avgt    6     0.403 ±  0.215  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential    1000000  avgt    6     2.029 ±  0.001  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential   10000000  avgt    6    20.563 ±  0.104  ms/op
SumIntGroupingAggregatorBenchmark.benchmark      sequential  100000000  avgt    6   207.230 ±  2.234  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random      10000  avgt    6     0.045 ±  0.001  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random     100000  avgt    6     0.407 ±  0.295  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random    1000000  avgt    6     4.335 ±  0.344  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random   10000000  avgt    6   155.533 ±  0.347  ms/op
SumIntGroupingAggregatorBenchmark.benchmark          random  100000000  avgt    6  1890.025 ± 22.591  ms/op
```