### PR TITLE
[Native] Compute bf16 squared distance directly instead of via dot products

### DIFF
--- a/docs/changelog/158817.yaml
+++ b/docs/changelog/158817.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 158817
+summary: "[Native] Compute bf16 squared distance directly instead of via dot products"
+type: bug

--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -39,7 +39,7 @@ configurations.consumable('nativeLibs') {
 }
 
 var zstdVersion = "1.5.7-1"
-var vecVersion = "1.0.140"
+var vecVersion = "1.0.141"
 var libSimdjsonVersion = "0.2.0"
 
 // vec and libsimdjson come either from published artifacts or from source builds in their

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.140"
+VERSION="1.0.141"
 
 LOCAL=false
 FORCE_UPLOAD=false

--- a/libs/simdvec/native/src/vec/c/aarch64/vec_bf16_2.cpp
+++ b/libs/simdvec/native/src/vec/c/aarch64/vec_bf16_2.cpp
@@ -79,114 +79,86 @@ EXPORT f32_t vec_dotDbf16Qbf16_2(const bf16_t* a, const bf16_t* b, const int32_t
 }
 
 /*
- * Squared distance of 2 bf16 vectors using bfdot, via the identity:
- * |a - b|^2 = a*a - 2*a*b + b*b
- * Each term is a dot product computed natively with bfdot, avoiding
- * the costly bf16 -> f32 conversion
+ * bf16 is the upper half of the f32 bit pattern, so a vector of bf16 values viewed as 32-bit
+ * lanes widens without unpacking: even elements (low half of each lane) by a shift, odd
+ * elements (already in the high half) by masking the low half. Element order differs from
+ * memory, which is irrelevant for reductions.
+ */
+static inline svfloat32_t bf16_even_to_f32(svbool_t pg, svint32_t v) {
+    return svreinterpret_f32_s32(svlsl_n_s32_x(pg, v, 16));
+}
+
+static inline svfloat32_t bf16_odd_to_f32(svbool_t pg, svint32_t v) {
+    return svreinterpret_f32_s32(svand_n_s32_x(pg, v, (int32_t)0xFFFF0000));
+}
+
+/*
+ * Squared distance of 2 bf16 vectors, computed as sum((a - b)^2) on f32-widened lanes.
+ * Differencing before squaring keeps the result exact to f32 rounding of the distance itself, so
+ * duplicates score exactly 0 and near-duplicates keep their precision even when the norms are
+ * large. Four blocks per pass with two accumulators each (even and odd lanes).
  */
 static inline f32_t sqrDbf16Qbf16_inner_sve(const bfloat16_t* d, const bfloat16_t* q, const int32_t elementCount) {
-    constexpr int batches = 8;
+    constexpr int batches = 4;
     int i = 0;
 
-    svfloat32_t sum_self0 = svdup_f32(0.0f);
-    svfloat32_t sum_self1 = svdup_f32(0.0f);
-    svfloat32_t sum_self2 = svdup_f32(0.0f);
-    svfloat32_t sum_self3 = svdup_f32(0.0f);
-    svfloat32_t sum_self4 = svdup_f32(0.0f);
-    svfloat32_t sum_self5 = svdup_f32(0.0f);
-    svfloat32_t sum_self6 = svdup_f32(0.0f);
-    svfloat32_t sum_self7 = svdup_f32(0.0f);
-    svfloat32_t sum_cross0 = svdup_f32(0.0f);
-    svfloat32_t sum_cross1 = svdup_f32(0.0f);
-    svfloat32_t sum_cross2 = svdup_f32(0.0f);
-    svfloat32_t sum_cross3 = svdup_f32(0.0f);
-    svfloat32_t sum_cross4 = svdup_f32(0.0f);
-    svfloat32_t sum_cross5 = svdup_f32(0.0f);
-    svfloat32_t sum_cross6 = svdup_f32(0.0f);
-    svfloat32_t sum_cross7 = svdup_f32(0.0f);
+    const svbool_t all16 = svptrue_b16();
+    const svbool_t all32 = svptrue_b32();
+    svfloat32_t se0 = svdup_f32(0.0f), so0 = svdup_f32(0.0f);
+    svfloat32_t se1 = svdup_f32(0.0f), so1 = svdup_f32(0.0f);
+    svfloat32_t se2 = svdup_f32(0.0f), so2 = svdup_f32(0.0f);
+    svfloat32_t se3 = svdup_f32(0.0f), so3 = svdup_f32(0.0f);
 
+    const uint16_t* du = (const uint16_t*)d;
+    const uint16_t* qu = (const uint16_t*)q;
     const int elements = svcnth();
     const int stride = elements * batches;
-    const svbool_t all16 = svptrue_b16();
     for (; i + stride <= elementCount; i += stride) {
-        svbfloat16_t av0 = svld1_vnum(all16, d + i, 0);
-        svbfloat16_t bv0 = svld1_vnum(all16, q + i, 0);
-        sum_self0 = svbfdot_f32(sum_self0, av0, av0);
-        sum_cross0 = svbfdot_f32(sum_cross0, av0, bv0);
-        sum_self0 = svbfdot_f32(sum_self0, bv0, bv0);
+        svint32_t av0 = svreinterpret_s32_u16(svld1_vnum_u16(all16, du + i, 0));
+        svint32_t bv0 = svreinterpret_s32_u16(svld1_vnum_u16(all16, qu + i, 0));
+        svfloat32_t de0 = svsub_f32_x(all32, bf16_even_to_f32(all32, av0), bf16_even_to_f32(all32, bv0));
+        svfloat32_t do0 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av0), bf16_odd_to_f32(all32, bv0));
+        se0 = svmla_f32_x(all32, se0, de0, de0);
+        so0 = svmla_f32_x(all32, so0, do0, do0);
 
-        svbfloat16_t av1 = svld1_vnum(all16, d + i, 1);
-        svbfloat16_t bv1 = svld1_vnum(all16, q + i, 1);
-        sum_self1 = svbfdot_f32(sum_self1, av1, av1);
-        sum_cross1 = svbfdot_f32(sum_cross1, av1, bv1);
-        sum_self1 = svbfdot_f32(sum_self1, bv1, bv1);
+        svint32_t av1 = svreinterpret_s32_u16(svld1_vnum_u16(all16, du + i, 1));
+        svint32_t bv1 = svreinterpret_s32_u16(svld1_vnum_u16(all16, qu + i, 1));
+        svfloat32_t de1 = svsub_f32_x(all32, bf16_even_to_f32(all32, av1), bf16_even_to_f32(all32, bv1));
+        svfloat32_t do1 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av1), bf16_odd_to_f32(all32, bv1));
+        se1 = svmla_f32_x(all32, se1, de1, de1);
+        so1 = svmla_f32_x(all32, so1, do1, do1);
 
-        svbfloat16_t av2 = svld1_vnum(all16, d + i, 2);
-        svbfloat16_t bv2 = svld1_vnum(all16, q + i, 2);
-        sum_self2 = svbfdot_f32(sum_self2, av2, av2);
-        sum_cross2 = svbfdot_f32(sum_cross2, av2, bv2);
-        sum_self2 = svbfdot_f32(sum_self2, bv2, bv2);
+        svint32_t av2 = svreinterpret_s32_u16(svld1_vnum_u16(all16, du + i, 2));
+        svint32_t bv2 = svreinterpret_s32_u16(svld1_vnum_u16(all16, qu + i, 2));
+        svfloat32_t de2 = svsub_f32_x(all32, bf16_even_to_f32(all32, av2), bf16_even_to_f32(all32, bv2));
+        svfloat32_t do2 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av2), bf16_odd_to_f32(all32, bv2));
+        se2 = svmla_f32_x(all32, se2, de2, de2);
+        so2 = svmla_f32_x(all32, so2, do2, do2);
 
-        svbfloat16_t av3 = svld1_vnum(all16, d + i, 3);
-        svbfloat16_t bv3 = svld1_vnum(all16, q + i, 3);
-        sum_self3 = svbfdot_f32(sum_self3, av3, av3);
-        sum_cross3 = svbfdot_f32(sum_cross3, av3, bv3);
-        sum_self3 = svbfdot_f32(sum_self3, bv3, bv3);
-
-        svbfloat16_t av4 = svld1_vnum(all16, d + i, 4);
-        svbfloat16_t bv4 = svld1_vnum(all16, q + i, 4);
-        sum_self4 = svbfdot_f32(sum_self4, av4, av4);
-        sum_cross4 = svbfdot_f32(sum_cross4, av4, bv4);
-        sum_self4 = svbfdot_f32(sum_self4, bv4, bv4);
-
-        svbfloat16_t av5 = svld1_vnum(all16, d + i, 5);
-        svbfloat16_t bv5 = svld1_vnum(all16, q + i, 5);
-        sum_self5 = svbfdot_f32(sum_self5, av5, av5);
-        sum_cross5 = svbfdot_f32(sum_cross5, av5, bv5);
-        sum_self5 = svbfdot_f32(sum_self5, bv5, bv5);
-
-        svbfloat16_t av6 = svld1_vnum(all16, d + i, 6);
-        svbfloat16_t bv6 = svld1_vnum(all16, q + i, 6);
-        sum_self6 = svbfdot_f32(sum_self6, av6, av6);
-        sum_cross6 = svbfdot_f32(sum_cross6, av6, bv6);
-        sum_self6 = svbfdot_f32(sum_self6, bv6, bv6);
-
-        svbfloat16_t av7 = svld1_vnum(all16, d + i, 7);
-        svbfloat16_t bv7 = svld1_vnum(all16, q + i, 7);
-        sum_self7 = svbfdot_f32(sum_self7, av7, av7);
-        sum_cross7 = svbfdot_f32(sum_cross7, av7, bv7);
-        sum_self7 = svbfdot_f32(sum_self7, bv7, bv7);
+        svint32_t av3 = svreinterpret_s32_u16(svld1_vnum_u16(all16, du + i, 3));
+        svint32_t bv3 = svreinterpret_s32_u16(svld1_vnum_u16(all16, qu + i, 3));
+        svfloat32_t de3 = svsub_f32_x(all32, bf16_even_to_f32(all32, av3), bf16_even_to_f32(all32, bv3));
+        svfloat32_t do3 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av3), bf16_odd_to_f32(all32, bv3));
+        se3 = svmla_f32_x(all32, se3, de3, de3);
+        so3 = svmla_f32_x(all32, so3, do3, do3);
     }
 
-    const svbool_t all32 = svptrue_b32();
-    svfloat32_t sum_self = svadd_f32_x(all32,
-        svadd_f32_x(all32,
-            svadd_f32_x(all32, sum_self0, sum_self1),
-            svadd_f32_x(all32, sum_self2, sum_self3)),
-        svadd_f32_x(all32,
-             svadd_f32_x(all32, sum_self4, sum_self5),
-             svadd_f32_x(all32, sum_self6, sum_self7)));
-    svfloat32_t sum_cross = svadd_f32_x(all32,
-        svadd_f32_x(all32,
-            svadd_f32_x(all32, sum_cross0, sum_cross1),
-            svadd_f32_x(all32, sum_cross2, sum_cross3)),
-        svadd_f32_x(all32,
-             svadd_f32_x(all32, sum_cross4, sum_cross5),
-             svadd_f32_x(all32, sum_cross6, sum_cross7)));
-
-    // unstrided tail
+    // Predicated tail. Inactive 16-bit lanes load as zero, so a half-covered 32-bit lane (odd
+    // element count) yields an exact zero difference and the tail also covers odd counts.
     for (; i < elementCount; i += elements) {
         svbool_t pg = svwhilelt_b16(i, elementCount);
-        svbfloat16_t av = svld1(pg, d + i);
-        svbfloat16_t bv = svld1(pg, q + i);
-        // don't need predicated vector_op (even for odd dimensions), inactive lanes are all zero anyway
-        sum_self = svbfdot_f32(sum_self, av, av);
-        sum_cross = svbfdot_f32(sum_cross, av, bv);
-        sum_self = svbfdot_f32(sum_self, bv, bv);
+        svint32_t av = svreinterpret_s32_u16(svld1_u16(pg, du + i));
+        svint32_t bv = svreinterpret_s32_u16(svld1_u16(pg, qu + i));
+        svfloat32_t de = svsub_f32_x(all32, bf16_even_to_f32(all32, av), bf16_even_to_f32(all32, bv));
+        svfloat32_t dodd = svsub_f32_x(all32, bf16_odd_to_f32(all32, av), bf16_odd_to_f32(all32, bv));
+        se0 = svmla_f32_x(all32, se0, de, de);
+        so0 = svmla_f32_x(all32, so0, dodd, dodd);
     }
 
-    // |a - b|^2 = a*a - 2*a*b + b*b
-    return svaddv_f32(all32, sum_self) - 2.0f * svaddv_f32(all32, sum_cross);
+    svfloat32_t total = svadd_f32_x(all32,
+        svadd_f32_x(all32, svadd_f32_x(all32, se0, se1), svadd_f32_x(all32, se2, se3)),
+        svadd_f32_x(all32, svadd_f32_x(all32, so0, so1), svadd_f32_x(all32, so2, so3)));
+    return svaddv_f32(all32, total);
 }
 
 EXPORT f32_t vec_sqrDbf16Qbf16_2(const bf16_t* a, const bf16_t* b, const int32_t elementCount) {

--- a/libs/simdvec/native/src/vec/c/aarch64/vec_bf16_2.cpp
+++ b/libs/simdvec/native/src/vec/c/aarch64/vec_bf16_2.cpp
@@ -274,9 +274,10 @@ EXPORT void vec_dotDbf16Qbf16_bulk_offsets_2(
 }
 
 /*
- * Bulk squared distance for bf16×bf16 using bfdot via ||a-b||² = a·a - 2·a·b + b·b.
- * Loads query once per dimension step. Computes q·q once (shared across all vectors
- * in the batch), then per vector accumulates a·a and a·q.
+ * Bulk squared distance for bf16 x bf16, computed as sum((a - b)^2) on f32-widened lanes
+ * (see sqrDbf16Qbf16_inner_sve for the numerical rationale). The widened query halves are shared by all vectors in
+ * the batch and computed once per dimension step. Eight vectors per batch with two
+ * accumulators each fit in the 32 SVE registers without spilling.
  */
 template <
     typename TData,
@@ -295,86 +296,93 @@ static inline void sqrDbf16Qbf16_bulk_sve(
 
     int c = 0;
     const int elements = svcnth();
+    const svbool_t all32 = svptrue_b32();
+    const uint16_t* bu = (const uint16_t*)b;
 
     for (; c + batches <= count; c += batches) {
-        // there are 32 SVE registers, so we can define these all as local vars without spilling
-        svfloat32_t sum_aa0 = svdup_f32(0.0f);
-        svfloat32_t sum_ab0 = svdup_f32(0.0f);
-        svfloat32_t sum_aa1 = svdup_f32(0.0f);
-        svfloat32_t sum_ab1 = svdup_f32(0.0f);
-        svfloat32_t sum_aa2 = svdup_f32(0.0f);
-        svfloat32_t sum_ab2 = svdup_f32(0.0f);
-        svfloat32_t sum_aa3 = svdup_f32(0.0f);
-        svfloat32_t sum_ab3 = svdup_f32(0.0f);
-        svfloat32_t sum_aa4 = svdup_f32(0.0f);
-        svfloat32_t sum_ab4 = svdup_f32(0.0f);
-        svfloat32_t sum_aa5 = svdup_f32(0.0f);
-        svfloat32_t sum_ab5 = svdup_f32(0.0f);
-        svfloat32_t sum_aa6 = svdup_f32(0.0f);
-        svfloat32_t sum_ab6 = svdup_f32(0.0f);
-        svfloat32_t sum_aa7 = svdup_f32(0.0f);
-        svfloat32_t sum_ab7 = svdup_f32(0.0f);
-        svfloat32_t sum_bb = svdup_f32(0.0f);
+        svfloat32_t se0 = svdup_f32(0.0f), so0 = svdup_f32(0.0f);
+        svfloat32_t se1 = svdup_f32(0.0f), so1 = svdup_f32(0.0f);
+        svfloat32_t se2 = svdup_f32(0.0f), so2 = svdup_f32(0.0f);
+        svfloat32_t se3 = svdup_f32(0.0f), so3 = svdup_f32(0.0f);
+        svfloat32_t se4 = svdup_f32(0.0f), so4 = svdup_f32(0.0f);
+        svfloat32_t se5 = svdup_f32(0.0f), so5 = svdup_f32(0.0f);
+        svfloat32_t se6 = svdup_f32(0.0f), so6 = svdup_f32(0.0f);
+        svfloat32_t se7 = svdup_f32(0.0f), so7 = svdup_f32(0.0f);
 
-        const bfloat16_t* a0 = (const bfloat16_t*)mapper(a, c + 0, offsets, pitch);
-        const bfloat16_t* a1 = (const bfloat16_t*)mapper(a, c + 1, offsets, pitch);
-        const bfloat16_t* a2 = (const bfloat16_t*)mapper(a, c + 2, offsets, pitch);
-        const bfloat16_t* a3 = (const bfloat16_t*)mapper(a, c + 3, offsets, pitch);
-        const bfloat16_t* a4 = (const bfloat16_t*)mapper(a, c + 4, offsets, pitch);
-        const bfloat16_t* a5 = (const bfloat16_t*)mapper(a, c + 5, offsets, pitch);
-        const bfloat16_t* a6 = (const bfloat16_t*)mapper(a, c + 6, offsets, pitch);
-        const bfloat16_t* a7 = (const bfloat16_t*)mapper(a, c + 7, offsets, pitch);
+        const uint16_t* a0 = (const uint16_t*)mapper(a, c + 0, offsets, pitch);
+        const uint16_t* a1 = (const uint16_t*)mapper(a, c + 1, offsets, pitch);
+        const uint16_t* a2 = (const uint16_t*)mapper(a, c + 2, offsets, pitch);
+        const uint16_t* a3 = (const uint16_t*)mapper(a, c + 3, offsets, pitch);
+        const uint16_t* a4 = (const uint16_t*)mapper(a, c + 4, offsets, pitch);
+        const uint16_t* a5 = (const uint16_t*)mapper(a, c + 5, offsets, pitch);
+        const uint16_t* a6 = (const uint16_t*)mapper(a, c + 6, offsets, pitch);
+        const uint16_t* a7 = (const uint16_t*)mapper(a, c + 7, offsets, pitch);
 
         int i = 0;
         for (; i < dims; i += elements) {
             svbool_t pg = svwhilelt_b16(i, dims);
 
-            svbfloat16_t bi = svld1_bf16(pg, (const bfloat16_t*)(b + i));
-            sum_bb = svbfdot_f32(sum_bb, bi, bi);
+            svint32_t qv = svreinterpret_s32_u16(svld1_u16(pg, bu + i));
+            svfloat32_t q_even = bf16_even_to_f32(all32, qv);
+            svfloat32_t q_odd = bf16_odd_to_f32(all32, qv);
 
-            svbfloat16_t ai0 = svld1_bf16(pg, (const bfloat16_t*)(a0 + i));
-            sum_aa0 = svbfdot_f32(sum_aa0, ai0, ai0);
-            sum_ab0 = svbfdot_f32(sum_ab0, ai0, bi);
+            svint32_t av0 = svreinterpret_s32_u16(svld1_u16(pg, a0 + i));
+            svfloat32_t de0 = svsub_f32_x(all32, bf16_even_to_f32(all32, av0), q_even);
+            svfloat32_t do0 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av0), q_odd);
+            se0 = svmla_f32_x(all32, se0, de0, de0);
+            so0 = svmla_f32_x(all32, so0, do0, do0);
 
-            svbfloat16_t ai1 = svld1_bf16(pg, (const bfloat16_t*)(a1 + i));
-            sum_aa1 = svbfdot_f32(sum_aa1, ai1, ai1);
-            sum_ab1 = svbfdot_f32(sum_ab1, ai1, bi);
+            svint32_t av1 = svreinterpret_s32_u16(svld1_u16(pg, a1 + i));
+            svfloat32_t de1 = svsub_f32_x(all32, bf16_even_to_f32(all32, av1), q_even);
+            svfloat32_t do1 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av1), q_odd);
+            se1 = svmla_f32_x(all32, se1, de1, de1);
+            so1 = svmla_f32_x(all32, so1, do1, do1);
 
-            svbfloat16_t ai2 = svld1_bf16(pg, (const bfloat16_t*)(a2 + i));
-            sum_aa2 = svbfdot_f32(sum_aa2, ai2, ai2);
-            sum_ab2 = svbfdot_f32(sum_ab2, ai2, bi);
+            svint32_t av2 = svreinterpret_s32_u16(svld1_u16(pg, a2 + i));
+            svfloat32_t de2 = svsub_f32_x(all32, bf16_even_to_f32(all32, av2), q_even);
+            svfloat32_t do2 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av2), q_odd);
+            se2 = svmla_f32_x(all32, se2, de2, de2);
+            so2 = svmla_f32_x(all32, so2, do2, do2);
 
-            svbfloat16_t ai3 = svld1_bf16(pg, (const bfloat16_t*)(a3 + i));
-            sum_aa3 = svbfdot_f32(sum_aa3, ai3, ai3);
-            sum_ab3 = svbfdot_f32(sum_ab3, ai3, bi);
+            svint32_t av3 = svreinterpret_s32_u16(svld1_u16(pg, a3 + i));
+            svfloat32_t de3 = svsub_f32_x(all32, bf16_even_to_f32(all32, av3), q_even);
+            svfloat32_t do3 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av3), q_odd);
+            se3 = svmla_f32_x(all32, se3, de3, de3);
+            so3 = svmla_f32_x(all32, so3, do3, do3);
 
-            svbfloat16_t ai4 = svld1_bf16(pg, (const bfloat16_t*)(a4 + i));
-            sum_aa4 = svbfdot_f32(sum_aa4, ai4, ai4);
-            sum_ab4 = svbfdot_f32(sum_ab4, ai4, bi);
+            svint32_t av4 = svreinterpret_s32_u16(svld1_u16(pg, a4 + i));
+            svfloat32_t de4 = svsub_f32_x(all32, bf16_even_to_f32(all32, av4), q_even);
+            svfloat32_t do4 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av4), q_odd);
+            se4 = svmla_f32_x(all32, se4, de4, de4);
+            so4 = svmla_f32_x(all32, so4, do4, do4);
 
-            svbfloat16_t ai5 = svld1_bf16(pg, (const bfloat16_t*)(a5 + i));
-            sum_aa5 = svbfdot_f32(sum_aa5, ai5, ai5);
-            sum_ab5 = svbfdot_f32(sum_ab5, ai5, bi);
+            svint32_t av5 = svreinterpret_s32_u16(svld1_u16(pg, a5 + i));
+            svfloat32_t de5 = svsub_f32_x(all32, bf16_even_to_f32(all32, av5), q_even);
+            svfloat32_t do5 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av5), q_odd);
+            se5 = svmla_f32_x(all32, se5, de5, de5);
+            so5 = svmla_f32_x(all32, so5, do5, do5);
 
-            svbfloat16_t ai6 = svld1_bf16(pg, (const bfloat16_t*)(a6 + i));
-            sum_aa6 = svbfdot_f32(sum_aa6, ai6, ai6);
-            sum_ab6 = svbfdot_f32(sum_ab6, ai6, bi);
+            svint32_t av6 = svreinterpret_s32_u16(svld1_u16(pg, a6 + i));
+            svfloat32_t de6 = svsub_f32_x(all32, bf16_even_to_f32(all32, av6), q_even);
+            svfloat32_t do6 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av6), q_odd);
+            se6 = svmla_f32_x(all32, se6, de6, de6);
+            so6 = svmla_f32_x(all32, so6, do6, do6);
 
-            svbfloat16_t ai7 = svld1_bf16(pg, (const bfloat16_t*)(a7 + i));
-            sum_aa7 = svbfdot_f32(sum_aa7, ai7, ai7);
-            sum_ab7 = svbfdot_f32(sum_ab7, ai7, bi);
+            svint32_t av7 = svreinterpret_s32_u16(svld1_u16(pg, a7 + i));
+            svfloat32_t de7 = svsub_f32_x(all32, bf16_even_to_f32(all32, av7), q_even);
+            svfloat32_t do7 = svsub_f32_x(all32, bf16_odd_to_f32(all32, av7), q_odd);
+            se7 = svmla_f32_x(all32, se7, de7, de7);
+            so7 = svmla_f32_x(all32, so7, do7, do7);
         }
 
-        const svbool_t all32 = svptrue_b32();
-        f32_t final_bb = svaddv_f32(all32, sum_bb);
-        results[c + 0] = svaddv_f32(all32, sum_aa0) + final_bb - 2.0f * svaddv_f32(all32, sum_ab0);
-        results[c + 1] = svaddv_f32(all32, sum_aa1) + final_bb - 2.0f * svaddv_f32(all32, sum_ab1);
-        results[c + 2] = svaddv_f32(all32, sum_aa2) + final_bb - 2.0f * svaddv_f32(all32, sum_ab2);
-        results[c + 3] = svaddv_f32(all32, sum_aa3) + final_bb - 2.0f * svaddv_f32(all32, sum_ab3);
-        results[c + 4] = svaddv_f32(all32, sum_aa4) + final_bb - 2.0f * svaddv_f32(all32, sum_ab4);
-        results[c + 5] = svaddv_f32(all32, sum_aa5) + final_bb - 2.0f * svaddv_f32(all32, sum_ab5);
-        results[c + 6] = svaddv_f32(all32, sum_aa6) + final_bb - 2.0f * svaddv_f32(all32, sum_ab6);
-        results[c + 7] = svaddv_f32(all32, sum_aa7) + final_bb - 2.0f * svaddv_f32(all32, sum_ab7);
+        results[c + 0] = svaddv_f32(all32, svadd_f32_x(all32, se0, so0));
+        results[c + 1] = svaddv_f32(all32, svadd_f32_x(all32, se1, so1));
+        results[c + 2] = svaddv_f32(all32, svadd_f32_x(all32, se2, so2));
+        results[c + 3] = svaddv_f32(all32, svadd_f32_x(all32, se3, so3));
+        results[c + 4] = svaddv_f32(all32, svadd_f32_x(all32, se4, so4));
+        results[c + 5] = svaddv_f32(all32, svadd_f32_x(all32, se5, so5));
+        results[c + 6] = svaddv_f32(all32, svadd_f32_x(all32, se6, so6));
+        results[c + 7] = svaddv_f32(all32, svadd_f32_x(all32, se7, so7));
     }
 
     // vectors tail

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
@@ -23,6 +23,20 @@ static inline __m512 bf16_to_f32(__m256i bf16) {
     return _mm512_castsi512_ps(shifted);
 }
 
+/*
+ * bf16 is the upper half of the f32 bit pattern, so a 512-bit load of 32 bf16 values can be
+ * widened without shuffles: the even elements (low half of each 32-bit lane) by a shift, the
+ * odd elements (already in the high half) by masking off the low half. The two results are
+ * in a different element order than memory, which is irrelevant for reductions.
+ */
+static inline __m512 bf16_even_to_f32(__m512i v) {
+    return _mm512_castsi512_ps(_mm512_slli_epi32(v, 16));
+}
+
+static inline __m512 bf16_odd_to_f32(__m512i v) {
+    return _mm512_castsi512_ps(_mm512_and_si512(v, _mm512_set1_epi32((int)0xFFFF0000)));
+}
+
 static inline __m512 load_bf16(const bf16_t* ptr, const int elements) {
     return bf16_to_f32(_mm256_lddqu_si256((const __m256i*)(ptr + elements)));
 }
@@ -153,70 +167,68 @@ EXPORT f32_t vec_sqrDbf16Qf32_3(const bf16_t* a, const f32_t* b, const int32_t e
 }
 
 /*
- * Squared distance of 2 bf16 vectors using dpbf16, via the identity:
- * |a - b|^2 = a*a - 2*a*b + b*b
- * Each term is a dot product computed natively with dpbf16, avoiding
- * the costly bf16 -> f32 conversion that makes the generic path ALU-bound.
+ * Squared distance of 2 bf16 vectors, computed as sum((a - b)^2) on f32-widened lanes.
  *
- * `unroll_dim` consecutive blocks per pass with independent accumulators; same idea
- * as the bulk variants below.
+ * Differencing before squaring keeps the result exact to f32 rounding of the distance itself, so
+ * duplicates score exactly 0 and near-duplicates keep their precision even when the norms are
+ * large; Lucene's 1 / (1 + d) score mapping requires d >= 0. Widening with shift/mask (see
+ * bf16_even_to_f32) costs two integer ops per 32 elements per operand.
+ *
+ * `unroll_dim` consecutive blocks per pass with two independent accumulators each (even and odd
+ * lanes), same idea as the bulk variants below.
  */
 static inline f32_t sqrDbf16Qbf16_inner_avx512(const bf16_t* a, const bf16_t* b, int32_t elementCount) {
     constexpr int unroll_dim = 4;
 
-    __m512 sum_self[unroll_dim];
-    __m512 sum_cross[unroll_dim];
+    __m512 sum_even[unroll_dim];
+    __m512 sum_odd[unroll_dim];
     apply_indexed<unroll_dim>([&](auto I) {
-        sum_self[I] = _mm512_setzero_ps();
-        sum_cross[I] = _mm512_setzero_ps();
+        sum_even[I] = _mm512_setzero_ps();
+        sum_odd[I] = _mm512_setzero_ps();
     });
 
     int i = 0;
-    constexpr int elements = sizeof(__m512bh) / sizeof(bf16_t);
+    constexpr int elements = sizeof(__m512i) / sizeof(bf16_t);
     constexpr int stride = elements * unroll_dim;
     for (; i < (elementCount & ~(stride - 1)); i += stride) {
         apply_indexed<unroll_dim>([&](auto I) {
-            __m512bh av = (__m512bh)_mm512_loadu_epi16(a + i + I * elements);
-            __m512bh bv = (__m512bh)_mm512_loadu_epi16(b + i + I * elements);
-            sum_self[I] = _mm512_dpbf16_ps(sum_self[I], av, av);
-            sum_self[I] = _mm512_dpbf16_ps(sum_self[I], bv, bv);
-            sum_cross[I] = _mm512_dpbf16_ps(sum_cross[I], av, bv);
+            __m512i av = _mm512_loadu_si512(a + i + I * elements);
+            __m512i bv = _mm512_loadu_si512(b + i + I * elements);
+            __m512 d_even = _mm512_sub_ps(bf16_even_to_f32(av), bf16_even_to_f32(bv));
+            __m512 d_odd = _mm512_sub_ps(bf16_odd_to_f32(av), bf16_odd_to_f32(bv));
+            sum_even[I] = _mm512_fmadd_ps(d_even, d_even, sum_even[I]);
+            sum_odd[I] = _mm512_fmadd_ps(d_odd, d_odd, sum_odd[I]);
         });
     }
 
-    __m512 total_self = tree_reduce<unroll_dim, __m512, _mm512_add_ps>(sum_self);
-    __m512 total_cross = tree_reduce<unroll_dim, __m512, _mm512_add_ps>(sum_cross);
+    __m512 total = _mm512_add_ps(
+        tree_reduce<unroll_dim, __m512, _mm512_add_ps>(sum_even),
+        tree_reduce<unroll_dim, __m512, _mm512_add_ps>(sum_odd));
 
     // Non-batched tail
     for (; i + elements <= elementCount; i += elements) {
-        __m512bh av = (__m512bh)_mm512_loadu_epi16(a + i);
-        __m512bh bv = (__m512bh)_mm512_loadu_epi16(b + i);
-        total_self = _mm512_dpbf16_ps(total_self, av, av);
-        total_self = _mm512_dpbf16_ps(total_self, bv, bv);
-        total_cross = _mm512_dpbf16_ps(total_cross, av, bv);
+        __m512i av = _mm512_loadu_si512(a + i);
+        __m512i bv = _mm512_loadu_si512(b + i);
+        __m512 d_even = _mm512_sub_ps(bf16_even_to_f32(av), bf16_even_to_f32(bv));
+        __m512 d_odd = _mm512_sub_ps(bf16_odd_to_f32(av), bf16_odd_to_f32(bv));
+        total = _mm512_fmadd_ps(d_even, d_even, total);
+        total = _mm512_fmadd_ps(d_odd, d_odd, total);
     }
 
-    // Masked tail
-    const int maskRem = elementCount - i;
-    if (maskRem > 0) {
-        __mmask32 readMask = (__mmask32)((1UL << maskRem) - 1);
-        __mmask16 dpMask = (__mmask16)((1U << (maskRem / 2)) - 1);
-        __m512bh a_rem = (__m512bh)_mm512_maskz_loadu_epi16(readMask, a + i);
-        __m512bh b_rem = (__m512bh)_mm512_maskz_loadu_epi16(readMask, b + i);
-        total_self = _mm512_mask_dpbf16_ps(total_self, dpMask, a_rem, a_rem);
-        total_self = _mm512_mask_dpbf16_ps(total_self, dpMask, b_rem, b_rem);
-        total_cross = _mm512_mask_dpbf16_ps(total_cross, dpMask, a_rem, b_rem);
+    // Masked tail: zero-masked lanes give a zero difference, including the unused half of a
+    // 32-bit lane when the remaining element count is odd, so this also covers odd counts.
+    const int rem = elementCount - i;
+    if (rem > 0) {
+        __mmask32 readMask = (__mmask32)((1UL << rem) - 1);
+        __m512i av = _mm512_maskz_loadu_epi16(readMask, a + i);
+        __m512i bv = _mm512_maskz_loadu_epi16(readMask, b + i);
+        __m512 d_even = _mm512_sub_ps(bf16_even_to_f32(av), bf16_even_to_f32(bv));
+        __m512 d_odd = _mm512_sub_ps(bf16_odd_to_f32(av), bf16_odd_to_f32(bv));
+        total = _mm512_fmadd_ps(d_even, d_even, total);
+        total = _mm512_fmadd_ps(d_odd, d_odd, total);
     }
 
-    // |a - b|^2 = a*a - 2*a*b + b*b
-    f32_t result = _mm512_reduce_add_ps(total_self) - 2.0f * _mm512_reduce_add_ps(total_cross);
-
-    // Scalar tail for odd remaining element
-    if ((maskRem & 1) != 0) {
-        result += sqr_scalar(a[elementCount - 1], b[elementCount - 1]);
-    }
-
-    return result;
+    return _mm512_reduce_add_ps(total);
 }
 
 EXPORT f32_t vec_sqrDbf16Qbf16_3(const bf16_t* a, const bf16_t* b, const int32_t elementCount) {

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
@@ -483,12 +483,11 @@ static inline void dotDbf16Qbf16_bulk_avx512(
 }
 
 /*
- * Bulk squared distance for bf16×bf16 using vdpbf16ps via ||a-b||² = a·a - 2·a·b + b·b.
- * b·b is invariant across the batches dimension (the query is shared), so it is
- * accumulated once per batch loop iteration and reduced into a single scalar at the
- * end, freeing register pressure inside the inner loop. Per-batch we carry only the
- * `aa` and `ab` streams. `unroll_dim` applies to all three streams — see
- * `dotDbf16Qbf16_bulk_avx512` for the latency / aliasing rationale.
+ * Bulk squared distance for bf16 x bf16, computed as sum((a - b)^2) on f32-widened lanes
+ * (see sqrDbf16Qbf16_inner_avx512 for the numerical rationale). The widened query halves are loop-invariant across the batch, so they are computed once per
+ * dimension step and reused for every vector. Two accumulators per vector (even and odd lanes)
+ * keep 2 * batches * unroll_dim independent FMA chains in flight. `unroll_dim` semantics and
+ * the batches/aliasing rationale are as in dotDbf16Qbf16_bulk_avx512.
  */
 template <
     typename TData,
@@ -510,10 +509,8 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
         " see dotDbf16Qbf16_bulk_avx512 for the rationale.");
 
     int c = 0;
-    constexpr int elements = sizeof(__m512bh) / sizeof(bf16_t);
+    constexpr int elements = sizeof(__m512i) / sizeof(bf16_t);
     constexpr int dimStride = elements * unroll_dim;
-    const int rem = dims % elements;
-    const bool odd_dims = (rem & 1) != 0;
     const int lines_to_fetch = dims * sizeof(bf16_t) / CACHE_LINE_SIZE + 1;
 
     const bf16_t* current_vecs[batches];
@@ -529,23 +526,15 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
             head_prefetch_or_burst<batches, unroll_dim>(next_vecs, lines_to_fetch);
         }
 
-        // Row-major layout for sum_aa / sum_ab: sum_xx[I * unroll_dim + U] keeps
-        // unroll_dim accumulators per batch member contiguous, so tree_reduce can
-        // fold them in one call. sum_bb is already contiguous along the unroll axis.
-        __m512 sum_aa[batches * unroll_dim];
-        __m512 sum_ab[batches * unroll_dim];
-        __m512 sum_bb[unroll_dim];
+        // Row-major: sum_xx[I * unroll_dim + U] keeps the unroll_dim accumulators of one batch
+        // member contiguous so tree_reduce can fold them in one call.
+        __m512 sum_even[batches * unroll_dim];
+        __m512 sum_odd[batches * unroll_dim];
         apply_indexed<batches * unroll_dim>([&](auto I) {
-            sum_aa[I] = _mm512_setzero_ps();
-            sum_ab[I] = _mm512_setzero_ps();
-        });
-        apply_indexed<unroll_dim>([&](auto U) {
-            sum_bb[U] = _mm512_setzero_ps();
+            sum_even[I] = _mm512_setzero_ps();
+            sum_odd[I] = _mm512_setzero_ps();
         });
 
-        // Main loop: each iteration advances the dim cursor by unroll_dim * elements
-        // bf16 lanes, issuing unroll_dim * (1 + 2 * batches) independent vdpbf16ps's.
-        // dimStride = unroll_dim cache lines, matching lines_per_iter=unroll_dim.
         int i = 0;
         for (; i + dimStride <= dims; i += dimStride) {
             if (has_next) {
@@ -553,26 +542,24 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
                     next_vecs, i * sizeof(bf16_t), lines_to_fetch);
             }
             apply_indexed<unroll_dim>([&](auto U) {
-                __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i + U * elements);
-                sum_bb[U] = _mm512_dpbf16_ps(sum_bb[U], qi, qi);
+                __m512i qv = _mm512_loadu_si512(b + i + U * elements);
+                __m512 q_even = bf16_even_to_f32(qv);
+                __m512 q_odd = bf16_odd_to_f32(qv);
                 apply_indexed<batches>([&](auto I) {
-                    __m512bh ai = (__m512bh)_mm512_loadu_epi16(current_vecs[I] + i + U * elements);
-                    sum_aa[I * unroll_dim + U] = _mm512_dpbf16_ps(sum_aa[I * unroll_dim + U], ai, ai);
-                    sum_ab[I * unroll_dim + U] = _mm512_dpbf16_ps(sum_ab[I * unroll_dim + U], ai, qi);
+                    __m512i av = _mm512_loadu_si512(current_vecs[I] + i + U * elements);
+                    __m512 d_even = _mm512_sub_ps(bf16_even_to_f32(av), q_even);
+                    __m512 d_odd = _mm512_sub_ps(bf16_odd_to_f32(av), q_odd);
+                    sum_even[I * unroll_dim + U] = _mm512_fmadd_ps(d_even, d_even, sum_even[I * unroll_dim + U]);
+                    sum_odd[I * unroll_dim + U] = _mm512_fmadd_ps(d_odd, d_odd, sum_odd[I * unroll_dim + U]);
                 });
             });
         }
 
-        // After the main loop, fold the unroll_dim accumulators per stream back
-        // into sum_aa[I] / sum_ab[I] / sum_bb[0]. The constexpr branch is skipped
-        // at unroll_dim=1, where the main loop already wrote sum_*[I*1+0] = sum_*[I]
-        // and sum_bb[0] -- byte-equivalent to the pre-optimisation code.
         if constexpr (unroll_dim > 1) {
             apply_indexed<batches>([&](auto I) {
-                sum_aa[I] = tree_reduce<unroll_dim, __m512, _mm512_add_ps>(&sum_aa[I * unroll_dim]);
-                sum_ab[I] = tree_reduce<unroll_dim, __m512, _mm512_add_ps>(&sum_ab[I * unroll_dim]);
+                sum_even[I] = tree_reduce<unroll_dim, __m512, _mm512_add_ps>(&sum_even[I * unroll_dim]);
+                sum_odd[I] = tree_reduce<unroll_dim, __m512, _mm512_add_ps>(&sum_odd[I * unroll_dim]);
             });
-            sum_bb[0] = tree_reduce<unroll_dim, __m512, _mm512_add_ps>(sum_bb);
 
             // Dim-unroll-1 tail: full 32-element blocks not consumed by the main loop.
             for (; i + elements <= dims; i += elements) {
@@ -580,46 +567,39 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
                     spread_prefetch_step<batches, 1, elements * sizeof(bf16_t)>(
                         next_vecs, i * sizeof(bf16_t), lines_to_fetch);
                 }
-                __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i);
-                sum_bb[0] = _mm512_dpbf16_ps(sum_bb[0], qi, qi);
+                __m512i qv = _mm512_loadu_si512(b + i);
+                __m512 q_even = bf16_even_to_f32(qv);
+                __m512 q_odd = bf16_odd_to_f32(qv);
                 apply_indexed<batches>([&](auto I) {
-                    __m512bh ai = (__m512bh)_mm512_loadu_epi16(current_vecs[I] + i);
-                    sum_aa[I] = _mm512_dpbf16_ps(sum_aa[I], ai, ai);
-                    sum_ab[I] = _mm512_dpbf16_ps(sum_ab[I], ai, qi);
+                    __m512i av = _mm512_loadu_si512(current_vecs[I] + i);
+                    __m512 d_even = _mm512_sub_ps(bf16_even_to_f32(av), q_even);
+                    __m512 d_odd = _mm512_sub_ps(bf16_odd_to_f32(av), q_odd);
+                    sum_even[I] = _mm512_fmadd_ps(d_even, d_even, sum_even[I]);
+                    sum_odd[I] = _mm512_fmadd_ps(d_odd, d_odd, sum_odd[I]);
                 });
             }
         }
 
-        // Masked tail (< 32 BF16 left)
+        // Masked tail (< 32 bf16 left). Zero-masked lanes give a zero difference, so this also
+        // covers an odd remaining count.
+        const int rem = dims - i;
         if (rem > 0) {
             __mmask32 readMask = (__mmask32)((1UL << rem) - 1);
-            __mmask16 dpMask = (__mmask16)((1U << (rem / 2)) - 1);
-            __m512bh qi = (__m512bh)_mm512_maskz_loadu_epi16(readMask, b + i);
-            sum_bb[0] = _mm512_mask_dpbf16_ps(sum_bb[0], dpMask, qi, qi);
+            __m512i qv = _mm512_maskz_loadu_epi16(readMask, b + i);
+            __m512 q_even = bf16_even_to_f32(qv);
+            __m512 q_odd = bf16_odd_to_f32(qv);
             apply_indexed<batches>([&](auto I) {
-                __m512bh ai = (__m512bh)_mm512_maskz_loadu_epi16(readMask, current_vecs[I] + i);
-                sum_aa[I] = _mm512_mask_dpbf16_ps(sum_aa[I], dpMask, ai, ai);
-                sum_ab[I] = _mm512_mask_dpbf16_ps(sum_ab[I], dpMask, ai, qi);
+                __m512i av = _mm512_maskz_loadu_epi16(readMask, current_vecs[I] + i);
+                __m512 d_even = _mm512_sub_ps(bf16_even_to_f32(av), q_even);
+                __m512 d_odd = _mm512_sub_ps(bf16_odd_to_f32(av), q_odd);
+                sum_even[I] = _mm512_fmadd_ps(d_even, d_even, sum_even[I]);
+                sum_odd[I] = _mm512_fmadd_ps(d_odd, d_odd, sum_odd[I]);
             });
         }
 
-        f32_t bb = _mm512_reduce_add_ps(sum_bb[0]);
-        if (odd_dims) {
-            bb += dot_scalar(b[dims - 1], b[dims - 1]);
-            apply_indexed<batches>([&](auto I) {
-                f32_t aa = _mm512_reduce_add_ps(sum_aa[I]);
-                f32_t ab = _mm512_reduce_add_ps(sum_ab[I]);
-                aa += dot_scalar(current_vecs[I][dims - 1], current_vecs[I][dims - 1]);
-                ab += dot_scalar(current_vecs[I][dims - 1], b[dims - 1]);
-                results[c + I] = aa + bb - 2.0f * ab;
-            });
-        } else {
-            apply_indexed<batches>([&](auto I) {
-                f32_t aa = _mm512_reduce_add_ps(sum_aa[I]);
-                f32_t ab = _mm512_reduce_add_ps(sum_ab[I]);
-                results[c + I] = aa + bb - 2.0f * ab;
-            });
-        }
+        apply_indexed<batches>([&](auto I) {
+            results[c + I] = _mm512_reduce_add_ps(_mm512_add_ps(sum_even[I], sum_odd[I]));
+        });
 
         if (has_next) {
             std::copy_n(next_vecs, batches, current_vecs);

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/SimdVecLibraryBFloat16Tests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/SimdVecLibraryBFloat16Tests.java
@@ -25,6 +25,7 @@ import java.util.function.IntFunction;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT_UNALIGNED;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class SimdVecLibraryBFloat16Tests extends SimdVecLibraryTests {
 
@@ -312,6 +313,110 @@ public class SimdVecLibraryBFloat16Tests extends SimdVecLibraryTests {
         assertScoresEquals(expectedScores, bulkScoresSeg, delta);
     }
 
+    /**
+     * Squared distance of duplicate and near-duplicate vectors at raw (unnormalised) scale, where the norms are large
+     * compared to the distance. The result must be non-negative, exactly 0 for an exact duplicate, and within f32
+     * rounding of the scalar reference; Lucene's distance-to-score mapping requires a non-negative distance.
+     */
+    public void testDuplicateAndNearDuplicateVectors() {
+        assumeTrue(notSupportedMsg(), supported());
+        assumeTrue("only meaningful for squared distance", function == SimdVecLibrary.SimilarityFunction.SQUARE_DISTANCE);
+        final int dims = size;
+        final float scale = randomFrom(64f, 150f, 300f, 500f, 1000f);
+
+        float[] base = new float[dims];
+        for (int i = 0; i < dims; i++) {
+            base[i] = BFloat16.truncateToBFloat16((randomFloat() * 2f - 1f) * scale);
+        }
+
+        // vector 0 is an exact duplicate of the query; the others differ by one bf16 ulp in a few components
+        final int numVecs = randomIntBetween(2, 17);
+        float[][] docs = new float[numVecs][];
+        docs[0] = base.clone();
+        for (int v = 1; v < numVecs; v++) {
+            docs[v] = base.clone();
+            int perturbed = randomIntBetween(1, Math.min(4, dims));
+            for (int k = 0; k < perturbed; k++) {
+                int idx = randomInt(dims - 1);
+                docs[v][idx] = nextBFloat16AwayFromZero(docs[v][idx]);
+            }
+        }
+
+        var bf16Segment = arena.allocate((long) dims * numVecs * BFloat16.BYTES);
+        for (int v = 0; v < numVecs; v++) {
+            copyToBFloat16Segment(docs[v], bf16Segment, (long) v * dims * BFloat16.BYTES);
+        }
+        MemorySegment querySeg = switch (queryType) {
+            case BFLOAT16 -> {
+                var seg = arena.allocate((long) dims * BFloat16.BYTES);
+                copyToBFloat16Segment(base, seg, 0L);
+                yield seg;
+            }
+            case FLOAT32 -> {
+                var seg = arena.allocate((long) dims * Float.BYTES);
+                MemorySegment.copy(base, 0, seg, LAYOUT_LE_FLOAT, 0L, dims);
+                yield seg;
+            }
+        };
+
+        // single
+        for (int v = 0; v < numVecs; v++) {
+            float expected = ScalarOperations.similarity(function, base, docs[v]);
+            var docSeg = bf16Segment.asSlice((long) v * dims * BFloat16.BYTES, (long) dims * BFloat16.BYTES);
+            assertDistance("single vector " + v, expected, similarity(docSeg, querySeg, dims));
+        }
+
+        // bulk (sequential)
+        int[] identity = new int[numVecs];
+        for (int v = 0; v < numVecs; v++) {
+            identity[v] = v;
+        }
+        float[] expected = new float[numVecs];
+        ScalarOperations.bulkWithOffsets(function, base, docs, identity, expected);
+        var scores = arena.allocate((long) numVecs * Float.BYTES);
+        similarityBulk(bf16Segment, querySeg, dims, numVecs, scores);
+        assertDistances("bulk", expected, scores);
+
+        // bulk with offsets (random ordinals)
+        int[] ordinals = new int[numVecs];
+        for (int v = 0; v < numVecs; v++) {
+            ordinals[v] = randomInt(numVecs - 1);
+        }
+        // Guarantee that every layout scores the exact duplicate (docs[0]) on every seed.
+        ordinals[0] = 0;
+        ScalarOperations.bulkWithOffsets(function, base, docs, ordinals, expected);
+        var offsetsSeg = arena.allocate((long) numVecs * Integer.BYTES);
+        for (int v = 0; v < numVecs; v++) {
+            offsetsSeg.setAtIndex(ValueLayout.JAVA_INT, v, ordinals[v]);
+        }
+        similarityBulkWithOffsets(bf16Segment, querySeg, dims, dims * BFloat16.BYTES, offsetsSeg, numVecs, scores);
+        assertDistances("bulk offsets", expected, scores);
+
+        // bulk sparse (same ordinals as addresses)
+        var addressesSeg = arena.allocate(ValueLayout.ADDRESS.byteSize() * numVecs, ValueLayout.ADDRESS.byteAlignment());
+        for (int v = 0; v < numVecs; v++) {
+            addressesSeg.setAtIndex(
+                ValueLayout.ADDRESS,
+                v,
+                bf16Segment.asSlice((long) ordinals[v] * dims * BFloat16.BYTES, (long) dims * BFloat16.BYTES)
+            );
+        }
+        similarityBulkSparse(addressesSeg, querySeg, dims, numVecs, scores);
+        assertDistances("bulk sparse", expected, scores);
+    }
+
+    private static void assertDistance(String what, float expected, float actual) {
+        assertThat(what + " must not be negative", actual, greaterThanOrEqualTo(0f));
+        // an exact duplicate must be exactly 0; otherwise allow f32 accumulation-order differences
+        assertEquals(what, expected, actual, expected * 1e-3f);
+    }
+
+    private static void assertDistances(String what, float[] expected, MemorySegment scores) {
+        for (int v = 0; v < expected.length; v++) {
+            assertDistance(what + " vector " + v, expected[v], scores.getAtIndex(JAVA_FLOAT_UNALIGNED, v));
+        }
+    }
+
     // Verifies that bulk sparse similarity rejects invalid arguments (undersized segments,
     // negative dims/count) with appropriate out-of-bounds exceptions.
     public void testBulkSparseIllegalArgs() {
@@ -446,6 +551,12 @@ public class SimdVecLibraryBFloat16Tests extends SimdVecLibraryTests {
             fa[i] = BFloat16.truncateToBFloat16(randomFloat());
         }
         return fa;
+    }
+
+    /** The adjacent bf16 value one ulp further from zero; {@code bf16Value} must itself be a bf16 value. */
+    static float nextBFloat16AwayFromZero(float bf16Value) {
+        short bits = BFloat16.floatToBFloat16(bf16Value);
+        return BFloat16.bFloat16ToFloat((short) (bits + 1));
     }
 
     private static void copyToBFloat16Segment(float[] fa, MemorySegment segment, long offset) {

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/SimdVecLibraryBFloat16Tests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/SimdVecLibraryBFloat16Tests.java
@@ -555,8 +555,7 @@ public class SimdVecLibraryBFloat16Tests extends SimdVecLibraryTests {
 
     /** The adjacent bf16 value one ulp further from zero; {@code bf16Value} must itself be a bf16 value. */
     static float nextBFloat16AwayFromZero(float bf16Value) {
-        short bits = BFloat16.floatToBFloat16(bf16Value);
-        return BFloat16.bFloat16ToFloat((short) (bits + 1));
+        return Float.intBitsToFloat(Float.floatToRawIntBits(bf16Value) + 0x10000);
     }
 
     private static void copyToBFloat16Segment(float[] fa, MemorySegment segment, long offset) {


### PR DESCRIPTION
## Summary

The tier-3 AVX-512 (`vec_bf16_3.cpp`) and SVE (`aarch64/vec_bf16_2.cpp`) bf16 x bf16 squared-distance kernels
computed `|a-b|^2` as `a.a - 2a.b + b.b` with three native bf16 dot products. Each term is rounded to f32 at the
magnitude of the vector norms, so for near-duplicate vectors the result is rounding noise and frequently negative.
This PR replaces the identity with a direct `sum((a-b)^2)` on f32-widened lanes, in the single and bulk kernels on
both architectures, and adds a regression test with duplicate and one-ulp-perturbed vectors at raw scale.

## Intention

`BFloat16VectorScorerSupplier` maps the distance with Lucene's `normalizeDistanceToUnitInterval`, `1 / (1 + d)`,
which requires `d >= 0`. With the identity, a vector compared with itself at dims 1024 and values in +-150 returned
exactly -1 in about one of ten random draws (score +Infinity), and a two-component one-ulp perturbation at dims 4096,
values +-500, returned -128 where the exact distance is 5 (score -0.008 instead of 0.167). An unnormalised
`element_type: bfloat16` index with `l2_norm` can therefore rank an exact duplicate as the worst candidate or give
it an infinite score. Unit-normalised vectors are not affected in practice. The tier-1 AVX2 and NEON kernels never
used the identity, so scores also differed between hosts.

## Changes

- `amd64/vec_bf16_3.cpp`: `sqrDbf16Qbf16_inner_avx512` and `sqrDbf16Qbf16_bulk_avx512` widen bf16 to f32 with a
  shift (even lanes) and a mask (odd lanes), subtract and fused-multiply-add. Two integer ops per 32 elements per
  operand, no shuffles, no masked `vdpbf16ps`, no scalar tail for odd dims (masked-off lanes contribute 0).
- `aarch64/vec_bf16_2.cpp`: same for `sqrDbf16Qbf16_inner_sve` and `sqrDbf16Qbf16_bulk_sve`.
- `SimdVecLibraryBFloat16Tests.testDuplicateAndNearDuplicateVectors`: single, bulk, bulk offsets and bulk sparse;
  asserts every distance is non-negative, exact duplicates are exactly 0, near-duplicates within 0.1 % of the
  scalar reference. One ordinal is pinned to the exact duplicate, ensuring every layout scores it on every seed.
  Fails on the previous tier-3 kernels, passes on tiers 1 and 2. Against the published 1.0.140 library on this
  host, 23 of 124 parameterised instances fail, all of them `BFLOAT16` query `SQUARE_DISTANCE`, with negative
  distances such as -1.0 and -0.125; against the library built from this branch the whole class passes.
- Native library version 1.0.140 to 1.0.141.

## Performance

All measurements on a Xeon w5-3435X (Sapphire Rapids), library built with the clang-21 cross-toolchain image.

### Single-pair, L1-resident (pre-implementation microbenchmark)

| dims | identity | direct (a-b)^2 |
|------|----------|----------------|
| 768  | 37.4 ns  | 24.9 ns        |
| 1024 | 48.8 ns  | 33.8 ns        |
| 1536 | 71.7 ns  | 46.6 ns        |

`vdpbf16ps` is four uops on Intel server cores, so the identity cost twelve uops per 32 elements against eight for
the direct path.

### dlopen A/B per-layout summary (interleaved re-measurement, 80-cell grid)

The grid covers dims {384, 768, 1024, 1536}, numVectors {128, 2500, 65000}, and bulkSize {32, 1024}, with four
call-path layouts (single, sequential, offsets, sparse). Two fully interleaved repetitions (r1, r2) were run,
each alternating between the baseline (1.0.140) and fixed libraries to equalise residual cache state.

A first-run cell at sequential/384 dims/65000 vectors showed -26 % for the fixed library. This did not reproduce
in either interleaved repetition (r1: +7.0 %, r2: -2.6 %); the 49.9 MB working set marginally exceeds the 45 MB L3,
and the original baseline measurement had been taken while the cache was still warm from a prior pass. Both
subsequent runs fell into the 15-17 GB/s DRAM throughput band seen at all other sequential/large-working-set cells
for both libraries. No genuine regression is present.

| layout     | r1 mean | r1 range           | r2 mean | r2 range           |
|------------|---------|--------------------|---------|--------------------|
| single     | +30.2%  | +10.4 % to +36.0 % | +27.1%  | +0.6 % to +36.4 %  |
| sequential | +12.8%  | -9.7 % to +36.4 %  | +13.0%  | -4.2 % to +36.4 %  |
| offsets    | +23.7%  | -13.1 % to +33.9 % | +24.1%  | -7.3 % to +33.5 %  |
| sparse     | +24.7%  | -12.7 % to +33.1 % | +24.8%  | -1.4 % to +34.4 %  |

Negative values in the range column are DRAM-bound sequential cells at 65000 vectors; they are within noise across
repetitions (no cell shows a consistent >5 % regression in both r1 and r2).

### JMH single-vector (`VectorScorerBFloat16OperationBenchmark.nativeWithNativeSeg`, EUCLIDEAN BFLOAT16)

| dims | baseline (ns/op) | fixed (ns/op) | speedup |
|------|-----------------|---------------|---------|
| 768  | 39.864 ± 0.939  | 27.714 ± 1.521 | +30.5 % |
| 1024 | 51.854 ± 1.318  | 33.790 ± 0.624 | +34.8 % |
| 1536 | 75.545 ± 2.152  | 48.207 ± 0.747 | +36.2 % |

### JMH bulk (`VectorScorerBFloat16BulkOperationBenchmark`, dims=1024, bulkSize=32, EUCLIDEAN BFLOAT16, ops/s)

Higher ops/s is better. Cells marked [noise] have a difference below one combined standard deviation.

| benchmark          | numVectors | baseline ops/s        | fixed ops/s            | change    |
|--------------------|------------|----------------------|------------------------|-----------|
| scoreBulk          | 128        | 146 290 ± 7 503      | 230 299 ± 7 133        | +57.4 %   |
| scoreBulk          | 2 500      | 7 218 ± 533          | 7 799 ± 642            | +8.1 % [noise] |
| scoreBulk          | 65 000     | 672 ± 46             | 700 ± 113              | +4.1 % [noise] |
| scoreBulkOffsets   | 128        | 203 281 ± 7 479      | 289 428 ± 12 842       | +42.4 %   |
| scoreBulkOffsets   | 2 500      | 7 380 ± 2 420        | 7 400 ± 3 452          | +0.3 % [noise] |
| scoreBulkOffsets   | 65 000     | 471 ± 56             | 503 ± 36               | +6.9 % [noise] |
| scoreBulkSparse    | 128        | 203 621 ± 944        | 292 481 ± 18 339       | +43.6 %   |
| scoreBulkSparse    | 2 500      | 7 390 ± 1 997        | 7 107 ± 663            | -3.8 % [noise] |
| scoreBulkSparse    | 65 000     | 484 ± 64             | 508 ± 34               | +5.0 % [noise] |
| scoreRandom        | 128        | 147 005 ± 5 749      | 205 028 ± 10 296       | +39.5 %   |
| scoreRandom        | 2 500      | 4 213 ± 638          | 4 298 ± 367            | +2.0 % [noise] |
| scoreRandom        | 65 000     | 205 ± 7              | 225 ± 4                | +9.8 %    |
| scoreSequential    | 128        | 144 468 ± 7 162      | 215 340 ± 5 249        | +49.1 %   |
| scoreSequential    | 2 500      | 6 724 ± 370          | 7 471 ± 1 478          | +11.1 % [noise] |
| scoreSequential    | 65 000     | 613 ± 73             | 519 ± 89               | -15.4 % [noise] |

The scoreSequential/65000 difference (-94 ops/s) is within one combined standard deviation (115 ops/s); the dlopen
bench at the same working set (1024 dims, 65000 vectors) also showed no consistent regression (-1.8 % at bulkSize 32,
+1.1 % at bulkSize 1024, both within noise).

## Notes

- **No aarch64 hardware was available to me.** The SVE kernels are cross-compiled with the toolchain image and
  verified for correctness under QEMU user-mode emulation (arm64 Docker container): 22680
  checks, 0 failures for both the SVE exports and the NEON tier-1 control. Graviton 3/4 performance is unmeasured;
  a run of `VectorScorerBFloat16OperationBenchmark` and `VectorScorerBFloat16BulkOperationBenchmark` with
  `function=EUCLIDEAN queryType=BFLOAT16` on c7g/c8g before and after would be appreciated.
- **No Zen 4/5 hardware was available.** `vdpbf16ps` is a single uop on Zen, so the removed identity may have been
  faster there in cache-resident cases. If a c8a run shows a regression, the alternative is to keep the identity and
  recompute exactly only when the result is below `self_sum / 4096` (cancellation guard); measured cost of the guard
  is below 1 ns.
