### PR TITLE
[DOCS] Add ES|QL histogram fields guide

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/exponential-histogram.md
+++ b/docs/reference/elasticsearch/mapping-reference/exponential-histogram.md
@@ -67,7 +67,7 @@ If the histogram is empty (no positive/negative buckets and zero count is `0`), 
 
 `exponential_histogram` fields are primarily intended for use with aggregations. To make them efficient for aggregations, the histogram is stored as compact [doc values](/reference/elasticsearch/mapping-reference/doc-values.md) and not indexed.
 
-Exponential histograms are supported in ES|QL; see the [ES|QL reference](/reference/query-languages/esql.md) for details.
+Exponential histograms are supported in ES|QL. Refer to [](/reference/query-languages/esql/esql-histogram-fields.md) for supported aggregation functions, casting, and query examples.
 
 In Query DSL, because the data is not indexed, you can use `exponential_histogram` fields only with the following aggregations:
 

--- a/docs/reference/elasticsearch/mapping-reference/histogram.md
+++ b/docs/reference/elasticsearch/mapping-reference/histogram.md
@@ -42,6 +42,10 @@ Because the data is not indexed, you only can use `histogram` fields for the fol
 * [range](/reference/aggregations/search-aggregations-bucket-range-aggregation.md#search-aggregations-bucket-range-aggregation-histogram-fields) aggregation
 * [exists](/reference/query-languages/query-dsl/query-dsl-exists-query.md) query
 
+### Query histogram fields in ES|QL
+
+In ES|QL, `histogram` fields that contain T-Digest data can be queried by casting to `tdigest` or `exponential_histogram`. HDR histogram data is not supported. Refer to [](/reference/query-languages/esql/esql-histogram-fields.md) for details.
+
 
 ## Building a histogram [mapping-types-histogram-building-histogram]
 

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/ts.md
@@ -149,6 +149,10 @@ Typically, `::exponential_histogram` is the right choice, unless you know that y
 You can use [`METRICS_INFO`](/reference/query-languages/esql/commands/metrics-info.md) to inspect
 the field type.
 
+For the full list of supported aggregation functions, casting between histogram types, and
+using `FROM` with histogram fields, refer to
+[](/reference/query-languages/esql/esql-histogram-fields.md).
+
 ## Grouping time series [grouping-time-series]
 
 When the first `STATS` after `TS` uses a bare

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -274,7 +274,6 @@ which field types are in use across backing indices.
 - [`VALUES`](/reference/query-languages/esql/functions-operators/aggregation-functions/values.md) does not accept histogram types.
 - Multivalue functions like [`MV_FIRST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_first.md), [`MV_LAST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_last.md), and [`MV_COUNT`](/reference/query-languages/esql/functions-operators/mv-functions/mv_count.md) reject histogram fields.
 - Counts and percentiles derived from histogram fields are estimates because the underlying data structures store distributions, not exact values.
-- [`TO_STRING`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_string.md) works on `exponential_histogram` and `histogram` fields but does not currently support `tdigest`.
 
 ## Further reading
 

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -267,28 +267,6 @@ recommended.
 Use [`METRICS_INFO`](/reference/query-languages/esql/commands/metrics-info.md) to inspect
 which field types are in use across backing indices.
 
-## Ingest OpenTelemetry exponential histograms
-
-To send OpenTelemetry exponential histograms directly to {{es}}, point your OTel SDK or agent
-at the [{{es}} OTLP/HTTP endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-otlp.md)
-and configure the following environment variables:
-
-```yaml
-OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
-OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
-```
-
-- **Temporality preference**: {{es}} supports both delta and cumulative
-  ({applies_to}`stack: ga 9.5`) temporality for `exponential_histogram` fields. Delta
-  temporality (where the histogram is cleared after each export) is recommended for most use
-  cases. `tdigest` fields support delta temporality only.
-- **Default histogram aggregation**: By default, OpenTelemetry exports histograms in the
-  classic fixed-bucket format. Setting this to `BASE2_EXPONENTIAL_BUCKET_HISTOGRAM` uses
-  exponential histograms instead.
-
-The histograms are stored natively as `exponential_histogram` fields and are queryable
-immediately in {{esql}}.
-
 ## Limitations
 
 - Sorting on histogram fields is not allowed. Use [`SORT`](/reference/query-languages/esql/commands/sort.md) on aggregated results (like `RANGE_MIN(bucket)`) instead of on the histogram field itself.
@@ -305,6 +283,8 @@ immediately in {{esql}}.
   percentile analysis of JVM garbage collection metrics.
 - [Work with histogram metrics](/reference/query-languages/esql/commands/ts.md#work-with-histogram-metrics):
   Histogram-specific guidance in the `TS` command reference.
+- [Ingest OpenTelemetry data via OTLP](docs-content://manage-data/data-store/data-streams/tsds-ingest-otlp.md):
+  How to send OpenTelemetry exponential histograms to {{es}}.
 - [Exponential histogram field type](/reference/elasticsearch/mapping-reference/exponential-histogram.md):
   Mapping reference for the `exponential_histogram` field type.
 - [Downsampling time series data](docs-content://manage-data/data-store/data-streams/downsampling-time-series-data-stream.md):

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -83,8 +83,10 @@ Apply regular [aggregation functions](/reference/query-languages/esql/functions-
 directly to histogram fields. Aggregations act as if you were running them on the raw
 observations that produced the histogram. For example, `COUNT(responseTime)` returns the
 total number of HTTP requests whose response times were recorded, not the number of
-histogram documents. You do not need a time series aggregation function like `RATE` or
-`AVG_OVER_TIME`. The following functions support histogram inputs:
+histogram documents. You do not need a time series aggregation function like
+[`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md) or
+[`AVG_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/avg_over_time.md).
+The following functions support histogram inputs:
 
 | Function | What it returns for histogram fields |
 |---|---|
@@ -139,7 +141,9 @@ aggregation then operates on these merged per-series histograms.
 The [time series aggregation functions](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md)
 (`*_OVER_TIME` variants) also accept histogram inputs for windowed aggregation within a time
 series. You can use these when you need finer control over the aggregation window, for example
-`FIRST_OVER_TIME` or `LAST_OVER_TIME` to select the histogram from a specific point in the
+[`FIRST_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/first_over_time.md)
+or [`LAST_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/last_over_time.md)
+to select the histogram from a specific point in the
 time series. For most use cases, the regular aggregation functions above are sufficient.
 
 ### Using `FROM` with histogram fields
@@ -225,7 +229,7 @@ Exponential histograms skip empty buckets.
 
 ## Cast between histogram types
 
-Use the casting operator (`::`) to convert between histogram types inline:
+Use the [casting operator (`::`)](/reference/query-languages/esql/functions-operators/operators.md#esql-cast-operator) to convert between histogram types inline:
 
 - `field::exponential_histogram` converts to an exponential histogram. This is the recommended
   default.
@@ -241,7 +245,7 @@ TS metrics-*
 You can also use the explicit conversion functions
 [`TO_EXPONENTIAL_HISTOGRAM`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_exponential_histogram.md)
 and [`TO_TDIGEST`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_tdigest.md)
-in an `EVAL` step. Both functions accept all three histogram types as input and return the
+in an [`EVAL`](/reference/query-languages/esql/commands/eval.md) step. Both functions accept all three histogram types as input and return the
 target type (identity conversion is a no-op).
 
 ## Query historical data alongside new data
@@ -302,16 +306,16 @@ immediately in {{esql}}.
 
 ## Limitations
 
-- **No sorting.** Sorting on histogram fields is not allowed. Use `SORT` on aggregated results
+- **No sorting.** Sorting on histogram fields is not allowed. Use [`SORT`](/reference/query-languages/esql/commands/sort.md) on aggregated results
   (like `RANGE_MIN(bucket)`) instead of on the histogram field itself.
-- **No `RATE`.** The `RATE` function does not support histogram fields. If you need rate-like
+- **No `RATE`.** The [`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md) function does not support histogram fields. If you need rate-like
   computations, use other aggregation functions on the histogram directly.
-- **No `VALUES`.** The `VALUES` aggregation does not support histogram types.
-- **No multivalue functions.** Functions like `MV_FIRST`, `MV_LAST`, and `MV_COUNT` reject
+- **No `VALUES`.** The [`VALUES`](/reference/query-languages/esql/functions-operators/aggregation-functions/values.md) aggregation does not support histogram types.
+- **No multivalue functions.** Functions like [`MV_FIRST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_first.md), [`MV_LAST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_last.md), and [`MV_COUNT`](/reference/query-languages/esql/functions-operators/mv-functions/mv_count.md) reject
   histogram fields.
 - **Approximate counts.** Counts and percentiles derived from histogram fields are estimates
   because the underlying data structures store distributions, not exact values.
-- **`TO_STRING` gap.** `TO_STRING` works on `exponential_histogram` and `histogram` fields but
+- **`TO_STRING` gap.** [`TO_STRING`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_string.md) works on `exponential_histogram` and `histogram` fields but
   does not currently support `tdigest`.
 
 ## Further reading

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -8,33 +8,36 @@ navigation_title: "Histogram fields"
 # Query histogram fields in {{esql}} [esql-histogram-fields]
 
 Histogram fields store pre-aggregated value distributions rather than individual data points.
-They appear in [time series data streams](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md)
-(TSDS) as metrics that capture latency distributions, request sizes, or other measurements
-where storing every raw value is not practical. For example, an OpenTelemetry agent can record
-thousands of HTTP request durations per minute and ship them as a single exponential histogram
-per collection interval, giving you percentile estimates at query time without the storage cost
-of every individual sample.
+They are useful anywhere you have high-volume numeric data and need percentile, average, or
+count queries without the storage cost of keeping every raw value. The most common source is
+observability pipelines: an OpenTelemetry agent can record thousands of HTTP request durations
+per minute and ship them as a single exponential histogram per collection interval.
 
 This page explains the histogram field types available in {{esql}}, how to query them, and
 how to create value-distribution histograms from them.
 
 ## Why histogram fields exist
 
-Counters and gauges are the most common metric types, but they fall short when you need to
-understand the distribution of values rather than just a total or an average. For example,
-knowing that your average HTTP response time is 3ms tells you little about outliers. The best
-insights come from analyzing the full distribution through median and percentile calculations.
+When you need to understand the distribution of values across a large population, storing
+every individual observation is often impractical. A histogram compresses those observations
+into a compact summary that still supports percentile queries, averages, and counts. This
+makes histograms useful anywhere you have high-volume numeric data and care about the shape
+of the distribution, not just a single aggregate.
 
-Classic Prometheus-style histograms address this by defining fixed buckets (for example, one for
-response times in the range `[0s, 1s)`, one for `[1s, 4s)`, and so on) and associating a counter
-with each. However, you have to know the distribution of your data up front to define useful
-buckets. If the boundaries are wrong, you lose accuracy.
+For example, knowing that your average HTTP response time is 3ms tells you little about
+outliers. A histogram preserves enough detail to answer questions like "what is the 99th
+percentile?" without storing every request.
 
-Exponential histograms solve this problem. They assign values to buckets whose sizes increase
-exponentially: small buckets for small values, wider buckets for larger values. The boundaries
-adapt dynamically based on collected values, so you do not need to define them up front. This
-gives you a guaranteed upper bound on relative error for every percentile. For a deeper
-explanation, refer to the
+### Histograms in metrics and observability
+
+Histograms are widely used in metrics pipelines.
+[OpenTelemetry](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram)
+and [Prometheus](https://prometheus.io/docs/specs/native_histograms/) both define exponential
+histogram formats that dynamically adapt bucket boundaries to the data, giving a guaranteed
+upper bound on relative error for every percentile. Classic Prometheus-style histograms use
+fixed buckets instead, which requires knowing the value distribution up front.
+
+For a deeper explanation of how exponential bucketing works, refer to the
 [OpenTelemetry exponential histograms introduction](https://opentelemetry.io/blog/2022/exponential-histograms/).
 
 ## Histogram field types
@@ -83,10 +86,7 @@ Apply regular [aggregation functions](/reference/query-languages/esql/functions-
 directly to histogram fields. Aggregations act as if you were running them on the raw
 observations that produced the histogram. For example, `COUNT(responseTime)` returns the
 total number of HTTP requests whose response times were recorded, not the number of
-histogram documents. You do not need a time series aggregation function like
-[`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md) or
-[`AVG_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/avg_over_time.md).
-The following functions support histogram inputs:
+histogram documents. The following functions support histogram inputs:
 
 | Function | What it returns for histogram fields |
 |---|---|
@@ -101,33 +101,31 @@ The following functions support histogram inputs:
 | [`LAST`](/reference/query-languages/esql/functions-operators/aggregation-functions/last.md) / [`LATEST`](/reference/query-languages/esql/functions-operators/aggregation-functions/latest.md) | Last histogram value by sort order / timestamp {applies_to}`stack: ga 9.5` |
 
 For example, to calculate the count, average, and 99th-percentile duration of garbage collection
-events per action in 5-minute buckets:
+events per action:
 
 ```esql
-TS metrics-*
-| WHERE TRANGE(1 hour)
+FROM metrics-*
 | STATS count = COUNT(jvm.gc.duration),
         avg = AVG(jvm.gc.duration),
         p99 = PERCENTILE(jvm.gc.duration, 99)
-  BY jvm.gc.action, TBUCKET(5 minutes)
+  BY jvm.gc.action
 ```
 
-Because `PERCENTILE` works on the merged histogram directly, you can query any percentile at
+Because `PERCENTILE` works on the histogram directly, you can query any percentile at
 runtime without having to pre-define bucket boundaries at index time. This is a key advantage
 of the `exponential_histogram` type over classic fixed-bucket approaches.
 
 You can combine multiple aggregations in a single query to get a complete picture of the
-distribution over time. For example, to compare the minimum, median, 99th percentile, and
-maximum of major garbage collection durations across time buckets:
+distribution. For example, to compare the minimum, median, 99th percentile, and maximum of
+major garbage collection durations:
 
 ```esql
-TS metrics-*
+FROM metrics-*
 | WHERE jvm.gc.action == "end of major GC"
 | STATS MAX(jvm.gc.duration),
         PERCENTILE(jvm.gc.duration, 99),
         MEDIAN(jvm.gc.duration),
         MIN(jvm.gc.duration)
-  BY TBUCKET(100)
 ```
 
 ### Using `TS` with histogram fields
@@ -138,13 +136,28 @@ merge: all histogram documents within each time series are combined into a singl
 and the metric's temporality (delta or cumulative) is respected during the merge. The outer
 aggregation then operates on these merged per-series histograms.
 
+You do not need a time series aggregation function like
+[`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md) or
+[`AVG_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/avg_over_time.md)
+to query histogram fields. Use the regular aggregation functions from the table above, combined
+with `TBUCKET` for time-based grouping:
+
+```esql
+TS metrics-*
+| WHERE TRANGE(1 hour)
+| STATS count = COUNT(jvm.gc.duration),
+        avg = AVG(jvm.gc.duration),
+        p99 = PERCENTILE(jvm.gc.duration, 99)
+  BY jvm.gc.action, TBUCKET(5 minutes)
+```
+
 The [time series aggregation functions](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md)
 (`*_OVER_TIME` variants) also accept histogram inputs for windowed aggregation within a time
 series. You can use these when you need finer control over the aggregation window, for example
 [`FIRST_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/first_over_time.md)
 or [`LAST_OVER_TIME`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/last_over_time.md)
 to select the histogram from a specific point in the
-time series. For most use cases, the regular aggregation functions above are sufficient.
+time series. For most use cases, the regular aggregation functions are sufficient.
 
 ### Using `FROM` with histogram fields
 
@@ -181,7 +194,7 @@ bucket as the second argument to `COUNT` to count the histogram values that fall
 bucket:
 
 ```esql
-TS exp_histo_sample
+FROM exp_histo_sample
 | WHERE instance == "instance-0"
 | STATS count = COUNT(responseTime, bucket) BY bucket = BUCKET(responseTime, 1)
 | SORT RANGE_MIN(bucket)
@@ -207,7 +220,7 @@ Histograms record approximate value distributions, so the counts per bucket are 
 The same pattern works for `tdigest` fields. [Cast the field](#cast-between-histogram-types) if needed:
 
 ```esql
-TS histogram_timeseries_index
+FROM histogram_timeseries_index
 | WHERE instance == "instance-0"
 | STATS count = COUNT(responseTime::tdigest, bucket) BY bucket = BUCKET(responseTime::tdigest, 1)
 | SORT RANGE_MIN(bucket)
@@ -237,9 +250,8 @@ Use the [casting operator (`::`)](/reference/query-languages/esql/functions-oper
   as T-Digest centroids.
 
 ```esql
-TS metrics-*
-| WHERE TRANGE(1 hour)
-| STATS avg = AVG(response_time::exponential_histogram) BY TBUCKET(5 minutes)
+FROM metrics-*
+| STATS avg = AVG(response_time::exponential_histogram) BY instance
 ```
 
 You can also use the explicit conversion functions
@@ -258,9 +270,8 @@ Thanks to [union types](/reference/query-languages/esql/esql-multi-index.md#esql
 you can query across both by adding a `::exponential_histogram` cast:
 
 ```esql
-TS metrics-*
-| WHERE TRANGE(1 hour)
-| STATS avg = AVG(jvm.gc.duration::exponential_histogram) BY TBUCKET(5 minutes)
+FROM metrics-*
+| STATS avg = AVG(jvm.gc.duration::exponential_histogram) BY jvm.gc.action
 ```
 
 When this query encounters `histogram` fields, it converts them to exponential histograms.

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -1,6 +1,6 @@
 ---
 applies_to:
-  stack: preview 9.3, ga 9.4
+  stack: ga
   serverless: ga
 navigation_title: "Histogram fields"
 ---

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -1,0 +1,331 @@
+---
+applies_to:
+  stack: preview 9.3, ga 9.4
+  serverless: ga
+navigation_title: "Histogram fields"
+---
+
+# Query histogram fields in {{esql}} [esql-histogram-fields]
+
+Histogram fields store pre-aggregated value distributions rather than individual data points.
+They appear in [time series data streams](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md)
+(TSDS) as metrics that capture latency distributions, request sizes, or other measurements
+where storing every raw value is not practical. For example, an OpenTelemetry agent can record
+thousands of HTTP request durations per minute and ship them as a single exponential histogram
+per collection interval, giving you percentile estimates at query time without the storage cost
+of every individual sample.
+
+This page explains the histogram field types available in {{esql}}, how to query them, and
+how to create value-distribution histograms from them.
+
+## Why histogram fields exist
+
+Counters and gauges are the most common metric types, but they fall short when you need to
+understand the distribution of values rather than just a total or an average. For example,
+knowing that your average HTTP response time is 3ms tells you little about outliers. The best
+insights come from analyzing the full distribution through median and percentile calculations.
+
+Classic Prometheus-style histograms address this by defining fixed buckets (for example, one for
+response times in the range `[0s, 1s)`, one for `[1s, 4s)`, and so on) and associating a counter
+with each. However, you have to know the distribution of your data up front to define useful
+buckets. If the boundaries are wrong, you lose accuracy.
+
+Exponential histograms solve this problem. They assign values to buckets whose sizes increase
+exponentially: small buckets for small values, wider buckets for larger values. The boundaries
+adapt dynamically based on collected values, so you do not need to define them up front. This
+gives you a guaranteed upper bound on relative error for every percentile. For a deeper
+explanation, refer to the
+[OpenTelemetry exponential histograms introduction](https://opentelemetry.io/blog/2022/exponential-histograms/).
+
+## Histogram field types
+
+{{esql}} recognizes three histogram field types:
+
+`exponential_histogram`
+:   The recommended type for new data. Uses an exponential bucketing scheme that dynamically
+    adapts to your data and provides a guaranteed upper bound on relative error for every
+    percentile. This is the native format used by
+    [OpenTelemetry exponential histograms](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram)
+    and maps directly to
+    [Prometheus native histograms](https://prometheus.io/docs/specs/native_histograms/).
+    Most aggregation functions work natively with this type.
+
+`tdigest`
+:   Stores a [T-Digest](https://github.com/tdunning/t-digest) data structure. Provides good
+    accuracy for extreme percentiles (like p99) but loses accuracy for mid-range percentiles
+    like the median. Before {{es}} 9.4, OpenTelemetry histograms were converted to T-Digest
+    for storage. Use this type when your data is already stored as T-Digest values.
+
+`histogram` (legacy)
+:   The original [histogram field type](/reference/elasticsearch/mapping-reference/histogram.md).
+    This type can represent either T-Digest or HDR histogram data, but {{esql}} only supports
+    T-Digest. Cast `histogram` fields with `::tdigest` to query them, or with
+    `::exponential_histogram` to convert them for use alongside newer data. Refer to
+    [Cast between histogram types](#cast-between-histogram-types).
+
+To check which type a metric uses, run
+[`METRICS_INFO`](/reference/query-languages/esql/commands/metrics-info.md) against the
+data stream.
+
+### Choosing between exponential histogram and T-Digest
+
+For new data, use `exponential_histogram`. It provides a guaranteed upper bound on relative
+error for every percentile and eliminates the lossy conversion step that T-Digest requires.
+Percentile computation on exponential histograms is also more efficient at query time.
+
+Use `tdigest` only when your data is already stored in that format. T-Digest provides good
+accuracy at the tails of the distribution (p99, p99.9) but lower accuracy for mid-range
+percentiles like the median. It also only supports delta temporality (not cumulative).
+
+## Aggregate histogram fields
+
+Apply regular [aggregation functions](/reference/query-languages/esql/functions-operators/aggregation-functions.md)
+directly to histogram fields. Aggregations act as if you were running them on the raw
+observations that produced the histogram. For example, `COUNT(responseTime)` returns the
+total number of HTTP requests whose response times were recorded, not the number of
+histogram documents. You do not need a time series aggregation function like `RATE` or
+`AVG_OVER_TIME`. The following functions support histogram inputs:
+
+| Function | What it returns for histogram fields |
+|---|---|
+| [`COUNT`](/reference/query-languages/esql/functions-operators/aggregation-functions/count.md) | Total number of values recorded across all histograms |
+| [`SUM`](/reference/query-languages/esql/functions-operators/aggregation-functions/sum.md) | Sum of all recorded values |
+| [`AVG`](/reference/query-languages/esql/functions-operators/aggregation-functions/avg.md) | Average of all recorded values (computed as `SUM / COUNT`) |
+| [`MIN`](/reference/query-languages/esql/functions-operators/aggregation-functions/min.md) | Minimum recorded value |
+| [`MAX`](/reference/query-languages/esql/functions-operators/aggregation-functions/max.md) | Maximum recorded value |
+| [`MEDIAN`](/reference/query-languages/esql/functions-operators/aggregation-functions/median.md) | Estimated median (50th percentile) |
+| [`PERCENTILE`](/reference/query-languages/esql/functions-operators/aggregation-functions/percentile.md) | Estimated value at a given percentile |
+| [`FIRST`](/reference/query-languages/esql/functions-operators/aggregation-functions/first.md) / [`EARLIEST`](/reference/query-languages/esql/functions-operators/aggregation-functions/earliest.md) | First histogram value by sort order / timestamp {applies_to}`stack: ga 9.5` |
+| [`LAST`](/reference/query-languages/esql/functions-operators/aggregation-functions/last.md) / [`LATEST`](/reference/query-languages/esql/functions-operators/aggregation-functions/latest.md) | Last histogram value by sort order / timestamp {applies_to}`stack: ga 9.5` |
+
+For example, to calculate the count, average, and 99th-percentile duration of garbage collection
+events per action in 5-minute buckets:
+
+```esql
+TS metrics-*
+| WHERE TRANGE(1 hour)
+| STATS count = COUNT(jvm.gc.duration),
+        avg = AVG(jvm.gc.duration),
+        p99 = PERCENTILE(jvm.gc.duration, 99)
+  BY jvm.gc.action, TBUCKET(5 minutes)
+```
+
+Because `PERCENTILE` works on the merged histogram directly, you can query any percentile at
+runtime without having to pre-define bucket boundaries at index time. This is a key advantage
+of the `exponential_histogram` type over classic fixed-bucket approaches.
+
+You can combine multiple aggregations in a single query to get a complete picture of the
+distribution over time. For example, to compare the minimum, median, 99th percentile, and
+maximum of major garbage collection durations across time buckets:
+
+```esql
+TS metrics-*
+| WHERE jvm.gc.action == "end of major GC"
+| STATS MAX(jvm.gc.duration),
+        PERCENTILE(jvm.gc.duration, 99),
+        MEDIAN(jvm.gc.duration),
+        MIN(jvm.gc.duration)
+  BY TBUCKET(100)
+```
+
+### Using `TS` with histogram fields
+
+[`TS`](/reference/query-languages/esql/commands/ts.md) is the recommended source command
+for time series data. Before your aggregation runs, `TS` performs an implicit per-series
+merge: all histogram documents within each time series are combined into a single histogram,
+and the metric's temporality (delta or cumulative) is respected during the merge. The outer
+aggregation then operates on these merged per-series histograms.
+
+The [time series aggregation functions](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md)
+(`*_OVER_TIME` variants) also accept histogram inputs for windowed aggregation within a time
+series. You can use these when you need finer control over the aggregation window, for example
+`FIRST_OVER_TIME` or `LAST_OVER_TIME` to select the histogram from a specific point in the
+time series. For most use cases, the regular aggregation functions above are sufficient.
+
+### Using `FROM` with histogram fields
+
+[`FROM`](/reference/query-languages/esql/commands/from.md) also supports histogram
+aggregations. Unlike `TS`, `FROM` does not perform an implicit per-series merge or handle
+metric temporality. Each histogram document is aggregated directly.
+
+For additive aggregations like `COUNT` and `SUM`, the results are mathematically equivalent
+to `TS`. For distribution-sensitive aggregations like `PERCENTILE` and `MEDIAN`, `TS` may
+produce more accurate results because it merges histograms per series before aggregating
+across series.
+
+```esql
+FROM metrics-*
+| STATS count = COUNT(responseTime),
+        avg = AVG(responseTime),
+        p99 = PERCENTILE(responseTime, 99)
+  BY instance
+```
+
+## Create value-distribution histograms
+
+```{applies_to}
+stack: ga 9.6
+```
+
+To break down the values recorded in a histogram field into fixed-width buckets, combine
+[`BUCKET`](/reference/query-languages/esql/functions-operators/grouping-functions/bucket.md)
+with [`COUNT`](/reference/query-languages/esql/functions-operators/aggregation-functions/count.md).
+
+When applied to a histogram field, `BUCKET` returns `double_range` buckets instead of single
+values. A histogram that spans several buckets contributes a row to each of them. Pass the
+bucket as the second argument to `COUNT` to count the histogram values that fall into each
+bucket:
+
+```esql
+TS exp_histo_sample
+| WHERE instance == "instance-0"
+| STATS count = COUNT(responseTime, bucket) BY bucket = BUCKET(responseTime, 1)
+| SORT RANGE_MIN(bucket)
+```
+
+| count:long | bucket:double_range |
+| --- | --- |
+| 8723 | 0.0..1.0 |
+| 112 | 1.0..2.0 |
+| 1 | 2.0..3.0 |
+| 2 | 3.0..4.0 |
+| 2 | 5.0..6.0 |
+| 1 | 6.0..7.0 |
+
+Use [`RANGE_MIN`](/reference/query-languages/esql/functions-operators/date-time-functions/range_min.md)
+or [`RANGE_MAX`](/reference/query-languages/esql/functions-operators/date-time-functions/range_max.md)
+to extract the start or end of each `double_range` bucket for sorting or further computation.
+
+::::{note}
+Histograms record approximate value distributions, so the counts per bucket are estimates.
+::::
+
+The same pattern works for `tdigest` fields. Cast the field if needed:
+
+```esql
+TS histogram_timeseries_index
+| WHERE instance == "instance-0"
+| STATS count = COUNT(responseTime::tdigest, bucket) BY bucket = BUCKET(responseTime::tdigest, 1)
+| SORT RANGE_MIN(bucket)
+```
+
+| count:long | bucket:double_range |
+| --- | --- |
+| 8733 | 0.0..1.0 |
+| 100 | 1.0..2.0 |
+| 4 | 2.0..3.0 |
+| 2 | 3.0..4.0 |
+| 0 | 4.0..5.0 |
+| 0 | 5.0..6.0 |
+| 2 | 6.0..7.0 |
+
+A T-Digest does not track which ranges between its centroids are empty. `BUCKET` returns every
+bucket between the smallest and the largest centroid, so some buckets may show a count of `0`.
+Exponential histograms skip empty buckets.
+
+## Cast between histogram types
+
+Use the casting operator (`::`) to convert between histogram types inline:
+
+- `field::exponential_histogram` converts to an exponential histogram. This is the recommended
+  default.
+- `field::tdigest` converts to a T-Digest. Use this when you know the data was originally stored
+  as T-Digest centroids.
+
+```esql
+TS metrics-*
+| WHERE TRANGE(1 hour)
+| STATS avg = AVG(response_time::exponential_histogram) BY TBUCKET(5 minutes)
+```
+
+You can also use the explicit conversion functions
+[`TO_EXPONENTIAL_HISTOGRAM`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_exponential_histogram.md)
+and [`TO_TDIGEST`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_tdigest.md)
+in an `EVAL` step. Both functions accept all three histogram types as input and return the
+target type (identity conversion is a no-op).
+
+## Query historical data alongside new data
+
+Before {{es}} 9.4, OpenTelemetry histograms were converted to T-Digest for storage in the
+`histogram` field type. After upgrading, newer indices use `exponential_histogram` while
+older indices still contain `histogram` data.
+
+Thanks to [union types](/reference/query-languages/esql/esql-multi-index.md#esql-multi-index-union-types),
+you can query across both by adding a `::exponential_histogram` cast:
+
+```esql
+TS metrics-*
+| WHERE TRANGE(1 hour)
+| STATS avg = AVG(jvm.gc.duration::exponential_histogram) BY TBUCKET(5 minutes)
+```
+
+When this query encounters `histogram` fields, it converts them to exponential histograms.
+When it encounters `exponential_histogram` fields, the cast has no effect. If you are building
+queries or dashboards that may run on pre-9.4 data, adding `::exponential_histogram` casts is
+recommended.
+
+Use [`METRICS_INFO`](/reference/query-languages/esql/commands/metrics-info.md) to inspect
+which field types are in use across backing indices.
+
+## Supported operators and expressions
+
+Histogram fields support the following operators and expressions:
+
+- **Equality**: `==` and `!=` compare two histogram values of the same type. Cross-type
+  comparison (for example, `exponential_histogram == tdigest`) is not supported.
+- **Null checks**: `IS NULL` and `IS NOT NULL` work on all histogram types.
+- **Conditional expressions**: [`CASE`](/reference/query-languages/esql/functions-operators/conditional-functions-and-expressions/case.md)
+  and [`COALESCE`](/reference/query-languages/esql/functions-operators/conditional-functions-and-expressions/coalesce.md)
+  can return histogram values.
+
+## Ingest OpenTelemetry exponential histograms
+
+To send OpenTelemetry exponential histograms directly to {{es}}, point your OTel SDK or agent
+at the [{{es}} OTLP/HTTP endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-otlp.md)
+and configure the following environment variables:
+
+```yaml
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
+OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
+```
+
+- **Temporality preference**: {{es}} supports both delta and cumulative
+  ({applies_to}`stack: ga 9.5`) temporality for `exponential_histogram` fields. Delta
+  temporality (where the histogram is cleared after each export) is recommended for most use
+  cases. `tdigest` fields support delta temporality only.
+- **Default histogram aggregation**: By default, OpenTelemetry exports histograms in the
+  classic fixed-bucket format. Setting this to `BASE2_EXPONENTIAL_BUCKET_HISTOGRAM` uses
+  exponential histograms instead.
+
+The histograms are stored natively as `exponential_histogram` fields and are queryable
+immediately in {{esql}}.
+
+## Limitations
+
+- **No sorting.** Sorting on histogram fields is not allowed. Use `SORT` on aggregated results
+  (like `RANGE_MIN(bucket)`) instead of on the histogram field itself.
+- **No `RATE`.** The `RATE` function does not support histogram fields. If you need rate-like
+  computations, use other aggregation functions on the histogram directly.
+- **No `VALUES`.** The `VALUES` aggregation does not support histogram types.
+- **No multivalue functions.** Functions like `MV_FIRST`, `MV_LAST`, and `MV_COUNT` reject
+  histogram fields.
+- **Approximate counts.** Counts and percentiles derived from histogram fields are estimates
+  because the underlying data structures store distributions, not exact values.
+- **`TO_STRING` gap.** `TO_STRING` works on `exponential_histogram` and `histogram` fields but
+  does not currently support `tdigest`.
+
+## Further reading
+
+- [OTel histograms: Working with ES|QL histogram metrics](https://www.elastic.co/search-labs/blog/otel-histogram-metrics-esql):
+  A walkthrough of querying OpenTelemetry exponential histograms in {{esql}}, including
+  percentile analysis of JVM garbage collection metrics.
+- [Work with histogram metrics](/reference/query-languages/esql/commands/ts.md#work-with-histogram-metrics):
+  Histogram-specific guidance in the `TS` command reference.
+- [Exponential histogram field type](/reference/elasticsearch/mapping-reference/exponential-histogram.md):
+  Mapping reference for the `exponential_histogram` field type.
+- [Downsampling time series data](docs-content://manage-data/data-store/data-streams/downsampling-time-series-data-stream.md):
+  How histogram fields are preserved during downsampling.
+- [Create a histogram from regular data](/reference/query-languages/esql/esql-getting-started.md#esql-getting-started-histogram):
+  Use `BUCKET` on plain numeric or date fields to group rows into buckets.
+- [`BUCKET` function reference](/reference/query-languages/esql/functions-operators/grouping-functions/bucket.md):
+  Full syntax and examples for the `BUCKET` grouping function.

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -150,12 +150,10 @@ time series. For most use cases, the regular aggregation functions are sufficien
 
 [`FROM`](/reference/query-languages/esql/commands/from.md) also supports histogram
 aggregations. Unlike `TS`, `FROM` does not perform an implicit per-series merge or handle
-metric temporality. Each histogram document is aggregated directly.
+metric temporality.
 
-For additive aggregations like `COUNT` and `SUM`, the results are mathematically equivalent
-to `TS`. For distribution-sensitive aggregations like `PERCENTILE` and `MEDIAN`, `TS` may
-produce more accurate results because it merges histograms per series before aggregating
-across series.
+If your data is stored in a time series data stream, use `TS`. Use `FROM` for non-TSDS data
+such as legacy indices or non-metrics use cases.
 
 ```esql
 FROM metrics-*

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -115,19 +115,6 @@ Because `PERCENTILE` works on the histogram directly, you can query any percenti
 runtime without having to pre-define bucket boundaries at index time. This is a key advantage
 of the `exponential_histogram` type over classic fixed-bucket approaches.
 
-You can combine multiple aggregations in a single query to get a complete picture of the
-distribution. For example, to compare the minimum, median, 99th percentile, and maximum of
-major garbage collection durations:
-
-```esql
-FROM metrics-*
-| WHERE jvm.gc.action == "end of major GC"
-| STATS MAX(jvm.gc.duration),
-        PERCENTILE(jvm.gc.duration, 99),
-        MEDIAN(jvm.gc.duration),
-        MIN(jvm.gc.duration)
-```
-
 ### Using `TS` with histogram fields
 
 [`TS`](/reference/query-languages/esql/commands/ts.md) is the recommended source command

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -306,17 +306,12 @@ immediately in {{esql}}.
 
 ## Limitations
 
-- **No sorting.** Sorting on histogram fields is not allowed. Use [`SORT`](/reference/query-languages/esql/commands/sort.md) on aggregated results
-  (like `RANGE_MIN(bucket)`) instead of on the histogram field itself.
-- **No `RATE`.** The [`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md) function does not support histogram fields. If you need rate-like
-  computations, use other aggregation functions on the histogram directly.
-- **No `VALUES`.** The [`VALUES`](/reference/query-languages/esql/functions-operators/aggregation-functions/values.md) aggregation does not support histogram types.
-- **No multivalue functions.** Functions like [`MV_FIRST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_first.md), [`MV_LAST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_last.md), and [`MV_COUNT`](/reference/query-languages/esql/functions-operators/mv-functions/mv_count.md) reject
-  histogram fields.
-- **Approximate counts.** Counts and percentiles derived from histogram fields are estimates
-  because the underlying data structures store distributions, not exact values.
-- **`TO_STRING` gap.** [`TO_STRING`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_string.md) works on `exponential_histogram` and `histogram` fields but
-  does not currently support `tdigest`.
+- Sorting on histogram fields is not allowed. Use [`SORT`](/reference/query-languages/esql/commands/sort.md) on aggregated results (like `RANGE_MIN(bucket)`) instead of on the histogram field itself.
+- [`RATE`](/reference/query-languages/esql/functions-operators/time-series-aggregation-functions/rate.md) does not accept histogram fields. Use other aggregation functions on the histogram directly.
+- [`VALUES`](/reference/query-languages/esql/functions-operators/aggregation-functions/values.md) does not accept histogram types.
+- Multivalue functions like [`MV_FIRST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_first.md), [`MV_LAST`](/reference/query-languages/esql/functions-operators/mv-functions/mv_last.md), and [`MV_COUNT`](/reference/query-languages/esql/functions-operators/mv-functions/mv_count.md) reject histogram fields.
+- Counts and percentiles derived from histogram fields are estimates because the underlying data structures store distributions, not exact values.
+- [`TO_STRING`](/reference/query-languages/esql/functions-operators/type-conversion-functions/to_string.md) works on `exponential_histogram` and `histogram` fields but does not currently support `tdigest`.
 
 ## Further reading
 

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -119,7 +119,7 @@ of the `exponential_histogram` type over classic fixed-bucket approaches.
 
 [`TS`](/reference/query-languages/esql/commands/ts.md) is the recommended source command
 for time series data. Before your aggregation runs, `TS` performs an implicit per-series
-merge: all histogram documents within each time series are combined into a single histogram,
+merge: all histogram documents within each time bucket and series are combined into a single histogram,
 and the metric's temporality (delta or cumulative) is respected during the merge. The outer
 aggregation then operates on these merged per-series histograms.
 

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -230,7 +230,7 @@ Exponential histograms skip empty buckets.
 Use the [casting operator (`::`)](/reference/query-languages/esql/functions-operators/operators.md#esql-cast-operator) to convert between histogram types inline:
 
 - `field::exponential_histogram` converts to an exponential histogram. This is the recommended
-  default.
+  default because `exponential_histogram` is the native type used for newly ingested metrics.
 - `field::tdigest` converts to a T-Digest. Use this when you know the data was originally stored
   as T-Digest centroids.
 

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -200,7 +200,7 @@ to extract the start or end of each `double_range` bucket for sorting or further
 Histograms record approximate value distributions, so the counts per bucket are estimates.
 ::::
 
-The same pattern works for `tdigest` fields. Cast the field if needed:
+The same pattern works for `tdigest` fields. [Cast the field](#cast-between-histogram-types) if needed:
 
 ```esql
 TS histogram_timeseries_index

--- a/docs/reference/query-languages/esql/esql-histogram-fields.md
+++ b/docs/reference/query-languages/esql/esql-histogram-fields.md
@@ -267,17 +267,6 @@ recommended.
 Use [`METRICS_INFO`](/reference/query-languages/esql/commands/metrics-info.md) to inspect
 which field types are in use across backing indices.
 
-## Supported operators and expressions
-
-Histogram fields support the following operators and expressions:
-
-- **Equality**: `==` and `!=` compare two histogram values of the same type. Cross-type
-  comparison (for example, `exponential_histogram == tdigest`) is not supported.
-- **Null checks**: `IS NULL` and `IS NOT NULL` work on all histogram types.
-- **Conditional expressions**: [`CASE`](/reference/query-languages/esql/functions-operators/conditional-functions-and-expressions/case.md)
-  and [`COALESCE`](/reference/query-languages/esql/functions-operators/conditional-functions-and-expressions/coalesce.md)
-  can return histogram values.
-
 ## Ingest OpenTelemetry exponential histograms
 
 To send OpenTelemetry exponential histograms directly to {{es}}, point your OTel SDK or agent

--- a/docs/reference/query-languages/esql/esql-types-and-fields.md
+++ b/docs/reference/query-languages/esql/esql-types-and-fields.md
@@ -19,4 +19,6 @@ This section details how {{esql}} handles different data types and special field
 
 * [Multivalued fields](esql-multivalued-fields.md): Learn how to work with fields that contain multiple values in {{esql}}.
 
+* [Histogram fields](esql-histogram-fields.md): Learn how to query pre-aggregated value distributions stored as `exponential_histogram`, `tdigest`, or `histogram` fields.
+
 * [Unmapped fields](esql-unmapped-fields.md): Learn how {{esql}} handles fields that aren't in the index mapping, and how to query them with `SET unmapped_fields`.

--- a/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/time-series-aggregation-functions.md
@@ -79,8 +79,9 @@ mapping:
   regular aggregation such as `SUM`, `AVG`, or `PERCENTILE` directly to the field, and
   `TS` implicitly merges the histograms per time series. Fields with the type `histogram` must first
   be cast using `::exponential_histogram` or `::tdigest`. Refer to
-  [Work with histogram metrics](/reference/query-languages/esql/commands/ts.md#work-with-histogram-metrics)
-  for examples and guidance on mixed field types.
+  [](/reference/query-languages/esql/esql-histogram-fields.md)
+  for full details, or [Work with histogram metrics](/reference/query-languages/esql/commands/ts.md#work-with-histogram-metrics)
+  for `TS`-specific examples.
 
 For the conceptual context behind the counter/gauge split, refer to
 [When to use TS vs FROM](/reference/query-languages/esql/commands/ts.md#when-to-use-ts-vs-from).

--- a/docs/reference/query-languages/esql/functions-operators/type-conversion-functions/to_exponential_histogram.md
+++ b/docs/reference/query-languages/esql/functions-operators/type-conversion-functions/to_exponential_histogram.md
@@ -6,3 +6,5 @@ navigation_title: "TO_EXPONENTIAL_HISTOGRAM"
 
 :::{include} ../../_snippets/generated/x-pack-esql/functions/layout/to_exponential_histogram.md
 :::
+
+For when and why to convert between histogram types, refer to [](/reference/query-languages/esql/esql-histogram-fields.md#cast-between-histogram-types).

--- a/docs/reference/query-languages/esql/functions-operators/type-conversion-functions/to_tdigest.md
+++ b/docs/reference/query-languages/esql/functions-operators/type-conversion-functions/to_tdigest.md
@@ -8,3 +8,5 @@ mapped_pages:
 
 :::{include} ../../_snippets/generated/x-pack-esql/functions/layout/to_tdigest.md
 :::
+
+For when and why to convert between histogram types, refer to [](/reference/query-languages/esql/esql-histogram-fields.md#cast-between-histogram-types).

--- a/docs/reference/query-languages/esql/limitations.md
+++ b/docs/reference/query-languages/esql/limitations.md
@@ -54,8 +54,8 @@ By default, an {{esql}} query returns up to 1,000 rows. You can increase the num
    * `counter`
    * `gauge`
    * `aggregate_metric_double`: Aggregation functions that do not natively support `aggregate_metric_double` will use the average value and treat it as a `double`. {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
-   * `exponential_histogram` {applies_to}`stack: preview 9.3+, ga 9.4.0`
-   * `tdigest` {applies_to}`stack: preview 9.3+, ga 9.4.0`
+   * [`exponential_histogram`](/reference/query-languages/esql/esql-histogram-fields.md) {applies_to}`stack: preview 9.3+, ga 9.4.0`
+   * [`tdigest`](/reference/query-languages/esql/esql-histogram-fields.md) {applies_to}`stack: preview 9.3+, ga 9.4.0`
 
 
 ### Unsupported types [_unsupported_types]
@@ -73,7 +73,7 @@ By default, an {{esql}} query returns up to 1,000 rows. You can increase the num
     * `binary`
     * `completion`
     * `float_range`
-    * `histogram`
+    * `histogram` (can be queried via [casting to `tdigest` or `exponential_histogram`](/reference/query-languages/esql/esql-histogram-fields.md#cast-between-histogram-types))
     * `integer_range`
     * `ip_range`
     * `long_range`

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -447,6 +447,7 @@ toc:
           - file: esql/esql-metadata-fields.md
           - file: esql/esql-null-values.md
           - file: esql/esql-multivalued-fields.md
+          - file: esql/esql-histogram-fields.md
           - file: esql/esql-unmapped-fields.md
       - file: esql/esql-examples.md
         children:


### PR DESCRIPTION
Adds a central page for querying histogram fields in ES|QL.

- covers all three field types, aggregation, casting, and TS vs FROM differences
- linked from the types and fields landing page and toc

Closes https://github.com/elastic/elasticsearch/issues/158744