### PR TITLE
[9.4] Guard against protobuf label/attribute fan-out (#157968)

### DIFF
--- a/docs/changelog/157968.yaml
+++ b/docs/changelog/157968.yaml
@@ -1,0 +1,5 @@
+area: TSDB
+issues: []
+pr: 157968
+summary: Guard against protobuf label/attribute fan-out
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -343,6 +343,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         HttpTransportSettings.SETTING_HTTP_DETAILED_ERRORS_ENABLED,
         HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH,
         HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_CONTENT_LENGTH,
+        HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH,
         HttpTransportSettings.SETTING_HTTP_MAX_CHUNK_SIZE,
         HttpTransportSettings.SETTING_HTTP_MAX_HEADER_SIZE,
         HttpTransportSettings.SETTING_HTTP_MAX_WARNING_HEADER_COUNT,

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -17,7 +17,9 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.common.settings.Setting.boolSetting;
@@ -97,6 +99,35 @@ public final class HttpTransportSettings {
         ByteSizeValue.of(8, ByteSizeUnit.MB),
         ByteSizeValue.ZERO,
         ByteSizeValue.ofBytes(Integer.MAX_VALUE),
+        Property.NodeScope
+    );
+    public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH = new Setting<>(
+        "http.max_protobuf_expanded_content_length",
+        ByteSizeValue.of(100, ByteSizeUnit.MB).getStringRep(),
+        s -> ByteSizeValue.parseBytesSizeValue(s, "http.max_protobuf_expanded_content_length"),
+        new Setting.Validator<>() {
+            @Override
+            public void validate(ByteSizeValue value) {}
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                return List.<Setting<?>>of(SETTING_HTTP_MAX_PROTOBUF_CONTENT_LENGTH).iterator();
+            }
+
+            @Override
+            public void validate(ByteSizeValue value, Map<Setting<?>, Object> settings) {
+                ByteSizeValue protobufContentLength = (ByteSizeValue) settings.get(SETTING_HTTP_MAX_PROTOBUF_CONTENT_LENGTH);
+                if (protobufContentLength != null && value.getBytes() < protobufContentLength.getBytes()) {
+                    throw new IllegalArgumentException(
+                        "[http.max_protobuf_expanded_content_length] ("
+                            + value
+                            + ") must not be less than [http.max_protobuf_content_length] ("
+                            + protobufContentLength
+                            + ")"
+                    );
+                }
+            }
+        },
         Property.NodeScope
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CHUNK_SIZE = Setting.byteSizeSetting(

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.oteldata.otlp;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
 
 import org.apache.logging.log4j.LogManager;
@@ -16,10 +17,13 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
@@ -36,6 +40,7 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
     private static final Logger logger = LogManager.getLogger(AbstractOTLPTransportAction.class);
     public static final int IGNORED_DATA_POINTS_MESSAGE_LIMIT = 10;
     private final Client client;
+    protected final long maxExpandedContentLength;
 
     @Inject
     public AbstractOTLPTransportAction(
@@ -43,10 +48,12 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
         TransportService transportService,
         ActionFilters actionFilters,
         ThreadPool threadPool,
-        Client client
+        Client client,
+        Settings settings
     ) {
         super(name, transportService, actionFilters, OTLPActionRequest::new, threadPool.executor(ThreadPool.Names.WRITE));
         this.client = client;
+        this.maxExpandedContentLength = HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH.get(settings).getBytes();
     }
 
     @Override
@@ -77,6 +84,14 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
                 }
             }));
 
+        } catch (InvalidProtocolBufferException e) {
+            logger.debug("invalid OTLP protobuf payload", e);
+            listener.onFailure(
+                new ElasticsearchStatusException("Invalid OTLP protobuf payload: " + e.getMessage(), RestStatus.BAD_REQUEST, e)
+            );
+        } catch (ElasticsearchStatusException e) {
+            logger.debug("failed to execute otlp request", e);
+            listener.onFailure(e);
         } catch (Exception e) {
             logger.error("failed to execute otlp request", e);
             listener.onFailure(e);
@@ -132,6 +147,26 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
      */
     protected abstract ProcessingContext prepareBulkRequest(OTLPActionRequest request, BulkRequestBuilder bulkRequestBuilder)
         throws IOException;
+
+    /**
+     * Accounts for the memory used by a generated {@link IndexRequest} and rejects the request if the running total would exceed
+     * {@link HttpTransportSettings#SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH}. Resource/scope attributes and labels are
+     * copied into every document, so {@link IndexRequest#ramBytesUsed()} reflects that fan-out.
+     *
+     * @param totalExpandedBytes bytes already accounted for from previously built index requests
+     * @param indexRequest       the newly built index request
+     * @return the updated running total including {@code indexRequest}
+     */
+    protected long accountExpandedContent(long totalExpandedBytes, IndexRequest indexRequest) {
+        long updatedTotal = totalExpandedBytes + indexRequest.ramBytesUsed();
+        if (updatedTotal > maxExpandedContentLength) {
+            throw new ElasticsearchStatusException(
+                "OTLP request rejected: expanded content would exceed limit [" + maxExpandedContentLength + "] bytes",
+                RestStatus.REQUEST_ENTITY_TOO_LARGE
+            );
+        }
+        return updatedTotal;
+    }
 
     private void handlePartialSuccess(
         BulkResponse bulkItemResponses,

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -42,6 +43,7 @@ import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Transport action for handling OpenTelemetry Protocol (OTLP) Metrics requests.
@@ -67,9 +69,10 @@ public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
         ActionFilters actionFilters,
         ThreadPool threadPool,
         Client client,
-        ClusterService clusterService
+        ClusterService clusterService,
+        Settings settings
     ) {
-        super(NAME, transportService, actionFilters, threadPool, client);
+        super(NAME, transportService, actionFilters, threadPool, client, settings);
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
         defaultMappingHints = MappingHints.fromSettings(clusterSettings.get(OTelPlugin.HISTOGRAM_FIELD_TYPE_SETTING));
         clusterSettings.addSettingsUpdateConsumer(OTelPlugin.HISTOGRAM_FIELD_TYPE_SETTING, histogramFieldTypeSetting -> {
@@ -90,8 +93,16 @@ public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
         MetricDocumentBuilder metricDocumentBuilder = new MetricDocumentBuilder(byteStringAccessor, defaultMappingHints);
         ProjectMetadata projectMetadata = clusterService.state().projectState(ProjectId.DEFAULT).metadata();
         Map<String, IndexVersion> indexVersions = new HashMap<>();
+        AtomicLong totalExpandedBytes = new AtomicLong();
         context.consume(
-            dataPointGroup -> addIndexRequest(bulkRequestBuilder, metricDocumentBuilder, dataPointGroup, projectMetadata, indexVersions)
+            dataPointGroup -> addIndexRequest(
+                bulkRequestBuilder,
+                metricDocumentBuilder,
+                dataPointGroup,
+                projectMetadata,
+                indexVersions,
+                totalExpandedBytes
+            )
         );
         return context;
     }
@@ -125,7 +136,8 @@ public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
         MetricDocumentBuilder metricDocumentBuilder,
         DataPointGroupingContext.DataPointGroup dataPointGroup,
         ProjectMetadata projectMetadata,
-        Map<String, IndexVersion> indexVersions
+        Map<String, IndexVersion> indexVersions,
+        AtomicLong totalExpandedBytes
     ) throws IOException {
         try (XContentBuilder xContentBuilder = XContentFactory.cborBuilder(new BytesStreamOutput())) {
             var dynamicTemplates = Maps.<String, String>newHashMapWithExpectedSize(dataPointGroup.dataPoints().size());
@@ -149,6 +161,7 @@ public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
             if (indexVersion.onOrAfter(IndexVersions.TSID_SINGLE_PREFIX_BYTE_FEATURE_FLAG)) {
                 indexRequest.tsid(tsid);
             }
+            totalExpandedBytes.set(accountExpandedContent(totalExpandedBytes.get(), indexRequest));
             bulkRequestBuilder.add(indexRequest);
         }
     }

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
@@ -13,6 +13,8 @@ import io.opentelemetry.proto.metrics.v1.Metric;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -23,18 +25,26 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpTransportSettings;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.oteldata.OTelPlugin;
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
+import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValue;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class OTLPMetricsTransportActionTests extends AbstractOTLPTransportActionTests {
@@ -44,6 +54,11 @@ public class OTLPMetricsTransportActionTests extends AbstractOTLPTransportAction
 
     @Override
     protected AbstractOTLPTransportAction createAction() {
+        metricsAction = createMetricsAction(Settings.EMPTY);
+        return metricsAction;
+    }
+
+    private OTLPMetricsTransportAction createMetricsAction(Settings settings) {
         ClusterService clusterService = mock(ClusterService.class);
         clusterSettings = new ClusterSettings(Settings.EMPTY, Set.of(OTelPlugin.HISTOGRAM_FIELD_TYPE_SETTING));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -52,14 +67,14 @@ public class OTLPMetricsTransportActionTests extends AbstractOTLPTransportAction
             .metadata(Metadata.builder().projectMetadata(Map.of(ProjectId.DEFAULT, projectMetadata)).build())
             .build();
         when(clusterService.state()).thenReturn(clusterState);
-        metricsAction = new OTLPMetricsTransportAction(
+        return new OTLPMetricsTransportAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
             mock(ThreadPool.class),
             client,
-            clusterService
+            clusterService,
+            settings
         );
-        return metricsAction;
     }
 
     @Override
@@ -105,6 +120,45 @@ public class OTLPMetricsTransportActionTests extends AbstractOTLPTransportAction
             Settings.builder().put(OTelPlugin.HISTOGRAM_FIELD_TYPE_SETTING.getKey(), "exponential_histogram").build()
         );
         assertThat(metricsAction.defaultMappingHints, equalTo(MappingHints.DEFAULT_EXPONENTIAL_HISTOGRAM));
+    }
+
+    public void testAttributeFanoutReturns413() {
+        Settings settings = Settings.builder()
+            .put(HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_CONTENT_LENGTH.getKey(), "1kb")
+            .put(HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH.getKey(), "10kb")
+            .build();
+        OTLPMetricsTransportAction action = createMetricsAction(settings);
+
+        // Distinct data-point attributes force separate documents; a large resource attribute is copied into each.
+        String largeValue = "x".repeat(1024);
+        List<Metric> metrics = new ArrayList<>();
+        for (int i = 0; i < 15; i++) {
+            metrics.add(
+                OtlpUtils.createGaugeMetric(
+                    "test.metric",
+                    "",
+                    List.of(OtlpUtils.createDoubleDataPoint(i, i, List.of(keyValue("series", String.valueOf(i)))))
+                )
+            );
+        }
+        OTLPActionRequest request = new OTLPActionRequest(
+            new BytesArray(
+                OtlpUtils.createMetricsRequest(
+                    List.of(keyValue("resource.large", largeValue), keyValue("service.name", "test-service")),
+                    metrics
+                ).toByteArray()
+            )
+        );
+
+        @SuppressWarnings("unchecked")
+        ActionListener<OTLPActionResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, request, responseListener);
+
+        ArgumentCaptor<Exception> exception = ArgumentCaptor.forClass(Exception.class);
+        verify(responseListener).onFailure(exception.capture());
+        assertThat(ExceptionsHelper.status(exception.getValue()), equalTo(RestStatus.REQUEST_ENTITY_TOO_LARGE));
+        assertThat(exception.getValue().getMessage(), containsString("expanded content would exceed limit"));
+        verify(client, never()).execute(any(), any(), any());
     }
 
     // --- helpers ---

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteTransportAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteTransportAction.java
@@ -30,9 +30,11 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
@@ -70,16 +72,19 @@ public class PrometheusRemoteWriteTransportAction extends HandledTransportAction
     private static final String METRICS_DATA_STREAM_PREFIX = "metrics-";
 
     private final Client client;
+    private final long maxExpandedContentLength;
 
     @Inject
     public PrometheusRemoteWriteTransportAction(
         TransportService transportService,
         ActionFilters actionFilters,
         ThreadPool threadPool,
-        Client client
+        Client client,
+        Settings settings
     ) {
         super(NAME, transportService, actionFilters, in -> TransportAction.localOnly(), threadPool.executor(ThreadPool.Names.WRITE));
         this.client = client;
+        this.maxExpandedContentLength = HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH.get(settings).getBytes();
     }
 
     @Override
@@ -103,6 +108,7 @@ public class PrometheusRemoteWriteTransportAction extends HandledTransportAction
             BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
 
             int droppedMissingName = 0;
+            long totalExpandedBytes = 0;
             for (TimeSeries timeSeries : writeRequest.getTimeseriesList()) {
                 String metricName = extractMetricName(timeSeries.getLabelsList());
                 if (metricName == null) {
@@ -115,6 +121,19 @@ public class PrometheusRemoteWriteTransportAction extends HandledTransportAction
                         continue;
                     }
                     IndexRequest indexRequest = buildIndexRequest(timeSeries, sample, metricName, request.dataset, request.namespace);
+                    // Guard against label fan-out: the same labels are copied into every per-sample document.
+                    totalExpandedBytes += indexRequest.ramBytesUsed();
+                    if (totalExpandedBytes > maxExpandedContentLength) {
+                        ElasticsearchStatusException e = new ElasticsearchStatusException(
+                            "Prometheus remote write request rejected: expanded content would exceed limit ["
+                                + maxExpandedContentLength
+                                + "] bytes",
+                            RestStatus.REQUEST_ENTITY_TOO_LARGE
+                        );
+                        logger.debug("failed to execute prometheus remote write request", e);
+                        listener.onFailure(e);
+                        return;
+                    }
                     bulkRequestBuilder.add(indexRequest);
                 }
             }
@@ -140,10 +159,12 @@ public class PrometheusRemoteWriteTransportAction extends HandledTransportAction
             }));
 
         } catch (InvalidProtocolBufferException e) {
+            logger.debug("invalid Prometheus remote write payload", e);
             listener.onFailure(
                 new ElasticsearchStatusException("Invalid Prometheus remote write payload: " + e.getMessage(), RestStatus.BAD_REQUEST, e)
             );
         } catch (Exception e) {
+            logger.error("failed to execute prometheus remote write request", e);
             listener.onFailure(e);
         }
     }

--- a/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteTransportActionTests.java
+++ b/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteTransportActionTests.java
@@ -20,8 +20,10 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
@@ -67,7 +69,7 @@ public class PrometheusRemoteWriteTransportActionTests extends ESTestCase {
         threadPool = mock(ThreadPool.class);
         when(threadPool.executor(ThreadPool.Names.WRITE)).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
-        action = new PrometheusRemoteWriteTransportAction(transportService, ActionFilters.EMPTY, threadPool, client);
+        action = new PrometheusRemoteWriteTransportAction(transportService, ActionFilters.EMPTY, threadPool, client, Settings.EMPTY);
     }
 
     @After
@@ -239,7 +241,8 @@ public class PrometheusRemoteWriteTransportActionTests extends ESTestCase {
                 }
             })),
             threadPool,
-            client
+            client,
+            Settings.EMPTY
         );
 
         @SuppressWarnings("unchecked")
@@ -249,6 +252,57 @@ public class PrometheusRemoteWriteTransportActionTests extends ESTestCase {
         verify(responseListener).onFailure(any(Exception.class));
         verify(client, never()).prepareBulk();
         assertRegisteredIndexingPressureReleased("indexing pressure should be released when execution short-circuits");
+    }
+
+    public void testLabelFanoutReturns413() {
+        long now = System.currentTimeMillis();
+        Settings settings = Settings.builder()
+            .put(HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_CONTENT_LENGTH.getKey(), "1kb")
+            .put(HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH.getKey(), "10kb")
+            .build();
+        action = new PrometheusRemoteWriteTransportAction(transportService, ActionFilters.EMPTY, threadPool, client, settings);
+
+        // ~1 KiB label value × enough samples that IndexRequest#ramBytesUsed() exceeds the 10 KiB limit
+        String largeLabelValue = "x".repeat(1024);
+        RemoteWrite.TimeSeries.Builder seriesBuilder = RemoteWrite.TimeSeries.newBuilder()
+            .addLabels(RemoteWrite.Label.newBuilder().setName("__name__").setValue("test_metric").build())
+            .addLabels(RemoteWrite.Label.newBuilder().setName("pad").setValue(largeLabelValue).build());
+        for (int i = 0; i < 15; i++) {
+            seriesBuilder.addSamples(RemoteWrite.Sample.newBuilder().setValue(i).setTimestamp(now + i).build());
+        }
+
+        RemoteWrite.WriteRequest writeRequest = RemoteWrite.WriteRequest.newBuilder().addTimeseries(seriesBuilder.build()).build();
+        Exception e = executeRequestExpectingFailure(createWriteRequest(writeRequest, "generic", "default"));
+
+        assertThat(ExceptionsHelper.status(e), equalTo(RestStatus.REQUEST_ENTITY_TOO_LARGE));
+        assertThat(e.getMessage(), containsString("expanded content would exceed limit"));
+        verify(client, never()).execute(any(), any(), any());
+    }
+
+    public void testReleasesIndexingPressureOnLabelFanout() {
+        long now = System.currentTimeMillis();
+        Settings settings = Settings.builder()
+            .put(HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_CONTENT_LENGTH.getKey(), "1kb")
+            .put(HttpTransportSettings.SETTING_HTTP_MAX_PROTOBUF_EXPANDED_CONTENT_LENGTH.getKey(), "10kb")
+            .build();
+        action = new PrometheusRemoteWriteTransportAction(transportService, ActionFilters.EMPTY, threadPool, client, settings);
+
+        String largeLabelValue = "x".repeat(1024);
+        RemoteWrite.TimeSeries.Builder seriesBuilder = RemoteWrite.TimeSeries.newBuilder()
+            .addLabels(RemoteWrite.Label.newBuilder().setName("__name__").setValue("test_metric").build())
+            .addLabels(RemoteWrite.Label.newBuilder().setName("pad").setValue(largeLabelValue).build());
+        for (int i = 0; i < 15; i++) {
+            seriesBuilder.addSamples(RemoteWrite.Sample.newBuilder().setValue(i).setTimestamp(now + i).build());
+        }
+
+        RemoteWrite.WriteRequest writeRequest = RemoteWrite.WriteRequest.newBuilder().addTimeseries(seriesBuilder.build()).build();
+        RemoteWriteRequest request = createWriteRequest(writeRequest, "generic", "default");
+
+        @SuppressWarnings("unchecked")
+        ActionListener<RemoteWriteResponse> responseListener = mock(ActionListener.class, CALLS_REAL_METHODS);
+        action.doExecute(null, request, responseListener);
+
+        assertRegisteredIndexingPressureReleased("indexing pressure should be released on label fan-out rejection");
     }
 
     public void testStalenessMarkerIsDropped() {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Guard against protobuf label/attribute fan-out (#157968)

Manual backport: 9.4 only has OTLP metrics (no logs/traces), so those parts of #157968 were omitted.

Made with [Cursor](https://cursor.com)