### PR TITLE
[8.19] Catch StackOverflowException in the KqlParser (#158830)

### DIFF
--- a/x-pack/plugin/kql/src/main/java/org/elasticsearch/xpack/kql/parser/KqlParser.java
+++ b/x-pack/plugin/kql/src/main/java/org/elasticsearch/xpack/kql/parser/KqlParser.java
@@ -36,24 +36,35 @@ public class KqlParser {
         Function<KqlBaseParser, ParserRuleContext> parseFunction,
         BiFunction<KqlAstBuilder, ParserRuleContext, T> visitor
     ) {
-        KqlBaseLexer lexer = new KqlBaseLexer(CharStreams.fromString(kqlQuery));
+        try {
+            KqlBaseLexer lexer = new KqlBaseLexer(CharStreams.fromString(kqlQuery));
 
-        lexer.removeErrorListeners();
-        lexer.addErrorListener(ERROR_LISTENER);
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(ERROR_LISTENER);
 
-        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
-        KqlBaseParser parser = new KqlBaseParser(tokenStream);
+            CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+            KqlBaseParser parser = new KqlBaseParser(tokenStream);
 
-        parser.removeErrorListeners();
-        parser.addErrorListener(ERROR_LISTENER);
+            parser.removeErrorListeners();
+            parser.addErrorListener(ERROR_LISTENER);
 
-        parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+            parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
 
-        ParserRuleContext tree = parseFunction.apply(parser);
+            ParserRuleContext tree = parseFunction.apply(parser);
 
-        log.trace(() -> Strings.format("Parse tree: %s", tree.toStringTree()));
+            log.trace(() -> Strings.format("Parse tree: %s", tree.toStringTree()));
 
-        return visitor.apply(new KqlAstBuilder(kqlParsingContext), tree);
+            return visitor.apply(new KqlAstBuilder(kqlParsingContext), tree);
+        } catch (StackOverflowError e) {
+            // we don't have information where exactly, so just say it's the whole query
+            throw new KqlParsingException(
+                "KQL statement is too large, causing stack overflow when generating the parsing tree: [{}]",
+                e,
+                0,
+                0,
+                kqlQuery
+            );
+        }
     }
 
     private static final BaseErrorListener ERROR_LISTENER = new BaseErrorListener() {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Catch StackOverflowException in the KqlParser (#158830)