### PR TITLE
[9.5] [ML] Log parent-task inference cancellation at DEBUG (#158706)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
@@ -70,7 +70,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             try {
                 parentActionTask.ensureNotCancelled();
             } catch (TaskCancelledException ex) {
-                logger.warn(() -> format("[%s] %s", getDeploymentId(), ex.getMessage()));
+                logger.debug(() -> format("[%s] %s", getDeploymentId(), ex.getMessage()));
                 return true;
             }
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchActionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.inference.deployment;
 
+import org.apache.logging.log4j.Level;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -19,6 +20,7 @@ import org.elasticsearch.tasks.TaskAwareRequest;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -230,26 +232,37 @@ public class InferencePyTorchActionTests extends ESTestCase {
                 return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers);
             }
         });
-        InferencePyTorchAction action = new InferencePyTorchAction(
-            "test-model",
-            1,
-            TimeValue.MAX_VALUE,
-            processContext,
-            new PassThroughConfig(null, null, null),
-            NlpInferenceInput.fromText("foo"),
-            TrainedModelPrefixStrings.PrefixType.NONE,
-            tp,
-            cancellableTask,
-            randomBoolean(),
-            listener
-        );
-        action.init();
-        taskManager.cancel(cancellableTask, "test", () -> {});
+        try (var mockLog = MockLog.capture(InferencePyTorchAction.class)) {
+            mockLog.addExpectation(
+                new MockLog.UnseenEventExpectation(
+                    "parent cancellation not WARN",
+                    InferencePyTorchAction.class.getCanonicalName(),
+                    Level.WARN,
+                    "*task cancelled*"
+                )
+            );
+            InferencePyTorchAction action = new InferencePyTorchAction(
+                "test-model",
+                1,
+                TimeValue.MAX_VALUE,
+                processContext,
+                new PassThroughConfig(null, null, null),
+                NlpInferenceInput.fromText("foo"),
+                TrainedModelPrefixStrings.PrefixType.NONE,
+                tp,
+                cancellableTask,
+                randomBoolean(),
+                listener
+            );
+            action.init();
+            taskManager.cancel(cancellableTask, "test", () -> {});
 
-        action.doRun();
-        assertThat(listener.failureCounts, equalTo(1));
-        assertThat(listener.responseCounts, equalTo(0));
-        verify(resultProcessor, never()).registerRequest(anyString(), any());
+            action.doRun();
+            assertThat(listener.failureCounts, equalTo(1));
+            assertThat(listener.responseCounts, equalTo(0));
+            verify(resultProcessor, never()).registerRequest(anyString(), any());
+            mockLog.assertAllExpectationsMatched();
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ML] Log parent-task inference cancellation at DEBUG (#158706)