### PR TITLE
ES|QL: Add TO_STRING support for TDigest

### DIFF
--- a/docs/changelog/158845.yaml
+++ b/docs/changelog/158845.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158845
+summary: Add TO_STRING support for TDigest
+type: enhancement

--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/types/to_string.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/types/to_string.md
@@ -26,6 +26,7 @@
 | ip | keyword |
 | keyword | keyword |
 | long | keyword |
+| tdigest {applies_to}`stack: ga 9.6.0` | keyword |
 | text | keyword |
 | unsigned_long | keyword |
 | version | keyword |

--- a/docs/reference/query-languages/esql/kibana/generated/x-pack-esql/definition/functions/to_string.json
+++ b/docs/reference/query-languages/esql/kibana/generated/x-pack-esql/definition/functions/to_string.json
@@ -272,6 +272,18 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "tdigest",
+          "optional" : false,
+          "description" : "Input value. The input can be a single- or multi-valued column or an expression."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "text",
           "optional" : false,
           "description" : "Input value. The input can be a single- or multi-valued column or an expression."

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
@@ -14,6 +14,23 @@ FROM tdigest_standard_index
 
 // -------------------------------------------------------------------------------
 
+to_string
+required_capability: fn_to_string_tdigest
+
+FROM tdigest_standard_index
+ | WHERE STARTS_WITH(instance, "hand-rolled")
+ | EVAL string = TO_STRING(responseTime)
+ | KEEP instance, string
+ | SORT instance
+;
+
+instance:keyword  | string:keyword
+hand-rolled       | "{""min"":0.1,""max"":0.5,""sum"":16.4,""centroids"":[0.1,0.2,0.3,0.4,0.5],""counts"":[3,7,23,12,6]}"
+hand-rolled-empty | "{""centroids"":[],""counts"":[]}"
+;
+
+// -------------------------------------------------------------------------------
+
 count_star with bucket
 required_capability: fn_bucket_histogram_types
 

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromTDigestEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromTDigestEvaluator.java
@@ -1,0 +1,119 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.TDigestBlock;
+import org.elasticsearch.compute.data.TDigestHolder;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link ToString}.
+ * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
+ */
+public final class ToStringFromTDigestEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ToStringFromTDigestEvaluator.class);
+
+  private final ExpressionEvaluator digest;
+
+  public ToStringFromTDigestEvaluator(Source source, ExpressionEvaluator digest,
+      DriverContext driverContext) {
+    super(driverContext, source);
+    this.digest = digest;
+  }
+
+  @Override
+  public ExpressionEvaluator next() {
+    return digest;
+  }
+
+  @Override
+  public Block evalVector(Vector v) {
+    throw new UnsupportedOperationException("vectors are unsupported for this evaluator");
+  }
+
+  @Override
+  public Block evalBlock(Block b) {
+    TDigestBlock block = (TDigestBlock) b;
+    int positionCount = block.getPositionCount();
+    try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
+      TDigestHolder scratchPad = new TDigestHolder();
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = block.getValueCount(p);
+        int start = block.getFirstValueIndex(p);
+        int end = start + valueCount;
+        boolean positionOpened = false;
+        boolean valuesAppended = false;
+        for (int i = start; i < end; i++) {
+          BytesRef value = evalValue(block, i, scratchPad);
+          if (positionOpened == false && valueCount > 1) {
+            builder.beginPositionEntry();
+            positionOpened = true;
+          }
+          builder.appendBytesRef(value);
+          valuesAppended = true;
+        }
+        if (valuesAppended == false) {
+          builder.appendNull();
+        } else if (positionOpened) {
+          builder.endPositionEntry();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private BytesRef evalValue(TDigestBlock container, int index, TDigestHolder scratchPad) {
+    TDigestHolder value = container.getTDigestHolder(index, scratchPad);
+    return ToString.fromTDigest(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromTDigestEvaluator[" + "digest=" + digest + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(digest);
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += digest.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory digest;
+
+    public Factory(Source source, ExpressionEvaluator.Factory digest) {
+      this.source = source;
+      this.digest = digest;
+    }
+
+    @Override
+    public ToStringFromTDigestEvaluator get(DriverContext context) {
+      return new ToStringFromTDigestEvaluator(source, digest.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "ToStringFromTDigestEvaluator[" + "digest=" + digest + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
+import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.xpack.esql.capabilities.ConfigurationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -61,6 +62,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TDIGEST;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.VERSION;
@@ -78,6 +80,7 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.longToStri
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.nanoTimeToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.numericBooleanToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.spatialToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.tDigestToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.unsignedLongToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.versionToString;
 
@@ -85,7 +88,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToString", ToString::new);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(ToString.class)
         .unaryConfig(ToString::new)
-        .capabilities("flattened")
+        .capabilities("flattened", "tdigest")
         .name("to_string", "to_str");
 
     private static final Map<DataType, BuildFactory> STATIC_EVALUATORS = Map.ofEntries(
@@ -111,6 +114,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
         Map.entry(AGGREGATE_METRIC_DOUBLE, ToStringFromAggregateMetricDoubleEvaluator.Factory::new),
         Map.entry(HISTOGRAM, ToStringFromHistogramEvaluator.Factory::new),
         Map.entry(EXPONENTIAL_HISTOGRAM, ToStringFromExponentialHistogramEvaluator.Factory::new),
+        Map.entry(TDIGEST, ToStringFromTDigestEvaluator.Factory::new),
 
         // Evaluators dynamically created in #factories()
         Map.entry(DATETIME, (source, fieldEval) -> null),
@@ -156,6 +160,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
                 "keyword",
                 "long",
                 "text",
+                "tdigest",
                 "unsigned_long",
                 "version",
                 "date_range",
@@ -319,6 +324,11 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
     @ConvertEvaluator(extraName = "FromHistogram", warnExceptions = { IllegalArgumentException.class })
     static BytesRef fromHistogram(BytesRef histogram) {
         return new BytesRef(EsqlDataTypeConverter.histogramToString(histogram));
+    }
+
+    @ConvertEvaluator(extraName = "FromTDigest")
+    static BytesRef fromTDigest(TDigestHolder digest) {
+        return new BytesRef(tDigestToString(digest));
     }
 
     @ConvertEvaluator(extraName = "FromDateRange")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -1894,7 +1894,7 @@ public class AnalyzerTests extends ESTestCase {
         final String supportedTypes =
             "aggregate_metric_double or boolean or cartesian_point or cartesian_shape or date_nanos or date_range or datetime "
                 + "or dense_vector or double_range or exponential_histogram or flattened or geo_point "
-                + "or geo_shape or geohash or geohex or geotile or histogram or ip or numeric or string or version";
+                + "or geo_shape or geohash or geohex or geotile or histogram or ip or numeric or string or tdigest or version";
         analyzer().error(
             "row period = 1 year | eval to_string(period)",
             containsString(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringErrorTests.java
@@ -44,10 +44,6 @@ public class ToStringErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
          * In general ToString should support all signatures. While building a
          * new type you may want to temporarily relax this.
          */
-        assertThat(
-            "all signatures except for TDigest should be supported",
-            invalidSignatureSamples,
-            equalTo(Set.of(List.of(DataType.TDIGEST)))
-        );
+        assertThat("all signatures should be supported", invalidSignatureSamples, equalTo(Set.of()));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
@@ -229,6 +229,13 @@ public class ToStringTests extends AbstractConfigurationFunctionTestCase {
             h -> matchesBytesRef(EsqlDataTypeConverter.histogramToString(h)),
             List.of()
         );
+        TestCaseSupplier.forUnaryTDigest(
+            suppliers,
+            "ToStringFromTDigestEvaluator[digest=" + read + "]",
+            DataType.KEYWORD,
+            digest -> matchesBytesRef(EsqlDataTypeConverter.tDigestToString(digest)),
+            List.of()
+        );
         // doesn't matter if it's not an actual encoded histogram, as we should never get to the decoding step
         BytesRef largeTDigest = new BytesRef(new byte[3 * 1024 * 1024]);
         suppliers.add(
@@ -290,10 +297,14 @@ public class ToStringTests extends AbstractConfigurationFunctionTestCase {
 
         FunctionAppliesTo histogramPreviewAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.3.0", "", true);
         FunctionAppliesTo histogramGaAppliesTo = appliesTo(FunctionAppliesToLifecycle.GA, "9.4.0", "", true);
+        FunctionAppliesTo tdigestGaAppliesTo = appliesTo(FunctionAppliesToLifecycle.GA, "9.6.0", "", false);
         suppliers = TestCaseSupplier.mapTestCases(suppliers, tc -> tc.withData(tc.getData().stream().map(typedData -> {
             DataType type = typedData.type();
             if (type == DataType.HISTOGRAM || type == DataType.EXPONENTIAL_HISTOGRAM) {
                 return typedData.withAppliesTo(histogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo);
+            }
+            if (type == DataType.TDIGEST) {
+                return typedData.withAppliesTo(tdigestGaAppliesTo);
             }
             return typedData;
         }).toList()));


### PR DESCRIPTION
`TO_STRING` should be supported for all types, looks like we just forgot to add it for `TDigest`.
This PR fills that gap.