### PR TITLE
[8.19] Add an option to limit the number of characters in analyze filters (#158713)

### DIFF
--- a/docs/changelog/158713.yaml
+++ b/docs/changelog/158713.yaml
@@ -1,0 +1,5 @@
+area: Analysis
+issues: []
+pr: 158713
+summary: Add option to limit the number of characters in analyze filters
+type: bug

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
@@ -84,3 +84,41 @@
     - match:  { detail.tokenizer.tokens.0.start_offset: 0 }
     - match:  { detail.tokenizer.tokens.0.end_offset: 15 }
     - match:  { detail.tokenizer.tokens.0.position: 0 }
+
+---
+"chained mapping char filters are bounded by index.analyze.max_char_count":
+    - requires:
+        test_runner_features: [capabilities]
+        capabilities:
+          - method: GET
+            path: /_analyze
+            capabilities: [ analyze_max_char_count ]
+        reason: index.analyze.max_char_count bounds the characters an _analyze request may produce
+    # A mapping chain expands its input geometrically ("a" -> 4 -> 16 -> 64 -> 256 -> 1024), so
+    # index.analyze.max_char_count fails the request with a 400 once the produced characters cross the cap.
+    - do:
+        indices.create:
+          index: test_char_count
+          body:
+            settings:
+              index.analyze.max_char_count: 1000
+
+    - do:
+        catch: /The number of characters produced by calling _analyze has exceeded the allowed maximum of \[1000\]. This limit can be set by changing the \[index.analyze.max_char_count\] index level setting\./
+        indices.analyze:
+          index: test_char_count
+          body:
+            text: "a"
+            tokenizer: keyword
+            explain: true
+            char_filter:
+              - type: mapping
+                mappings: ["a => bbbb"]
+              - type: mapping
+                mappings: ["b => aaaa"]
+              - type: mapping
+                mappings: ["a => bbbb"]
+              - type: mapping
+                mappings: ["b => aaaa"]
+              - type: mapping
+                mappings: ["a => bbbb"]

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/20_analyze_limit.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/20_analyze_limit.yml
@@ -32,7 +32,6 @@ setup:
               text: This should fail as it exceeds limit
               analyzer: standard
 
-
 ---
 "_analyze with explain with No. generated tokens more than index.analyze.max_token_count should fail":
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/21_analyze_max_char_count.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/21_analyze_max_char_count.yml
@@ -1,0 +1,53 @@
+---
+setup:
+  - requires:
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: GET
+          path: /_analyze
+          capabilities: [ analyze_max_char_count ]
+      reason: index.analyze.max_char_count bounds the characters an _analyze request may produce
+
+  - do:
+      indices.create:
+          index: test_2
+          body:
+              settings:
+                  index.analyze.max_char_count: 20
+
+---
+"_analyze with No. produced characters less than or equal to index.analyze.max_char_count should succeed":
+
+  - do:
+      indices.analyze:
+          index:  test_2
+          body:
+              text: under the limit
+              analyzer: standard
+  - length: { tokens: 3 }
+  - match:  { tokens.0.token: under }
+  - match:  { tokens.1.token: the }
+  - match:  { tokens.2.token: limit }
+
+---
+"_analyze with No. produced characters more than index.analyze.max_char_count should fail":
+
+  - do:
+      catch: /The number of characters produced by calling _analyze has exceeded the allowed maximum of \[20\]. This limit can be set by changing the \[index.analyze.max_char_count\] index level setting\./
+      indices.analyze:
+          index:  test_2
+          body:
+              text: this text is well over the limit
+              analyzer: standard
+
+---
+"_analyze with explain with No. produced characters more than index.analyze.max_char_count should fail":
+
+  - do:
+      catch: /The number of characters produced by calling _analyze has exceeded the allowed maximum of \[20\]. This limit can be set by changing the \[index.analyze.max_char_count\] index level setting\./
+      indices.analyze:
+          index:  test_2
+          body:
+              text: this text is well over the limit
+              analyzer: standard
+              explain: true

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeCapabilities.java
@@ -16,5 +16,7 @@ public final class AnalyzeCapabilities {
 
     private static final String WRONG_CUSTOM_ANALYZER_RETURNS_400_CAPABILITY = "wrong_custom_analyzer_returns_400";
 
-    public static final Set<String> CAPABILITIES = Set.of(WRONG_CUSTOM_ANALYZER_RETURNS_400_CAPABILITY);
+    private static final String MAX_CHAR_COUNT_CAPABILITY = "analyze_max_char_count";
+
+    public static final Set<String> CAPABILITIES = Set.of(WRONG_CUSTOM_ANALYZER_RETURNS_400_CAPABILITY, MAX_CHAR_COUNT_CAPABILITY);
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/LimitCharCountAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/LimitCharCountAnalyzer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.action.admin.indices.analyze;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.AnalyzerWrapper;
+
+import java.io.Reader;
+import java.util.function.Consumer;
+
+/**
+ * Wraps another {@link Analyzer} and caps how many characters its character filters may feed to the tokenizer
+ * for a single field value, failing the request with a {@code 400} once the cap is exceeded.
+ *
+ * <p>It uses its own {@link Analyzer#PER_FIELD_REUSE_STRATEGY}: the delegate may be a
+ * {@link org.elasticsearch.index.analysis.NamedAnalyzer}, whose reuse strategy rejects being wrapped by a
+ * non-delegating wrapper.
+ *
+ * @see LimitingReader
+ */
+final class LimitCharCountAnalyzer extends AnalyzerWrapper {
+
+    private final Analyzer delegate;
+    private final int maxCharCount;
+
+    LimitCharCountAnalyzer(Analyzer delegate, int maxCharCount) {
+        super(PER_FIELD_REUSE_STRATEGY);
+        this.delegate = delegate;
+        this.maxCharCount = maxCharCount;
+    }
+
+    @Override
+    protected Analyzer getWrappedAnalyzer(String fieldName) {
+        return delegate;
+    }
+
+    @Override
+    protected TokenStreamComponents wrapComponents(String fieldName, TokenStreamComponents components) {
+        final Consumer<Reader> source = components.getSource();
+        return new TokenStreamComponents(reader -> source.accept(new LimitingReader(reader, maxCharCount)), components.getTokenStream());
+    }
+
+    @Override
+    public String toString() {
+        return "LimitCharCountAnalyzer(" + delegate.toString() + ", maxCharCount=" + maxCharCount + ")";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/LimitingReader.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/LimitingReader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.action.admin.indices.analyze;
+
+import org.apache.lucene.analysis.CharFilter;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * A {@link CharFilter} that caps how many characters may be read from the reader it wraps. Once more than
+ * {@code maxCharCount} characters have been read, the request fails with a {@code 400}.
+ *
+ * <p>The {@code _analyze} API applies character filters as a chain, where each filter's output is the next filter's
+ * input, so a chain can expand its input far beyond the original text. Wrapping the reader downstream analysis pulls
+ * from bounds that expansion.
+ *
+ * <p>It extends {@link CharFilter} so offset correction is preserved: a tokenizer corrects offsets only through an
+ * input that is a {@link CharFilter}. This reader adds no correction of its own and forwards to the wrapped reader.
+ */
+final class LimitingReader extends CharFilter {
+
+    private final int maxCharCount;
+    private long charCount;
+
+    LimitingReader(Reader in, int maxCharCount) {
+        super(in);
+        this.maxCharCount = maxCharCount;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        final int read = input.read(cbuf, off, len);
+        if (read > 0) {
+            increment(read);
+        }
+        return read;
+    }
+
+    @Override
+    protected int correct(int currentOff) {
+        return currentOff;
+    }
+
+    private void increment(int count) {
+        charCount += count;
+        if (charCount > maxCharCount) {
+            throw new ElasticsearchStatusException(
+                "The number of characters produced by calling _analyze has exceeded the allowed maximum of ["
+                    + maxCharCount
+                    + "]."
+                    + " This limit can be set by changing the ["
+                    + IndexSettings.MAX_ANALYZE_CHAR_COUNT_SETTING.getKey()
+                    + "] index level setting.",
+                RestStatus.BAD_REQUEST
+            );
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -125,15 +125,36 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         final int maxTokenCount = indexService == null
             ? IndexSettings.MAX_TOKEN_COUNT_SETTING.get(settings)
             : indexService.getIndexSettings().getMaxTokenCount();
+        final int maxCharCount = indexService == null
+            ? IndexSettings.MAX_ANALYZE_CHAR_COUNT_SETTING.get(settings)
+            : indexService.getIndexSettings().getMaxAnalyzeCharCount();
 
-        return analyze(request, indicesService.getAnalysis(), indexService, maxTokenCount);
+        return analyze(request, indicesService.getAnalysis(), indexService, maxTokenCount, maxCharCount);
     }
 
+    /**
+     * Analyzes the request without a character-count limit. Callers that enforce
+     * {@link IndexSettings#MAX_ANALYZE_CHAR_COUNT_SETTING} should use the {@code maxCharCount} overload.
+     */
     public static AnalyzeAction.Response analyze(
         AnalyzeAction.Request request,
         AnalysisRegistry analysisRegistry,
         IndexService indexService,
         int maxTokenCount
+    ) throws IOException {
+        return analyze(request, analysisRegistry, indexService, maxTokenCount, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Analyzes the request, bounding both the tokens produced ({@code maxTokenCount}) and the characters a
+     * character-filter chain may produce ({@code maxCharCount}); exceeding either limit fails with a {@code 400}.
+     */
+    public static AnalyzeAction.Response analyze(
+        AnalyzeAction.Request request,
+        AnalysisRegistry analysisRegistry,
+        IndexService indexService,
+        int maxTokenCount,
+        int maxCharCount
     ) throws IOException {
 
         IndexSettings settings = indexService == null ? null : indexService.getIndexSettings();
@@ -142,14 +163,14 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         // need to build it and then close it after use.
         try (Analyzer analyzer = buildCustomAnalyzer(request, analysisRegistry, settings)) {
             if (analyzer != null) {
-                return analyze(request, analyzer, maxTokenCount);
+                return analyze(request, analyzer, maxTokenCount, maxCharCount);
             }
         } catch (IllegalStateException e) {
             throw new IllegalArgumentException("Can not build a custom analyzer", e);
         }
 
         // Otherwise we use a built-in analyzer, which should not be closed
-        return analyze(request, getAnalyzer(request, analysisRegistry, indexService), maxTokenCount);
+        return analyze(request, getAnalyzer(request, analysisRegistry, indexService), maxTokenCount, maxCharCount);
     }
 
     private IndexService getIndexService(ShardId shardId) {
@@ -239,11 +260,14 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         return null;
     }
 
-    private static AnalyzeAction.Response analyze(AnalyzeAction.Request request, Analyzer analyzer, int maxTokenCount) {
+    private static AnalyzeAction.Response analyze(AnalyzeAction.Request request, Analyzer analyzer, int maxTokenCount, int maxCharCount) {
         if (request.explain()) {
-            return new AnalyzeAction.Response(null, detailAnalyze(request, analyzer, maxTokenCount));
+            return new AnalyzeAction.Response(null, detailAnalyze(request, analyzer, maxTokenCount, maxCharCount));
         }
-        return new AnalyzeAction.Response(simpleAnalyze(request, analyzer, maxTokenCount), null);
+        // On this path the character filters run inside Analyzer#tokenStream, so bound their output by wrapping the analyzer.
+        try (Analyzer limitAnalyzer = new LimitCharCountAnalyzer(analyzer, maxCharCount)) {
+            return new AnalyzeAction.Response(simpleAnalyze(request, limitAnalyzer, maxTokenCount), null);
+        }
     }
 
     private static List<AnalyzeAction.AnalyzeToken> simpleAnalyze(AnalyzeAction.Request request, Analyzer analyzer, int maxTokenCount) {
@@ -291,7 +315,12 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         return tokens;
     }
 
-    private static AnalyzeAction.DetailAnalyzeResponse detailAnalyze(AnalyzeAction.Request request, Analyzer analyzer, int maxTokenCount) {
+    private static AnalyzeAction.DetailAnalyzeResponse detailAnalyze(
+        AnalyzeAction.Request request,
+        Analyzer analyzer,
+        int maxTokenCount,
+        int maxCharCount
+    ) {
         AnalyzeAction.DetailAnalyzeResponse detailResponse;
         final Set<String> includeAttributes = new HashSet<>();
         if (request.attributes() != null) {
@@ -333,14 +362,14 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
                         reader = charFilterFactories[charFilterIndex].create(reader);
                         Reader readerForWriteOut = new StringReader(charFilteredSource);
                         readerForWriteOut = charFilterFactories[charFilterIndex].create(readerForWriteOut);
-                        charFilteredSource = writeCharStream(readerForWriteOut);
+                        charFilteredSource = writeCharStream(new LimitingReader(readerForWriteOut, maxCharCount));
                         charFiltersTexts[charFilterIndex][textIndex] = charFilteredSource;
                     }
                 }
 
                 // analyzing only tokenizer
                 Tokenizer tokenizer = tokenizerFactory.create();
-                tokenizer.setReader(reader);
+                tokenizer.setReader(new LimitingReader(reader, maxCharCount));
                 tokenizerTokenListCreator.analyze(tokenizer, includeAttributes, positionIncrementGap, offsetGap);
 
                 // analyzing each tokenfilter
@@ -354,7 +383,8 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
                             charFilterFactories,
                             tokenizerFactory,
                             tokenFilterFactories,
-                            tokenFilterIndex + 1
+                            tokenFilterIndex + 1,
+                            maxCharCount
                         );
                         tokenFiltersTokenListCreator[tokenFilterIndex].analyze(stream, includeAttributes, positionIncrementGap, offsetGap);
                     }
@@ -395,13 +425,15 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
             }
 
             TokenListCreator tokenListCreator = new TokenListCreator(maxTokenCount);
-            for (String text : request.text()) {
-                tokenListCreator.analyze(
-                    analyzer.tokenStream(request.field(), text),
-                    includeAttributes,
-                    analyzer.getPositionIncrementGap(request.field()),
-                    analyzer.getOffsetGap(request.field())
-                );
+            try (Analyzer limitAnalyzer = new LimitCharCountAnalyzer(analyzer, maxCharCount)) {
+                for (String text : request.text()) {
+                    tokenListCreator.analyze(
+                        limitAnalyzer.tokenStream(request.field(), text),
+                        includeAttributes,
+                        analyzer.getPositionIncrementGap(request.field()),
+                        analyzer.getOffsetGap(request.field())
+                    );
+                }
             }
             detailResponse = new AnalyzeAction.DetailAnalyzeResponse(
                 new AnalyzeAction.AnalyzeTokenList(name, tokenListCreator.getArrayTokens())
@@ -415,14 +447,15 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         CharFilterFactory[] charFilterFactories,
         TokenizerFactory tokenizerFactory,
         TokenFilterFactory[] tokenFilterFactories,
-        int current
+        int current,
+        int maxCharCount
     ) {
         Reader reader = new StringReader(source);
         for (CharFilterFactory charFilterFactory : charFilterFactories) {
             reader = charFilterFactory.create(reader);
         }
         Tokenizer tokenizer = tokenizerFactory.create();
-        tokenizer.setReader(reader);
+        tokenizer.setReader(new LimitingReader(reader, maxCharCount));
         TokenStream tokenStream = tokenizer;
         for (int i = 0; i < current; i++) {
             tokenStream = tokenFilterFactories[i].create(tokenStream);
@@ -435,16 +468,21 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         char[] buf = new char[BUFFER_SIZE];
         int len;
         StringBuilder sb = new StringBuilder();
-        do {
+        // A Reader signals end-of-stream only with -1; a short read is not EOF. Drain until -1 so every character
+        // reaches the wrapping LimitingReader and is counted.
+        while (true) {
             try {
                 len = input.read(buf, 0, BUFFER_SIZE);
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to analyze (charFiltering)", e);
             }
+            if (len < 0) {
+                break;
+            }
             if (len > 0) {
                 sb.append(buf, 0, len);
             }
-        } while (len == BUFFER_SIZE);
+        }
         return sb.toString();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -264,19 +264,43 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         if (request.explain()) {
             return new AnalyzeAction.Response(null, detailAnalyze(request, analyzer, maxTokenCount, maxCharCount));
         }
-        // On this path the character filters run inside Analyzer#tokenStream, so bound their output by wrapping the analyzer.
-        try (Analyzer limitAnalyzer = new LimitCharCountAnalyzer(analyzer, maxCharCount)) {
-            return new AnalyzeAction.Response(simpleAnalyze(request, limitAnalyzer, maxTokenCount), null);
-        }
+        return new AnalyzeAction.Response(simpleAnalyze(request, analyzer, maxTokenCount, maxCharCount), null);
     }
 
-    private static List<AnalyzeAction.AnalyzeToken> simpleAnalyze(AnalyzeAction.Request request, Analyzer analyzer, int maxTokenCount) {
+    /**
+     * Builds the fully analyzed token stream for one input value, capping the characters the tokenizer reads at
+     * {@code maxCharCount}. When the analyzer exposes its components, its character-filter chain is rebuilt so the cap
+     * sits on the reader the tokenizer consumes; otherwise the input is capped before analysis.
+     */
+    private static TokenStream boundedTokenStream(AnalyzeAction.Request request, Analyzer analyzer, String text, int maxCharCount) {
+        Analyzer potentialCustomAnalyzer = analyzer instanceof NamedAnalyzer namedAnalyzer ? namedAnalyzer.analyzer() : analyzer;
+        if (potentialCustomAnalyzer instanceof AnalyzerComponentsProvider customAnalyzer) {
+            AnalyzerComponents components = customAnalyzer.getComponents();
+            TokenFilterFactory[] tokenFilters = components.getTokenFilters();
+            return createStackedTokenStream(
+                text,
+                components.getCharFilters(),
+                components.getTokenizerFactory(),
+                tokenFilters,
+                tokenFilters == null ? 0 : tokenFilters.length,
+                maxCharCount
+            );
+        }
+        return analyzer.tokenStream(request.field(), new LimitingReader(new StringReader(text), maxCharCount));
+    }
+
+    private static List<AnalyzeAction.AnalyzeToken> simpleAnalyze(
+        AnalyzeAction.Request request,
+        Analyzer analyzer,
+        int maxTokenCount,
+        int maxCharCount
+    ) {
         TokenCounter tc = new TokenCounter(maxTokenCount);
         List<AnalyzeAction.AnalyzeToken> tokens = new ArrayList<>();
         int lastPosition = -1;
         int lastOffset = 0;
         for (String text : request.text()) {
-            try (TokenStream stream = analyzer.tokenStream(request.field(), text)) {
+            try (TokenStream stream = boundedTokenStream(request, analyzer, text, maxCharCount)) {
                 stream.reset();
                 CharTermAttribute term = stream.addAttribute(CharTermAttribute.class);
                 PositionIncrementAttribute posIncr = stream.addAttribute(PositionIncrementAttribute.class);
@@ -451,8 +475,10 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         int maxCharCount
     ) {
         Reader reader = new StringReader(source);
-        for (CharFilterFactory charFilterFactory : charFilterFactories) {
-            reader = charFilterFactory.create(reader);
+        if (charFilterFactories != null) {
+            for (CharFilterFactory charFilterFactory : charFilterFactories) {
+                reader = charFilterFactory.create(reader);
+            }
         }
         Tokenizer tokenizer = tokenizerFactory.create();
         tokenizer.setReader(new LimitingReader(reader, maxCharCount));

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -118,6 +118,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.MAX_RESULT_WINDOW_SETTING,
         IndexSettings.MAX_INNER_RESULT_WINDOW_SETTING,
         IndexSettings.MAX_TOKEN_COUNT_SETTING,
+        IndexSettings.MAX_ANALYZE_CHAR_COUNT_SETTING,
         IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING,
         IndexSettings.MAX_SCRIPT_FIELDS_SETTING,
         IndexSettings.MAX_NGRAM_DIFF_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -183,6 +183,20 @@ public final class IndexSettings {
     );
 
     /**
+     * The maximum number of characters a single {@code _analyze} request may produce while applying character
+     * filters. A character-filter chain (each filter's output feeds the next) can expand its input far beyond the
+     * original text; this setting bounds that expansion and rejects the request once the limit is exceeded. The
+     * default of 1M is well above any realistic analysis input.
+     */
+    public static final Setting<Integer> MAX_ANALYZE_CHAR_COUNT_SETTING = Setting.intSetting(
+        "index.analyze.max_char_count",
+        1000000,
+        1,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /**
      * A setting describing the maximum number of characters that will be analyzed for a highlight request.
      * This setting is only applicable when highlighting is requested on a text that was indexed without
      * offsets or term vectors.
@@ -890,6 +904,7 @@ public final class IndexSettings {
     private volatile int maxDocvalueFields;
     private volatile int maxScriptFields;
     private volatile int maxTokenCount;
+    private volatile int maxAnalyzeCharCount;
     private volatile int maxNgramDiff;
     private volatile int maxShingleDiff;
     private volatile TimeValue searchIdleAfter;
@@ -1061,6 +1076,7 @@ public final class IndexSettings {
         maxDocvalueFields = scopedSettings.get(MAX_DOCVALUE_FIELDS_SEARCH_SETTING);
         maxScriptFields = scopedSettings.get(MAX_SCRIPT_FIELDS_SETTING);
         maxTokenCount = scopedSettings.get(MAX_TOKEN_COUNT_SETTING);
+        maxAnalyzeCharCount = scopedSettings.get(MAX_ANALYZE_CHAR_COUNT_SETTING);
         maxNgramDiff = scopedSettings.get(MAX_NGRAM_DIFF_SETTING);
         maxShingleDiff = scopedSettings.get(MAX_SHINGLE_DIFF_SETTING);
         maxRefreshListeners = scopedSettings.get(MAX_REFRESH_LISTENERS_PER_SHARD);
@@ -1159,6 +1175,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(MAX_DOCVALUE_FIELDS_SEARCH_SETTING, this::setMaxDocvalueFields);
         scopedSettings.addSettingsUpdateConsumer(MAX_SCRIPT_FIELDS_SETTING, this::setMaxScriptFields);
         scopedSettings.addSettingsUpdateConsumer(MAX_TOKEN_COUNT_SETTING, this::setMaxTokenCount);
+        scopedSettings.addSettingsUpdateConsumer(MAX_ANALYZE_CHAR_COUNT_SETTING, this::setMaxAnalyzeCharCount);
         scopedSettings.addSettingsUpdateConsumer(MAX_NGRAM_DIFF_SETTING, this::setMaxNgramDiff);
         scopedSettings.addSettingsUpdateConsumer(MAX_SHINGLE_DIFF_SETTING, this::setMaxShingleDiff);
         scopedSettings.addSettingsUpdateConsumer(INDEX_WARMER_ENABLED_SETTING, this::setEnableWarmer);
@@ -1529,6 +1546,15 @@ public final class IndexSettings {
 
     private void setMaxTokenCount(int maxTokenCount) {
         this.maxTokenCount = maxTokenCount;
+    }
+
+    /** Returns the {@code index.analyze.max_char_count} limit for this index. */
+    public int getMaxAnalyzeCharCount() {
+        return maxAnalyzeCharCount;
+    }
+
+    private void setMaxAnalyzeCharCount(int maxAnalyzeCharCount) {
+        this.maxAnalyzeCharCount = maxAnalyzeCharCount;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.action.admin.indices;
 
+import org.apache.lucene.analysis.CharFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.tests.analysis.MockTokenFilter;
 import org.apache.lucene.tests.analysis.MockTokenizer;
@@ -47,6 +48,10 @@ import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -115,9 +120,26 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 }
             }
 
+            class TrickleCharFilterFactory extends AbstractCharFilterFactory {
+
+                TrickleCharFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
+                    super(name);
+                }
+
+                @Override
+                public Reader create(Reader reader) {
+                    return new TrickleCharFilter(reader);
+                }
+
+                @Override
+                public Object sharingKey() {
+                    return this;
+                }
+            }
+
             @Override
             public Map<String, AnalysisProvider<CharFilterFactory>> getCharFilters() {
-                return singletonMap("append", AppendCharFilterFactory::new);
+                return Map.of("append", AppendCharFilterFactory::new, "trickle", TrickleCharFilterFactory::new);
             }
 
             @Override
@@ -520,6 +542,102 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         );
     }
 
+    /**
+     * A character filter that exceeds {@code index.analyze.max_char_count} must fail both the non-explain
+     * ({@code simpleAnalyze}) and explain ({@code detailAnalyze}) paths with a 400.
+     */
+    public void testExceedMaxCharCountLimit() {
+        int maxCharCount = 5;
+        String expectedMessage = "The number of characters produced by calling _analyze has exceeded the allowed maximum of ["
+            + maxCharCount
+            + "]."
+            + " This limit can be set by changing the [index.analyze.max_char_count] index level setting.";
+
+        // explain=false -> simpleAnalyze path; "abc" (3 chars) -> "abc0123456789" (13 chars).
+        AnalyzeAction.Request request = new AnalyzeAction.Request();
+        request.tokenizer("standard");
+        request.addCharFilter(Map.of("type", "append", "suffix", "0123456789"));
+        request.text("abc");
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> TransportAnalyzeAction.analyze(request, registry, mockIndexService(), maxTokenCount, maxCharCount)
+        );
+        assertEquals(expectedMessage, e.getMessage());
+
+        // explain=true -> detailAnalyze path, same char filter.
+        AnalyzeAction.Request explainRequest = new AnalyzeAction.Request();
+        explainRequest.tokenizer("standard");
+        explainRequest.addCharFilter(Map.of("type", "append", "suffix", "0123456789"));
+        explainRequest.text("abc");
+        explainRequest.explain(true);
+        ElasticsearchStatusException explainException = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> TransportAnalyzeAction.analyze(explainRequest, registry, mockIndexService(), maxTokenCount, maxCharCount)
+        );
+        assertEquals(expectedMessage, explainException.getMessage());
+    }
+
+    /**
+     * Within {@code index.analyze.max_char_count}, analysis is unaffected and returns the expected tokens.
+     */
+    public void testMaxCharCountNotExceededReturnsTokens() throws IOException {
+        AnalyzeAction.Request request = new AnalyzeAction.Request();
+        request.tokenizer("standard");
+        request.addCharFilter(Map.of("type", "append", "suffix", "foo"));
+        request.text("quick brown"); // appends "foo" -> "quick brownfoo", well under the limit
+        AnalyzeAction.Response analyze = TransportAnalyzeAction.analyze(request, registry, mockIndexService(), maxTokenCount, 1000);
+        List<AnalyzeAction.AnalyzeToken> tokens = analyze.getTokens();
+        assertThat(tokens, hasSize(2));
+        assertEquals("quick", tokens.get(0).getTerm());
+        assertEquals("brownfoo", tokens.get(1).getTerm());
+    }
+
+    /**
+     * The limit is exclusive — a value at the limit is accepted, one more is rejected — including the
+     * no-character-filter case where the text itself crosses it.
+     */
+    public void testMaxCharCountBoundary() throws IOException {
+        AnalyzeAction.Request atLimit = new AnalyzeAction.Request();
+        atLimit.tokenizer("standard");
+        atLimit.text("abcde"); // exactly 5 characters
+        AnalyzeAction.Response analyze = TransportAnalyzeAction.analyze(atLimit, registry, mockIndexService(), maxTokenCount, 5);
+        assertThat(analyze.getTokens(), hasSize(1));
+        assertEquals("abcde", analyze.getTokens().get(0).getTerm());
+
+        AnalyzeAction.Request overLimit = new AnalyzeAction.Request();
+        overLimit.tokenizer("standard");
+        overLimit.text("abcdef"); // 6 characters
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> TransportAnalyzeAction.analyze(overLimit, registry, mockIndexService(), maxTokenCount, 5)
+        );
+        assertEquals(
+            "The number of characters produced by calling _analyze has exceeded the allowed maximum of [5]."
+                + " This limit can be set by changing the [index.analyze.max_char_count] index level setting.",
+            e.getMessage()
+        );
+    }
+
+    /**
+     * The explain path must drain a character filter fully. With a filter that yields one character per read, the
+     * whole text must still be captured — draining to {@code -1}, not stopping at the first short read.
+     */
+    public void testExplainDrainsCharFilterReaderFully() throws IOException {
+        String text = "the quick brown fox";
+        AnalyzeAction.Request request = new AnalyzeAction.Request();
+        request.tokenizer("keyword");
+        request.addCharFilter(Map.of("type", "trickle"));
+        request.text(text);
+        request.explain(true);
+
+        AnalyzeAction.Response analyze = TransportAnalyzeAction.analyze(request, registry, mockIndexService(), maxTokenCount);
+
+        AnalyzeAction.CharFilteredText[] charFilters = analyze.detail().charfilters();
+        assertThat(charFilters, arrayWithSize(1));
+        String[] texts = charFilters[0].getTexts();
+        assertThat(texts, arrayContaining(text));
+    }
+
     public void testDeprecationWarnings() throws IOException {
         AnalyzeAction.Request req = new AnalyzeAction.Request();
         req.tokenizer("standard");
@@ -536,5 +654,29 @@ public class TransportAnalyzeActionTests extends ESTestCase {
 
         analyze = TransportAnalyzeAction.analyze(req, registry, mockIndexService(), maxTokenCount);
         assertEquals(1, analyze.getTokens().size());
+    }
+
+    /**
+     * A character filter that returns at most one character per {@link #read} while input remains — the short
+     * reads a drain loop must not mistake for end-of-stream.
+     */
+    private static final class TrickleCharFilter extends CharFilter {
+
+        TrickleCharFilter(Reader input) {
+            super(input);
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            if (len == 0) {
+                return 0;
+            }
+            return input.read(cbuf, off, 1);
+        }
+
+        @Override
+        protected int correct(int currentOff) {
+            return currentOff;
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -130,11 +130,6 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 public Reader create(Reader reader) {
                     return new TrickleCharFilter(reader);
                 }
-
-                @Override
-                public Object sharingKey() {
-                    return this;
-                }
             }
 
             @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -490,6 +490,7 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         IndexSettings.WEIGHT_MATCHES_MODE_ENABLED_SETTING,
         IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING,
         IndexSettings.MAX_TOKEN_COUNT_SETTING,
+        IndexSettings.MAX_ANALYZE_CHAR_COUNT_SETTING,
         IndexSettings.MAX_SLICES_PER_SCROLL,
         IndexSettings.DEFAULT_PIPELINE,
         IndexSettings.FINAL_PIPELINE,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add an option to limit the number of characters in analyze filters (#158713)](https://github.com/elastic/elasticsearch/pull/158713)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)