### PR TITLE
[8.19] Reject `allow_restricted_indices=true` with `manage_roles` privilege (#158831)

### DIFF
--- a/docs/changelog/158831.yaml
+++ b/docs/changelog/158831.yaml
@@ -1,0 +1,5 @@
+area: Authorization
+issues: []
+pr: 158831
+summary: "Reject `allow_restricted_indices=true` consistently in roles granted by users with the `manage_roles` privilege."
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
@@ -437,7 +437,8 @@ public final class ConfigurableClusterPrivileges {
                                     indexPrivilege -> requestIndexPatternsAllowed(
                                         indicesPermission,
                                         indexPrivilege.getIndices(),
-                                        indexPrivilege.getPrivileges()
+                                        indexPrivilege.getPrivileges(),
+                                        indexPrivilege.allowRestrictedIndices()
                                     ) == false
                                 );
                     } else if (request instanceof final BulkPutRolesRequest bulkPutRoleRequest) {
@@ -450,7 +451,8 @@ public final class ConfigurableClusterPrivileges {
                                             indexPrivilege -> requestIndexPatternsAllowed(
                                                 indicesPermission,
                                                 indexPrivilege.getIndices(),
-                                                indexPrivilege.getPrivileges()
+                                                indexPrivilege.getPrivileges(),
+                                                indexPrivilege.allowRestrictedIndices()
                                             ) == false
                                         )
                                 );
@@ -458,13 +460,15 @@ public final class ConfigurableClusterPrivileges {
                         return requestIndexPatternsAllowed(
                             indicesPermission,
                             new String[] { deleteRoleRequest.name() },
-                            DELETE_INDEX.name().toArray(String[]::new)
+                            DELETE_INDEX.name().toArray(String[]::new),
+                            false
                         );
                     } else if (request instanceof final BulkDeleteRolesRequest bulkDeleteRoleRequest) {
                         return requestIndexPatternsAllowed(
                             indicesPermission,
                             bulkDeleteRoleRequest.getRoleNames().toArray(String[]::new),
-                            DELETE_INDEX.name().toArray(String[]::new)
+                            DELETE_INDEX.name().toArray(String[]::new),
+                            false
                         );
                     }
                     throw new IllegalArgumentException("Unsupported request type [" + request.getClass() + "]");
@@ -668,9 +672,11 @@ public final class ConfigurableClusterPrivileges {
         private static boolean requestIndexPatternsAllowed(
             IndicesPermission indicesPermission,
             String[] requestIndexPatterns,
-            String[] privileges
+            String[] privileges,
+            boolean allowRestrictedIndices
         ) {
-            return indicesPermission.checkResourcePrivileges(Set.of(requestIndexPatterns), false, Set.of(privileges), true, null);
+            return allowRestrictedIndices == false
+                && indicesPermission.checkResourcePrivileges(Set.of(requestIndexPatterns), false, Set.of(privileges), true, null);
         }
 
         private static boolean hasNonIndexPrivileges(RoleDescriptor roleDescriptor) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageRolesPrivilegesTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageRolesPrivilegesTests.java
@@ -182,6 +182,82 @@ public class ManageRolesPrivilegesTests extends AbstractNamedWriteableTestCase<C
         assertAllowedIndexPatterns(permission, new String[] { "security", ".security-7" }, false);
     }
 
+    public void testRestrictedIndexPutRoleRequestWithAllowRestrictedIndices() {
+        new ReservedRolesStore();
+
+        final ManageRolesPrivilege privilege = new ManageRolesPrivilege(
+            List.of(new ManageRolesPrivilege.ManageRolesIndexPermissionGroup(new String[] { "*" }, new String[] { "all" }))
+        );
+        final ClusterPermission permission = privilege.buildPermission(
+            new ClusterPermission.Builder(new RestrictedIndices(TestRestrictedIndices.RESTRICTED_INDICES.getAutomaton()))
+        ).build();
+
+        assertAllowedIndexPatterns(permission, new String[] { "*" }, new String[] { "all" }, true, false);
+        assertAllowedIndexPatterns(permission, new String[] { ".*" }, new String[] { "all" }, true, false);
+        assertAllowedIndexPatterns(permission, new String[] { "/.*/" }, new String[] { "all" }, true, false);
+        assertAllowedIndexPatterns(permission, new String[] { ".security-7" }, new String[] { "all" }, true, false);
+        assertAllowedIndexPatterns(permission, new String[] { "security", "*" }, new String[] { "all" }, true, false);
+        assertAllowedIndexPatterns(permission, new String[] { "logs-*" }, new String[] { "all" }, true, false);
+        assertAllowedIndexPatterns(permission, new String[] { "logs-000001" }, new String[] { "all" }, true, false);
+
+        assertAllowedIndexPatterns(permission, new String[] { "*" }, new String[] { "all" }, false, true);
+        assertAllowedIndexPatterns(permission, new String[] { "logs-*" }, new String[] { "all" }, false, true);
+    }
+
+    public void testAllowRestrictedIndicesRejectedForPatternsOverlappingRestrictedIndices() {
+        new ReservedRolesStore();
+
+        for (String pattern : new String[] { "*security*", ".security*", ".s*", "*-7" }) {
+            final ManageRolesPrivilege privilege = new ManageRolesPrivilege(
+                List.of(new ManageRolesPrivilege.ManageRolesIndexPermissionGroup(new String[] { pattern }, new String[] { "all" }))
+            );
+            final ClusterPermission permission = privilege.buildPermission(
+                new ClusterPermission.Builder(new RestrictedIndices(TestRestrictedIndices.RESTRICTED_INDICES.getAutomaton()))
+            ).build();
+
+            assertAllowedIndexPatterns(permission, new String[] { pattern }, new String[] { "all" }, true, false);
+            assertAllowedIndexPatterns(permission, new String[] { pattern }, new String[] { "all" }, false, true);
+        }
+    }
+
+    public void testAllowRestrictedIndicesRejectedForSingleIndexGroup() {
+        new ReservedRolesStore();
+
+        final ManageRolesPrivilege privilege = new ManageRolesPrivilege(
+            List.of(new ManageRolesPrivilege.ManageRolesIndexPermissionGroup(new String[] { "allowed-*" }, new String[] { "all" }))
+        );
+        final ClusterPermission permission = privilege.buildPermission(
+            new ClusterPermission.Builder(new RestrictedIndices(TestRestrictedIndices.RESTRICTED_INDICES.getAutomaton()))
+        ).build();
+
+        {
+            final PutRoleRequest putRoleRequest = new PutRoleRequest();
+            putRoleRequest.name(randomAlphaOfLength(3));
+            putRoleRequest.addIndex(new String[] { "allowed-a" }, new String[] { "all" }, null, null, null, false);
+            putRoleRequest.addIndex(new String[] { "allowed-b" }, new String[] { "all" }, null, null, null, true);
+            assertThat(permissionCheck(permission, "cluster:admin/xpack/security/role/put", putRoleRequest), is(false));
+        }
+        {
+            final BulkPutRolesRequest bulkPutRolesRequest = new BulkPutRolesRequest(
+                List.of(
+                    new RoleDescriptor(
+                        randomAlphaOfLength(3),
+                        new String[] {},
+                        new RoleDescriptor.IndicesPrivileges[] {
+                            RoleDescriptor.IndicesPrivileges.builder().indices("allowed-a").privileges("all").build(),
+                            RoleDescriptor.IndicesPrivileges.builder()
+                                .indices("allowed-b")
+                                .privileges("all")
+                                .allowRestrictedIndices(true)
+                                .build() },
+                        new String[] {}
+                    )
+                )
+            );
+            assertThat(permissionCheck(permission, "cluster:admin/xpack/security/role/bulk_put", bulkPutRolesRequest), is(false));
+        }
+    }
+
     public void testGenerateAndParseXContent() throws Exception {
         final XContent xContent = randomFrom(XContentType.values()).xContent();
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -340,10 +416,20 @@ public class ManageRolesPrivilegesTests extends AbstractNamedWriteableTestCase<C
         String[] privileges,
         boolean expected
     ) {
+        assertAllowedIndexPatterns(permission, indexPatterns, privileges, false, expected);
+    }
+
+    private static void assertAllowedIndexPatterns(
+        ClusterPermission permission,
+        String[] indexPatterns,
+        String[] privileges,
+        boolean allowRestrictedIndices,
+        boolean expected
+    ) {
         {
             final PutRoleRequest putRoleRequest = new PutRoleRequest();
             putRoleRequest.name(randomAlphaOfLength(3));
-            putRoleRequest.addIndex(indexPatterns, privileges, null, null, null, false);
+            putRoleRequest.addIndex(indexPatterns, privileges, null, null, null, allowRestrictedIndices);
             assertThat(permissionCheck(permission, "cluster:admin/xpack/security/role/put", putRoleRequest), is(expected));
         }
         {
@@ -353,7 +439,11 @@ public class ManageRolesPrivilegesTests extends AbstractNamedWriteableTestCase<C
                         randomAlphaOfLength(3),
                         new String[] {},
                         new RoleDescriptor.IndicesPrivileges[] {
-                            RoleDescriptor.IndicesPrivileges.builder().indices(indexPatterns).privileges(privileges).build() },
+                            RoleDescriptor.IndicesPrivileges.builder()
+                                .indices(indexPatterns)
+                                .privileges(privileges)
+                                .allowRestrictedIndices(allowRestrictedIndices)
+                                .build() },
                         new String[] {}
                     )
                 )

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/ManageRolesPrivilegeIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/ManageRolesPrivilegeIT.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security;
 
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.SecureString;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 
 public class ManageRolesPrivilegeIT extends SecurityInBasicRestTestCase {
@@ -102,6 +104,76 @@ public class ManageRolesPrivilegeIT extends SecurityInBasicRestTestCase {
                 containsString("this action is granted by the cluster privileges [manage_security,all]")
             );
         }
+    }
+
+    public void testManageRolesCannotDelegateRestrictedIndicesAccess() throws Exception {
+        createManageRolesRole("manage-roles-role", new String[0], Set.of("*"), Set.of("all"));
+        createUser("test-user", Set.of("manage-roles-role"));
+
+        final String authHeader = basicAuthHeaderValue("test-user", TEST_PASSWORD);
+
+        assertSearchSecurityIndexForbidden(authHeader);
+
+        final ResponseException responseException = assertThrows(
+            ResponseException.class,
+            () -> createRole(authHeader, roleWithIndexPrivileges("manage-roles-role", "*", "all", true))
+        );
+
+        assertThat(
+            responseException.getMessage(),
+            containsString("this action is granted by the cluster privileges [manage_security,all]")
+        );
+
+        assertSearchSecurityIndexForbidden(authHeader);
+    }
+
+    public void testManageRolesRejectsAllowRestrictedIndicesWithinAllowedPattern() throws Exception {
+        createManageRolesRole("manage-logs-roles-role", new String[0], Set.of("logs-*"), Set.of("read"));
+        createUser("logs-role-admin", Set.of("manage-logs-roles-role"));
+
+        final String authHeader = basicAuthHeaderValue("logs-role-admin", TEST_PASSWORD);
+
+        createRole(authHeader, roleWithIndexPrivileges("logs-reader", "logs-*", "read", false));
+
+        final ResponseException responseException = assertThrows(
+            ResponseException.class,
+            () -> createRole(authHeader, roleWithIndexPrivileges("logs-reader", "logs-*", "read", true))
+        );
+
+        assertThat(
+            responseException.getMessage(),
+            containsString("this action is granted by the cluster privileges [manage_security,all]")
+        );
+    }
+
+    private static RoleDescriptor roleWithIndexPrivileges(
+        String roleName,
+        String indexPattern,
+        String privilege,
+        boolean allowRestrictedIndices
+    ) {
+        return new RoleDescriptor(
+            roleName,
+            new String[0],
+            new RoleDescriptor.IndicesPrivileges[] {
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(indexPattern)
+                    .privileges(privilege)
+                    .allowRestrictedIndices(allowRestrictedIndices)
+                    .build() },
+            new RoleDescriptor.ApplicationResourcePrivileges[0],
+            new ConfigurableClusterPrivilege[0],
+            new String[0],
+            Map.of(),
+            Map.of()
+        );
+    }
+
+    private void assertSearchSecurityIndexForbidden(String authHeader) {
+        final Request request = new Request("GET", "/.security/_search");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", authHeader));
+        final ResponseException responseException = assertThrows(ResponseException.class, () -> client().performRequest(request));
+        assertThat(responseException.getResponse().getStatusLine().getStatusCode(), equalTo(403));
     }
 
     public void testManageSecurityNullifiesManageRoles() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Reject `allow_restricted_indices=true` with `manage_roles` privilege (#158831)