### PR TITLE
Take the column type from the format's selector in a test

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordFunctionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/columnar/ColumnarKeywordFunctionTests.java
@@ -206,7 +206,7 @@ public class ColumnarKeywordFunctionTests extends ESTestCase {
     /** Every doc-values field through the columnar format, which is what makes the field a column. */
     private static Codec columnarCodec() {
         final Codec base = TestUtil.getDefaultCodec();
-        final DocValuesFormat columnar = new ColumNARDocValuesFormat();
+        final DocValuesFormat columnar = new ColumNARDocValuesFormat(field -> ColumnarFieldType.STRING);
         return new FilterCodec(base.getName(), base) {
             private final DocValuesFormat perField = new PerFieldDocValuesFormat() {
                 @Override
@@ -225,7 +225,6 @@ public class ColumnarKeywordFunctionTests extends ESTestCase {
     private static FieldType columnarBinaryFieldType() {
         final FieldType type = new FieldType();
         type.setDocValuesType(DocValuesType.BINARY);
-        type.putAttribute(ColumNARDocValuesFormat.TYPE_ATTRIBUTE, ColumnarFieldType.STRING.name());
         type.freeze();
         return type;
     }


### PR DESCRIPTION
`ColumnarKeywordFunctionTests` was written against the `columnar.type` field attribute, which #158392 removed while #158750 was in review. Both were green on their own branch and the conflict is semantic, not textual, so it only appeared once #158750 merged.

The column type comes from the selector the format is built with, which is how the other columnar tests already take it.
