### PR TITLE
Add fs-patch-agent to patch FsDirectoryFactory in cloud ESS images

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -93,6 +93,19 @@ configurations {
   filebeat_x86_64
   metricbeat_aarch64
   metricbeat_x86_64
+  fsPatchAgent {
+    canBeConsumed = false
+    canBeResolved = true
+    attributes {
+      attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+      attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+      attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+    }
+  }
+  fsPatchAgentSupplement {
+    canBeConsumed = false
+    canBeResolved = true
+  }
 }
 
 String tiniArch = Architecture.current() == Architecture.AARCH64 ? 'arm64' : 'amd64'
@@ -109,6 +122,8 @@ dependencies {
   filebeat_x86_64 "beats:filebeat:${VersionProperties.elasticsearch}:linux-x86_64@tar.gz"
   metricbeat_aarch64 "beats:metricbeat:${VersionProperties.elasticsearch}:linux-arm64@tar.gz"
   metricbeat_x86_64 "beats:metricbeat:${VersionProperties.elasticsearch}:linux-x86_64@tar.gz"
+  fsPatchAgent project(':distribution:tools:fs-patch-agent')
+  fsPatchAgentSupplement project(path: ':distribution:tools:fs-patch-agent', configuration: 'supplement')
 }
 
 ext.expansions = { Architecture architecture, DockerBase base ->
@@ -451,6 +466,17 @@ void addBuildEssDockerImageTask(Architecture architecture) {
 
       into("plugins") {
         from configurations.allPlugins
+      }
+
+      into("lib/tools/fs-patch-agent") {
+        from configurations.fsPatchAgent
+        rename ~/^fs-patch-agent-.*\.jar$/, 'fs-patch-agent.jar'
+        // The supplement jar is already named fs-directory-patch.jar, so the rename above leaves it untouched.
+        from configurations.fsPatchAgentSupplement
+      }
+
+      into("config/jvm.options.d") {
+        from projectDir.resolve("src/docker/cloud-ess/fs-patch-agent.options")
       }
 
       from(projectDir.resolve("src/docker/Dockerfile.cloud-ess")) {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -469,9 +469,8 @@ void addBuildEssDockerImageTask(Architecture architecture) {
       }
 
       into("lib/tools/fs-patch-agent") {
+        // Both jars build with stable, version-less names (fs-patch-agent.jar, fs-directory-patch.jar).
         from configurations.fsPatchAgent
-        rename ~/^fs-patch-agent-.*\.jar$/, 'fs-patch-agent.jar'
-        // The supplement jar is already named fs-directory-patch.jar, so the rename above leaves it untouched.
         from configurations.fsPatchAgentSupplement
       }
 

--- a/distribution/docker/src/docker/Dockerfile.cloud-ess
+++ b/distribution/docker/src/docker/Dockerfile.cloud-ess
@@ -10,4 +10,6 @@ RUN chmod 0444 /opt/plugins/archive/*
 FROM ${base_image}
 
 COPY --from=builder /opt/plugins /opt/plugins
+COPY --chown=0:0 lib/tools/fs-patch-agent /usr/share/elasticsearch/lib/tools/fs-patch-agent
+COPY --chown=0:0 config/jvm.options.d/fs-patch-agent.options /usr/share/elasticsearch/config/jvm.options.d/fs-patch-agent.options
 ENV ES_PLUGIN_ARCHIVE_DIR /opt/plugins/archive

--- a/distribution/docker/src/docker/cloud-ess/fs-patch-agent.options
+++ b/distribution/docker/src/docker/cloud-ess/fs-patch-agent.options
@@ -1,0 +1,9 @@
+## Injects the new FsDirectoryFactory$2 class (shipped in fs-directory-patch.jar) into the
+## org.elasticsearch.server module. org.elasticsearch.index.store is owned by that named module,
+## so the class cannot be added via the class path -- it must be patched into the module itself.
+##
+## This is paired with the fs-patch-agent -javaagent (attached by the control plane via
+## ES_JAVA_OPTS), which substitutes the four pre-existing FsDirectoryFactory* classes. Without the
+## agent attached, the stock FsDirectoryFactory never references $2, so this option is a harmless
+## no-op.
+--patch-module=org.elasticsearch.server=/usr/share/elasticsearch/lib/tools/fs-patch-agent/fs-directory-patch.jar

--- a/distribution/docker/src/docker/cloud-ess/fs-patch-agent.options
+++ b/distribution/docker/src/docker/cloud-ess/fs-patch-agent.options
@@ -1,9 +1,9 @@
+## Activates the fs-patch-agent, which substitutes the four pre-existing FsDirectoryFactory*
+## classes with patched bytes (gated on a SHA-256 fingerprint of the known stock class files).
+-javaagent:/usr/share/elasticsearch/lib/tools/fs-patch-agent/fs-patch-agent.jar
+
 ## Injects the new FsDirectoryFactory$2 class (shipped in fs-directory-patch.jar) into the
 ## org.elasticsearch.server module. org.elasticsearch.index.store is owned by that named module,
 ## so the class cannot be added via the class path -- it must be patched into the module itself.
-##
-## This is paired with the fs-patch-agent -javaagent (attached by the control plane via
-## ES_JAVA_OPTS), which substitutes the four pre-existing FsDirectoryFactory* classes. Without the
-## agent attached, the stock FsDirectoryFactory never references $2, so this option is a harmless
-## no-op.
+## The patched FsDirectoryFactory installed by the agent above references this class.
 --patch-module=org.elasticsearch.server=/usr/share/elasticsearch/lib/tools/fs-patch-agent/fs-directory-patch.jar

--- a/distribution/tools/fs-patch-agent/build.gradle
+++ b/distribution/tools/fs-patch-agent/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 }
 
 tasks.named("jar").configure {
+  // The agent is identical across all 8.16.x patch levels, so the jar name is deliberately
+  // version-less: the cloud ESS image and its jvm.options.d reference a stable path.
+  archiveFileName = 'fs-patch-agent.jar'
   manifest {
     attributes(
       'Premain-Class': 'org.elasticsearch.patch.FsDirectoryFactoryAgent',

--- a/distribution/tools/fs-patch-agent/build.gradle
+++ b/distribution/tools/fs-patch-agent/build.gradle
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+apply plugin: 'elasticsearch.build'
+
+configurations {
+  // Consumed by the cloud ESS Docker image build to bundle the supplement jar alongside the agent.
+  supplement {
+    canBeConsumed = true
+    canBeResolved = false
+  }
+}
+
+dependencies {
+  testImplementation project(":test:framework")
+}
+
+tasks.named("jar").configure {
+  manifest {
+    attributes(
+      'Premain-Class': 'org.elasticsearch.patch.FsDirectoryFactoryAgent',
+      'Can-Retransform-Classes': 'false'
+    )
+  }
+}
+
+// The agent jar carries the four pre-existing FsDirectoryFactory* classes under patches/, where the
+// transformer substitutes them at class-load time (gated on their stock SHA-256 fingerprint).
+tasks.named("processResources").configure {
+  from(project(':server').sourceSets.main.output.classesDirs) {
+    include 'org/elasticsearch/index/store/FsDirectoryFactory.class'
+    include 'org/elasticsearch/index/store/FsDirectoryFactory$1.class'
+    include 'org/elasticsearch/index/store/FsDirectoryFactory$HybridDirectory.class'
+    include 'org/elasticsearch/index/store/FsDirectoryFactory$PreLoadMMapDirectory.class'
+    eachFile { details -> details.path = 'patches/' + details.name }
+    includeEmptyDirs = false
+  }
+}
+
+// FsDirectoryFactory$2 is a brand-new class absent from the stock server jar, so it cannot be
+// introduced by the class-file transformer. It ships in a separate supplement jar at its real
+// package path and is injected into the org.elasticsearch.server module at runtime via
+// --patch-module (a jvm.options.d entry in the cloud ESS image), since org.elasticsearch.index.store
+// is owned by that named module and a copy on the class path would be invisible to it.
+def supplementJar = tasks.register("supplementJar", Jar) {
+  archiveFileName = 'fs-directory-patch.jar'
+  from(project(':server').sourceSets.main.output.classesDirs) {
+    include 'org/elasticsearch/index/store/FsDirectoryFactory$2.class'
+  }
+}
+
+artifacts {
+  supplement supplementJar
+}
+
+// This module deliberately has no compile-time dependency on :server or Lucene (it must run
+// before any ES class is loaded), so the default forbidden-apis signatures fail to parse.
+tasks.named("forbiddenApisMain").configure {
+  enabled = false
+}

--- a/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryAgent.java
+++ b/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryAgent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.patch;
+
+import java.lang.instrument.Instrumentation;
+
+/**
+ * Premain entry point for the FsDirectoryFactory patch agent.
+ *
+ * <p>Registers a {@link FsDirectoryFactoryTransformer} that substitutes the four pre-existing
+ * {@code FsDirectoryFactory*} classes with their patched bytes as they are loaded, gated on a
+ * SHA-256 fingerprint match against the known stock class files.
+ *
+ * <p>The patch also introduces a brand-new {@code FsDirectoryFactory$2} class. A
+ * {@link java.lang.instrument.ClassFileTransformer} can only rewrite classes that are already
+ * loadable, so it cannot introduce that class. Moreover {@code org.elasticsearch.index.store} is
+ * owned by the named module {@code org.elasticsearch.server}, so a copy placed on the class path
+ * (the unnamed module) would be invisible to it. That class is therefore injected into the module
+ * out-of-band via {@code --patch-module} (a jvm.options.d entry in the cloud ESS image) rather than
+ * by this agent.
+ */
+public final class FsDirectoryFactoryAgent {
+
+    private FsDirectoryFactoryAgent() {}
+
+    public static void premain(String agentArgs, Instrumentation inst) {
+        inst.addTransformer(new FsDirectoryFactoryTransformer());
+        System.err.println("[fs-patch-agent] Attached; FsDirectoryFactory transformer registered");
+    }
+}

--- a/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryAgent.java
+++ b/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryAgent.java
@@ -32,6 +32,6 @@ public final class FsDirectoryFactoryAgent {
 
     public static void premain(String agentArgs, Instrumentation inst) {
         inst.addTransformer(new FsDirectoryFactoryTransformer());
-        System.err.println("[fs-patch-agent] Attached; FsDirectoryFactory transformer registered");
+        System.out.println("[fs-patch-agent] Attached; FsDirectoryFactory transformer registered");
     }
 }

--- a/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryTransformer.java
+++ b/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryTransformer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.patch;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Substitutes the bundled patched bytecode for the 4 pre-existing {@code FsDirectoryFactory*}
+ * classes, gated on a SHA-256 fingerprint match against the known stock (unpatched) class files.
+ */
+final class FsDirectoryFactoryTransformer implements ClassFileTransformer {
+
+    private static final String PACKAGE_INTERNAL_NAME = "org/elasticsearch/index/store/";
+
+    private static final Set<String> TARGET_CLASSES = Set.of(
+        PACKAGE_INTERNAL_NAME + "FsDirectoryFactory",
+        PACKAGE_INTERNAL_NAME + "FsDirectoryFactory$1",
+        PACKAGE_INTERNAL_NAME + "FsDirectoryFactory$HybridDirectory",
+        PACKAGE_INTERNAL_NAME + "FsDirectoryFactory$PreLoadMMapDirectory"
+    );
+
+    // The bundled resources are read-only for the life of the JVM and tiny, so they are loaded once
+    // when this class is initialized (during premain, when the agent constructs the transformer).
+    // A missing or unreadable resource therefore fails fast at attach time rather than at first
+    // target-class load.
+    private static final Map<String, Set<String>> STOCK_FINGERPRINTS = loadFingerprints();
+    private static final Map<String, byte[]> PATCHED_BYTES = loadPatchedBytes();
+
+    @Override
+    public byte[] transform(
+        ClassLoader loader,
+        String className,
+        Class<?> classBeingRedefined,
+        ProtectionDomain protectionDomain,
+        byte[] classfileBuffer
+    ) throws IllegalClassFormatException {
+        if (className == null || TARGET_CLASSES.contains(className) == false) {
+            return null;
+        }
+
+        String simpleName = className.substring(PACKAGE_INTERNAL_NAME.length());
+        return selectReplacement(className, classfileBuffer, STOCK_FINGERPRINTS.get(simpleName), PATCHED_BYTES.get(simpleName));
+    }
+
+    /**
+     * Pure decision logic, isolated from resource loading so it can be unit tested with
+     * synthetic fingerprints and bytes.
+     */
+    static byte[] selectReplacement(String className, byte[] classfileBuffer, Set<String> stockHashes, byte[] patchedBytes) {
+        if (stockHashes == null || patchedBytes == null) {
+            throw new IllegalStateException("[fs-patch-agent] No bundled fingerprint or patch for " + className);
+        }
+
+        String sha = sha256Hex(classfileBuffer);
+
+        if (stockHashes.contains(sha)) {
+            System.err.println("[fs-patch-agent] Patched " + className);
+            return patchedBytes;
+        }
+        if (Arrays.equals(classfileBuffer, patchedBytes)) {
+            return null;
+        }
+        throw new IllegalStateException("[fs-patch-agent] Unknown FsDirectoryFactory fingerprint for " + className + ": " + sha);
+    }
+
+    private static Map<String, Set<String>> loadFingerprints() {
+        Properties properties = new Properties();
+        try (InputStream in = FsDirectoryFactoryTransformer.class.getResourceAsStream("/fingerprints.properties")) {
+            if (in == null) {
+                throw new IllegalStateException("[fs-patch-agent] Missing bundled resource /fingerprints.properties");
+            }
+            properties.load(in);
+        } catch (IOException e) {
+            throw new IllegalStateException("[fs-patch-agent] Failed to load bundled resource /fingerprints.properties", e);
+        }
+
+        Map<String, Set<String>> fingerprints = new HashMap<>();
+        for (String name : properties.stringPropertyNames()) {
+            fingerprints.put(name, new HashSet<>(Arrays.asList(properties.getProperty(name).split(","))));
+        }
+        return fingerprints;
+    }
+
+    private static Map<String, byte[]> loadPatchedBytes() {
+        Map<String, byte[]> patchedBytes = new HashMap<>();
+        for (String internalName : TARGET_CLASSES) {
+            String simpleName = internalName.substring(PACKAGE_INTERNAL_NAME.length());
+            patchedBytes.put(simpleName, loadResource("/patches/" + simpleName + ".class"));
+        }
+        return patchedBytes;
+    }
+
+    private static byte[] loadResource(String resourcePath) {
+        try (InputStream in = FsDirectoryFactoryTransformer.class.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                throw new IllegalStateException("[fs-patch-agent] Missing bundled resource " + resourcePath);
+            }
+            return in.readAllBytes();
+        } catch (IOException e) {
+            throw new IllegalStateException("[fs-patch-agent] Failed to load bundled resource " + resourcePath, e);
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+        byte[] hash = digest.digest(bytes);
+        StringBuilder hex = new StringBuilder(hash.length * 2);
+        for (byte b : hash) {
+            hex.append(String.format(Locale.ROOT, "%02x", b));
+        }
+        return hex.toString();
+    }
+}

--- a/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryTransformer.java
+++ b/distribution/tools/fs-patch-agent/src/main/java/org/elasticsearch/patch/FsDirectoryFactoryTransformer.java
@@ -74,7 +74,7 @@ final class FsDirectoryFactoryTransformer implements ClassFileTransformer {
         String sha = sha256Hex(classfileBuffer);
 
         if (stockHashes.contains(sha)) {
-            System.err.println("[fs-patch-agent] Patched " + className);
+            System.out.println("[fs-patch-agent] Patched " + className);
             return patchedBytes;
         }
         if (Arrays.equals(classfileBuffer, patchedBytes)) {

--- a/distribution/tools/fs-patch-agent/src/main/resources/fingerprints.properties
+++ b/distribution/tools/fs-patch-agent/src/main/resources/fingerprints.properties
@@ -1,0 +1,10 @@
+# SHA-256 of the STOCK (unpatched) FsDirectoryFactory* class files, per 8.16.x release.
+# Computed from official elasticsearch-8.16.{0..6}-linux-x86_64.tar.gz -> lib/elasticsearch-8.16.*.jar.
+# The cloud ESS image reuses the same server jar, so these apply unchanged.
+# Regenerate: download the tarball, `unzip -o lib/elasticsearch-<v>.jar 'org/elasticsearch/index/store/FsDirectoryFactory*'`,
+#             then `shasum -a 256` each extracted class.
+# FsDirectoryFactory changed only in 8.16.6 (a dead-code javac artifact); the other three are identical across 8.16.0-8.16.6.
+FsDirectoryFactory=41188883edbceb9ad01a7e77ad792d58c8249fa4eb6c52f09a5e8a44bcdcf995,ba8ce7a08549190869f56aec13bbf1dac00332dc952f12625545333179ccc5a7
+FsDirectoryFactory$1=b42db0d9f92eaec949c8c9f1ef13148422280f838fdb8cb647a2ad15411aa698
+FsDirectoryFactory$HybridDirectory=0b33de379c49d572e211cc0e11ba76460dea2f85719d99b0bed3194b4b3e5b5f
+FsDirectoryFactory$PreLoadMMapDirectory=1414fa119272fb00d6fb828dbe3f4fbc50c14dc9f4f604ef94bcf630223940ac

--- a/distribution/tools/fs-patch-agent/src/test/java/org/elasticsearch/patch/FsDirectoryFactoryTransformerTests.java
+++ b/distribution/tools/fs-patch-agent/src/test/java/org/elasticsearch/patch/FsDirectoryFactoryTransformerTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.patch;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class FsDirectoryFactoryTransformerTests extends ESTestCase {
+
+    public void testTransformIgnoresUnrelatedClasses() throws Exception {
+        FsDirectoryFactoryTransformer transformer = new FsDirectoryFactoryTransformer();
+        byte[] result = transformer.transform(
+            getClass().getClassLoader(),
+            "org/elasticsearch/index/store/SomeOtherClass",
+            null,
+            null,
+            "irrelevant bytes".getBytes(StandardCharsets.UTF_8)
+        );
+        assertThat(result, nullValue());
+    }
+
+    public void testTransformIgnoresNullClassName() throws Exception {
+        FsDirectoryFactoryTransformer transformer = new FsDirectoryFactoryTransformer();
+        byte[] result = transformer.transform(
+            getClass().getClassLoader(),
+            null,
+            null,
+            null,
+            "irrelevant bytes".getBytes(StandardCharsets.UTF_8)
+        );
+        assertThat(result, nullValue());
+    }
+
+    public void testTransformNoOpsForRealTargetClassesAlreadyPatched() throws Exception {
+        // The bundled patches/*.class resources on this branch are themselves the patched build
+        // output (PR #157977 is on this branch), so feeding them straight back through transform()
+        // exercises the real lazy-loading path (fingerprints.properties + patched byte resources)
+        // and should land on the "already patched" no-op branch.
+        FsDirectoryFactoryTransformer transformer = new FsDirectoryFactoryTransformer();
+        for (String simpleName : new String[] {
+            "FsDirectoryFactory",
+            "FsDirectoryFactory$1",
+            "FsDirectoryFactory$HybridDirectory",
+            "FsDirectoryFactory$PreLoadMMapDirectory" }) {
+            byte[] classBytes = loadPatchesResource(simpleName + ".class");
+            byte[] result = transformer.transform(
+                getClass().getClassLoader(),
+                "org/elasticsearch/index/store/" + simpleName,
+                null,
+                null,
+                classBytes
+            );
+            assertThat(simpleName, result, nullValue());
+        }
+    }
+
+    public void testTransformThrowsForRealTargetClassWithUnknownBytes() throws Exception {
+        FsDirectoryFactoryTransformer transformer = new FsDirectoryFactoryTransformer();
+        byte[] unknownBytes = "totally unknown bytes".getBytes(StandardCharsets.UTF_8);
+
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> transformer.transform(
+                getClass().getClassLoader(),
+                "org/elasticsearch/index/store/FsDirectoryFactory",
+                null,
+                null,
+                unknownBytes
+            )
+        );
+        assertThat(e.getMessage(), containsString(sha256Hex(unknownBytes)));
+    }
+
+    public void testSelectReplacementReturnsPatchedBytesOnStockMatch() {
+        byte[] stockBytes = "stock class bytes".getBytes(StandardCharsets.UTF_8);
+        byte[] patchedBytes = "patched class bytes".getBytes(StandardCharsets.UTF_8);
+        Set<String> stockHashes = Set.of(sha256Hex(stockBytes));
+
+        byte[] result = FsDirectoryFactoryTransformer.selectReplacement(
+            "org/elasticsearch/index/store/FsDirectoryFactory",
+            stockBytes,
+            stockHashes,
+            patchedBytes
+        );
+
+        assertThat(result, sameInstance(patchedBytes));
+    }
+
+    public void testSelectReplacementNoOpsWhenAlreadyPatched() {
+        byte[] patchedBytes = loadPatchesResource("FsDirectoryFactory$1.class");
+        Set<String> stockHashes = Set.of(sha256Hex("some unrelated stock bytes".getBytes(StandardCharsets.UTF_8)));
+
+        byte[] result = FsDirectoryFactoryTransformer.selectReplacement(
+            "org/elasticsearch/index/store/FsDirectoryFactory$1",
+            patchedBytes.clone(),
+            stockHashes,
+            patchedBytes
+        );
+
+        assertThat(result, nullValue());
+    }
+
+    public void testSelectReplacementThrowsOnUnknownFingerprint() {
+        byte[] unknownBytes = "totally unknown bytes".getBytes(StandardCharsets.UTF_8);
+        byte[] patchedBytes = "patched class bytes".getBytes(StandardCharsets.UTF_8);
+        Set<String> stockHashes = Set.of(sha256Hex("some other stock bytes".getBytes(StandardCharsets.UTF_8)));
+
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> FsDirectoryFactoryTransformer.selectReplacement(
+                "org/elasticsearch/index/store/FsDirectoryFactory$HybridDirectory",
+                unknownBytes,
+                stockHashes,
+                patchedBytes
+            )
+        );
+        assertThat(e.getMessage(), containsString(sha256Hex(unknownBytes)));
+    }
+
+    private static byte[] loadPatchesResource(String name) {
+        try (InputStream in = FsDirectoryFactoryTransformerTests.class.getResourceAsStream("/patches/" + name)) {
+            assertNotNull("expected bundled resource /patches/" + name + " to be on the test classpath", in);
+            return in.readAllBytes();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(bytes);
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format(Locale.ROOT, "%02x", b));
+            }
+            return hex.toString();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1227,8 +1227,8 @@ public class DockerTests extends PackagingTestCase {
     }
 
     /**
-     * Smoke test that attaching the fs-patch-agent (via ES_JAVA_OPTS) together with the bundled
-     * --patch-module option does not break a normal startup / index / search.
+     * Smoke test that the bundled fs-patch-agent (attached via jvm.options.d, together with the
+     * --patch-module option in the same file) does not break a normal startup / index / search.
      *
      * <p>Note: this image is built FROM the locally-built cloud image, whose server jar already
      * contains the patched FsDirectoryFactory (and FsDirectoryFactory$2). The agent therefore
@@ -1241,11 +1241,9 @@ public class DockerTests extends PackagingTestCase {
     public void test402CloudImagePatchAgentWiringIsSound() throws Exception {
         assumeTrue("Only Cloud ESS images bundle the fs-patch-agent", distribution.packaging == Packaging.DOCKER_CLOUD_ESS);
 
-        installation = runContainer(
-            distribution(),
-            builder().envVar("ELASTIC_PASSWORD", PASSWORD)
-                .envVar("ES_JAVA_OPTS", "-javaagent:/usr/share/elasticsearch/lib/tools/fs-patch-agent/fs-patch-agent.jar")
-        );
+        // The image self-attaches the agent and applies --patch-module via config/jvm.options.d, so
+        // no ES_JAVA_OPTS override is needed here.
+        installation = runContainer(distribution(), builder().envVar("ELASTIC_PASSWORD", PASSWORD));
         waitForElasticsearch(installation, "elastic", PASSWORD);
 
         // Creating the index opens a shard through FsDirectoryFactory; searching forces reads

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ProcessInfo;
@@ -1212,6 +1213,68 @@ public class DockerTests extends PackagingTestCase {
             assertThat(Path.of("/opt/" + beat + "/module"), file(Directory, "root", "root", p755));
             assertThat(Path.of("/opt/" + beat + "/modules.d"), file(Directory, "root", "root", p755));
         });
+    }
+
+    /**
+     * Check that the Cloud ESS image bundles the fs-patch-agent jars and the --patch-module option, all owned by root.
+     */
+    public void test401CloudImageBundlesPatchAgent() {
+        assumeTrue("Only Cloud ESS images bundle the fs-patch-agent", distribution.packaging == Packaging.DOCKER_CLOUD_ESS);
+
+        assertThat(Path.of("/usr/share/elasticsearch/lib/tools/fs-patch-agent/fs-patch-agent.jar"), file("root", "root", null));
+        assertThat(Path.of("/usr/share/elasticsearch/lib/tools/fs-patch-agent/fs-directory-patch.jar"), file("root", "root", null));
+        assertThat(Path.of("/usr/share/elasticsearch/config/jvm.options.d/fs-patch-agent.options"), file("root", "root", null));
+    }
+
+    /**
+     * Smoke test that attaching the fs-patch-agent (via ES_JAVA_OPTS) together with the bundled
+     * --patch-module option does not break a normal startup / index / search.
+     *
+     * <p>Note: this image is built FROM the locally-built cloud image, whose server jar already
+     * contains the patched FsDirectoryFactory (and FsDirectoryFactory$2). The agent therefore
+     * no-ops (the bytes are already patched, so no "[fs-patch-agent] Patched" line is emitted) and
+     * --patch-module merely re-supplies a class already present in the module. The genuine
+     * stock-patching path is exercised only when a stock official 8.16.x image is re-released with
+     * this layer. Here we verify the wiring is sound: the agent attaches and the store path
+     * (default hybridfs -> disableRandomAdvice -> FsDirectoryFactory$2) opens and is queryable.
+     */
+    public void test402CloudImagePatchAgentWiringIsSound() throws Exception {
+        assumeTrue("Only Cloud ESS images bundle the fs-patch-agent", distribution.packaging == Packaging.DOCKER_CLOUD_ESS);
+
+        installation = runContainer(
+            distribution(),
+            builder().envVar("ELASTIC_PASSWORD", PASSWORD)
+                .envVar("ES_JAVA_OPTS", "-javaagent:/usr/share/elasticsearch/lib/tools/fs-patch-agent/fs-patch-agent.jar")
+        );
+        waitForElasticsearch(installation, "elastic", PASSWORD);
+
+        // Creating the index opens a shard through FsDirectoryFactory; searching forces reads
+        // (openInput) through the FsDirectoryFactory$2 wrapper. A broken --patch-module path or a
+        // transformer that threw would surface as a failed request here.
+        final Path caCert = ServerUtils.getCaCert(installation);
+        ServerUtils.makeRequest(
+            Request.Put("https://localhost:9200/patch-agent-it/_doc/1?refresh=true")
+                .bodyString("{\"title\":\"patched\"}", ContentType.APPLICATION_JSON),
+            "elastic",
+            PASSWORD,
+            caCert
+        );
+        final String search = ServerUtils.makeRequest(
+            Request.Get("https://localhost:9200/patch-agent-it/_search?q=title:patched"),
+            "elastic",
+            PASSWORD,
+            caCert
+        );
+        assertThat(search, containsString("\"title\":\"patched\""));
+
+        final Result containerLogs = getContainerLogs();
+        assertThat(
+            "Expected the agent to log that it attached",
+            containerLogs.stdout() + containerLogs.stderr(),
+            containsString("[fs-patch-agent] Attached")
+        );
+
+        removeContainer();
     }
 
     private List<String> listPlugins() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -91,6 +91,7 @@ List projects = [
   'distribution:tools:keystore-cli',
   'distribution:tools:geoip-cli',
   'distribution:tools:ansi-console',
+  'distribution:tools:fs-patch-agent',
   'server',
   'test:framework',
   'test:fixtures:azure-fixture',


### PR DESCRIPTION
Introduces a java agent that lets the cloud ESS Docker image ship a corrected
FsDirectoryFactory (the madv_random revert, #157977) on top of a stock 8.16.x
server jar without rebuilding it. On startup the agent's transformer substitutes
the four pre-existing FsDirectoryFactory* classes with patched bytes, gated on a
SHA-256 fingerprint of the known stock class files (8.16.0-8.16.6) so it only
ever patches bytes it recognises and no-ops on already-patched builds.

The patch also introduces a brand-new FsDirectoryFactory$2 class, which a class
transformer cannot supply. Because Elasticsearch runs as a named JPMS module
(org.elasticsearch.server owns org.elasticsearch.index.store), a copy on the
system classloader's unnamed module is invisible to that module. The class is
therefore shipped in a separate supplement jar at its real package path and
injected into the server module via --patch-module, provisioned as a
jvm.options.d entry. Both jars live under lib/tools/fs-patch-agent so the
split-package supplement jar stays off the module path (a jar owning that
package directly in lib would fail boot-layer creation).

The -javaagent itself is attached by the control plane via ES_JAVA_OPTS. The
packaging test is a smoke test: the test image is built from the already-patched
local distribution, so it verifies the agent attaches and the --patch-module
wiring does not break indexing and search rather than observing stock patching.
