### PR TITLE
[8.19] [CI] Make the example-plugins Adoptium JDK 17 swap reach GradleRunner

### DIFF
--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -4,6 +4,9 @@ config:
     - build-tools/.*
     - build-tools-internal/.*
     - plugins/examples/.*
+    - ^\.ci/scripts/example-plugins\.sh$
+    - ^\.ci/scripts/run-gradle\.sh$
+    - ^\.buildkite/pipelines/pull-request/example-plugins\.yml$
 steps:
   - label: example-plugins
     command: |-

--- a/.ci/scripts/example-plugins.sh
+++ b/.ci/scripts/example-plugins.sh
@@ -16,7 +16,7 @@ resolve_java_home() {
     echo "$adoptium_home"
     return
   fi
-  echo "$JAVA_HOME"
+  echo "${JAVA_HOME:?JAVA_HOME not set}"
 }
 
 cd "$WORKSPACE/plugins/examples"

--- a/.ci/scripts/example-plugins.sh
+++ b/.ci/scripts/example-plugins.sh
@@ -2,22 +2,30 @@
 
 set -euo pipefail
 
-# Older versions of openjdk are incompatible to newer kernel of ubuntu. Use adoptopenjdk17 instead
+# Oracle OpenJDK 17.0.2 cannot read cgroup v2 on newer kernels
+# (NPE: CgroupInfo.getMountPoint() / anyController is null).
+# Adoptium 17 still can. JAVA_HOME alone is not enough: run-gradle.sh
+# launches Gradle via `java` on PATH.
 resolve_java_home() {
-  if [[ "$ES_BUILD_JAVA" == *"openjdk17"* ]]; then
-    if [ -f "/etc/os-release" ]; then
-        . /etc/os-release
-        if [[ "$ID" == "ubuntu" && "$VERSION_ID" == "24.04" ]]; then
-          echo "$HOME/.java/adoptopenjdk17"
-          return
-        fi
-      fi
+  local adoptium_home="$HOME/.java/adoptopenjdk17"
+  if [[ "${ES_BUILD_JAVA:-}" == *"openjdk17"* ]]; then
+    if [[ ! -d "$adoptium_home" ]]; then
+      echo "Missing $adoptium_home (required when ES_BUILD_JAVA=$ES_BUILD_JAVA)" >&2
+      exit 1
+    fi
+    echo "$adoptium_home"
+    return
   fi
-
   echo "$JAVA_HOME"
 }
 
-cd $WORKSPACE/plugins/examples
+cd "$WORKSPACE/plugins/examples"
 
-JAVA_HOME=$(resolve_java_home) \
-  $WORKSPACE/.ci/scripts/run-gradle.sh $@
+JAVA_HOME="$(resolve_java_home)"
+export JAVA_HOME
+export PATH="$JAVA_HOME/bin:$PATH"
+
+echo "--- Using JAVA_HOME=$JAVA_HOME"
+"$JAVA_HOME/bin/java" -version
+
+"$WORKSPACE/.ci/scripts/run-gradle.sh" "$@"

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -51,7 +51,9 @@ GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
 
-if command -v java > /dev/null; then
+if [[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/java" ]]; then
+  "$JAVA_HOME/bin/java" -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $@
+elif command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $@
 else
   "$GRADLEW" -S --max-workers=$MAX_WORKERS $@

--- a/plugins/examples/TEMP.txt
+++ b/plugins/examples/TEMP.txt
@@ -1,0 +1,1 @@
+Added only to run example-plugins for PR #158822

--- a/plugins/examples/TEMP.txt
+++ b/plugins/examples/TEMP.txt
@@ -1,1 +1,0 @@
-Added only to run example-plugins for PR #158822


### PR DESCRIPTION
## Summary
- After #150922, `run-gradle.sh` launches Gradle via `java -jar` from PATH, so the #138495 `JAVA_HOME=adoptopenjdk17` prefix is ignored.
- `example-plugins.sh` now exports PATH as well, always uses Adoptium 17 when `ES_BUILD_JAVA` is `openjdk17`, and fails if that JDK is missing.
- `run-gradle.sh` prefers `$JAVA_HOME/bin/java` so a JAVA_HOME override actually reaches GradleRunner.

I found it failing here: https://buildkite.com/elastic/elasticsearch-pull-request/builds/178351#01a0805b-3465-4225-aff9-88d8345251e4