### PR TITLE
Support columnar_stored in vectordb_columnar mode

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/280_vectordb_columnar_index_mode.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/280_vectordb_columnar_index_mode.yml
@@ -102,15 +102,80 @@ setup:
   - match: { hits.hits.0._id: "2" }
 
 ---
-"Vectordb_columnar index mode only supports synthetic source":
+"Vectordb_columnar index mode with columnar_stored source":
   - do:
-      catch: /unsupported source mode \[COLUMNAR_STORED\] for index mode \[vectordb_columnar\]/
       indices.create:
         index: test_vectordb_columnar_stored
         body:
           settings:
             index.mode: vectordb_columnar
             index.mapping.source.mode: columnar_stored
+          mappings:
+            properties:
+              title:
+                type: text
+              embedding:
+                type: dense_vector
+                dims: 3
+                element_type: float
+                similarity: l2_norm
+
+  - do:
+      index:
+        index: test_vectordb_columnar_stored
+        id: 1
+        refresh: true
+        body:
+          title: "A stored columnar document"
+          embedding: [1.0, 2.0, 3.0]
+
+  - do:
+      indices.get_settings:
+        index: test_vectordb_columnar_stored
+  - match: { test_vectordb_columnar_stored.settings.index.mapping.source.mode: "columnar_stored" }
+  - match: { test_vectordb_columnar_stored.settings.index.mapping.exclude_source_vectors: "true" }
+
+  # The vector is not part of the source blob, so it is absent unless the request asks for it.
+  - do:
+      search:
+        index: test_vectordb_columnar_stored
+        body:
+          query:
+            match_all: {}
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._source.title: "A stored columnar document" }
+  - is_false: hits.hits.0._source.embedding
+
+  # Asking for vectors patches them back in from the vector index.
+  - do:
+      search:
+        index: test_vectordb_columnar_stored
+        body:
+          _source:
+            exclude_vectors: false
+          query:
+            match_all: {}
+  - match: { hits.hits.0._source.embedding: [1.0, 2.0, 3.0] }
+
+  - do:
+      get:
+        index: test_vectordb_columnar_stored
+        id: 1
+        _source_exclude_vectors: false
+  - match: { _source.title: "A stored columnar document" }
+  - match: { _source.embedding: [1.0, 2.0, 3.0] }
+
+  # kNN search still works: the vector index itself is unaffected by the source mode.
+  - do:
+      search:
+        index: test_vectordb_columnar_stored
+        body:
+          query:
+            knn:
+              field: embedding
+              query_vector: [1.0, 2.0, 3.0]
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
 
 ---
 "Vectordb_columnar index mode forbids disabling exclude_source_vectors":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/280_vectordb_columnar_index_mode.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/280_vectordb_columnar_index_mode.yml
@@ -117,7 +117,6 @@ setup:
               embedding:
                 type: dense_vector
                 dims: 3
-                element_type: float
                 similarity: l2_norm
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -810,10 +810,9 @@ public enum IndexMode {
             return SourceFieldMapper.Mode.SYNTHETIC;
         }
 
-        // TODO: support SourceFieldMapper.Mode#COLUMNAR_STORED
         @Override
         public List<SourceFieldMapper.Mode> supportedSourceModes() {
-            return List.of(SourceFieldMapper.Mode.SYNTHETIC);
+            return List.of(SourceFieldMapper.Mode.SYNTHETIC, SourceFieldMapper.Mode.COLUMNAR_STORED);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -581,13 +581,6 @@ public class IndexModuleTests extends ESTestCase {
         assertFalse(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.get(settings));
     }
 
-    /** vectordb_columnar is the one strict columnar mode that keeps the query cache, so kNN filters stay cached. */
-    public void testQueryCacheEnabledByDefaultForVectordbColumnarMode() {
-        assumeTrue("vectordb_columnar index mode requires snapshot build", IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled());
-        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.VECTORDB_COLUMNAR.getName()).build();
-        assertTrue(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.get(settings));
-    }
-
     public void testDisableQueryCacheHasPrecedenceOverForceQueryCache() throws IOException {
         Settings settings = Settings.builder()
             .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -581,6 +581,13 @@ public class IndexModuleTests extends ESTestCase {
         assertFalse(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.get(settings));
     }
 
+    /** vectordb_columnar is the one strict columnar mode that keeps the query cache, so kNN filters stay cached. */
+    public void testQueryCacheEnabledByDefaultForVectordbColumnarMode() {
+        assumeTrue("vectordb_columnar index mode requires snapshot build", IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled());
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.VECTORDB_COLUMNAR.getName()).build();
+        assertTrue(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.get(settings));
+    }
+
     public void testDisableQueryCacheHasPrecedenceOverForceQueryCache() throws IOException {
         Settings settings = Settings.builder()
             .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)

--- a/server/src/test/java/org/elasticsearch/index/VectordbColumnarIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VectordbColumnarIndexModeTests.java
@@ -59,8 +59,10 @@ public class VectordbColumnarIndexModeTests extends ESTestCase {
 
     public void testColumnarDefaults() {
         assertThat(IndexMode.VECTORDB_COLUMNAR.defaultSourceMode(), equalTo(SourceFieldMapper.Mode.SYNTHETIC));
-        // Unlike the other columnar modes, columnar_stored source is not supported yet.
-        assertThat(IndexMode.VECTORDB_COLUMNAR.supportedSourceModes(), equalTo(List.of(SourceFieldMapper.Mode.SYNTHETIC)));
+        assertThat(
+            IndexMode.VECTORDB_COLUMNAR.supportedSourceModes(),
+            equalTo(List.of(SourceFieldMapper.Mode.SYNTHETIC, SourceFieldMapper.Mode.COLUMNAR_STORED))
+        );
         assertThat(IndexMode.VECTORDB_COLUMNAR.getDefaultCodec(), equalTo(CodecService.BEST_COMPRESSION_CODEC));
         assertTrue(IndexMode.VECTORDB_COLUMNAR.isColumnar());
         assertTrue(IndexMode.VECTORDB_COLUMNAR.isStrictColumnar());

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -570,27 +570,6 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
         }
     }
 
-    /** The vector columnar mode only supports synthetic source for now. */
-    public void testColumnarStoredSourceModeRejectedInVectordbColumnarIndex() {
-        assumeTrue("vectordb_columnar index mode requires snapshot build", IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled());
-        Settings settings = Settings.builder()
-            .put(IndexSettings.MODE.getKey(), IndexMode.VECTORDB_COLUMNAR.toString())
-            .put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), SourceFieldMapper.Mode.COLUMNAR_STORED.toString())
-            .build();
-        IllegalArgumentException exc = expectThrows(
-            IllegalArgumentException.class,
-            () -> createMapperService(settings, topMapping(b -> {}))
-        );
-        assertThat(
-            exc.getMessage(),
-            containsString(
-                "unsupported source mode [COLUMNAR_STORED] for index mode ["
-                    + IndexMode.VECTORDB_COLUMNAR
-                    + "]; supported values: [SYNTHETIC]"
-            )
-        );
-    }
-
     public void testSyntheticRecoverySourceRequiredForColumnarIndex() {
         // Disabling synthetic recovery source is rejected for columnar index modes
         for (var columnarMode : Arrays.stream(IndexMode.availableModes()).filter(IndexMode::isStrictColumnar).toList()) {

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenseChangeTestCase.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenseChangeTestCase.java
@@ -57,6 +57,18 @@ public abstract class DataStreamLicenseChangeTestCase extends LogsIndexModeRestT
         }
     }
 
+    /**
+     * Returns true if the cluster under test supports the {@code vectordb_columnar} index mode, which sits behind
+     * its own feature flag and therefore has a capability of its own.
+     */
+    protected static boolean isVectordbColumnarIndexModeSupported() {
+        try {
+            return clusterHasCapability("PUT", "/{index}", List.of(), List.of("vectordb_columnar_index_mode")).orElse(false);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
     protected static void startBasic() throws IOException {
         Request startTrial = new Request("POST", "/_license/start_basic");
         startTrial.addParameter("acknowledge", "true");

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/SourceModeLicenseDowngradeIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/SourceModeLicenseDowngradeIT.java
@@ -25,8 +25,7 @@ public class SourceModeLicenseDowngradeIT extends SourceModeLicenseChangeTestCas
     }
 
     /**
-     * Builds one TestCase for each strict-columnar index mode that has a source mode to fall back to. vectordb_columnar
-     * supports synthetic source only, so a downgrade rejects new indices rather than switching their source mode.
+     * Builds one TestCase for each strict-columnar index mode: all of them fall back to columnar_stored rather than stored.
      */
     private List<TestCase> columnarCases() {
         return List.of(
@@ -43,6 +42,13 @@ public class SourceModeLicenseDowngradeIT extends SourceModeLicenseChangeTestCas
                 SourceFieldMapper.Mode.SYNTHETIC,
                 SourceFieldMapper.Mode.COLUMNAR_STORED,
                 () -> isColumnarIndexModeSupported() == false
+            ),
+            new SourceModeTestCase(
+                "vectordb-columnar-test",
+                "vectordb_columnar",
+                SourceFieldMapper.Mode.SYNTHETIC,
+                SourceFieldMapper.Mode.COLUMNAR_STORED,
+                () -> isVectordbColumnarIndexModeSupported() == false
             )
         );
     }

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/SourceModeLicenseUpgradeIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/SourceModeLicenseUpgradeIT.java
@@ -23,8 +23,7 @@ public class SourceModeLicenseUpgradeIT extends SourceModeLicenseChangeTestCase 
     }
 
     /**
-     * Builds one TestCase for each strict-columnar index mode that has a source mode to fall back to. vectordb_columnar
-     * supports synthetic source only, so without a license it cannot be created at all rather than starting out stored.
+     * Builds one TestCase for each strict-columnar index mode: all of them start out on columnar_stored rather than stored.
      */
     private List<TestCase> columnarCases() {
         return List.of(
@@ -41,6 +40,13 @@ public class SourceModeLicenseUpgradeIT extends SourceModeLicenseChangeTestCase 
                 SourceFieldMapper.Mode.COLUMNAR_STORED,
                 SourceFieldMapper.Mode.SYNTHETIC,
                 () -> isColumnarIndexModeSupported() == false
+            ),
+            new SourceModeTestCase(
+                "vectordb-columnar-test",
+                "vectordb_columnar",
+                SourceFieldMapper.Mode.COLUMNAR_STORED,
+                SourceFieldMapper.Mode.SYNTHETIC,
+                () -> isVectordbColumnarIndexModeSupported() == false
             )
         );
     }

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -191,22 +191,10 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                 if (resolvedIndexMode == null) {
                     resolvedIndexMode = templateIndexMode;
                 }
-                if (resolvedIndexMode == IndexMode.VECTORDB_COLUMNAR) {
-                    // This mode supports synthetic source only, so there is no source mode to fall back to. Templates may
-                    // still declare the mode; the license is enforced when an index is created from them.
-                    if (isTemplateValidation == false) {
-                        throw new IllegalArgumentException(
-                            "index mode ["
-                                + IndexMode.VECTORDB_COLUMNAR.getName()
-                                + "] requires synthetic source, which is not available with the current license"
-                        );
-                    }
-                } else {
-                    additionalSettings.put(
-                        IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(),
-                        fallbackSourceMode(resolvedIndexMode).toString()
-                    );
-                }
+                additionalSettings.put(
+                    IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(),
+                    fallbackSourceMode(resolvedIndexMode).toString()
+                );
             }
         }
 

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/ColumnarSourceLicensingTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/ColumnarSourceLicensingTests.java
@@ -28,6 +28,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.common.settings.Settings.builder;
@@ -120,11 +121,7 @@ public class ColumnarSourceLicensingTests extends ESTestCase {
     }
 
     private List<IndexMode> columnarModes() {
-        var modes = new java.util.ArrayList<>(List.of(IndexMode.LOGSDB_COLUMNAR, IndexMode.COLUMNAR));
-        if (IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled()) {
-            modes.add(IndexMode.VECTORDB_COLUMNAR);
-        }
-        return modes;
+        return Arrays.stream(IndexMode.availableModes()).filter(IndexMode::isStrictColumnar).toList();
     }
 
     public void testFallsBackToColumnarStoredWithoutEnterpriseLicense() throws IOException {

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/ColumnarSourceLicensingTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/ColumnarSourceLicensingTests.java
@@ -39,8 +39,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the license-based source-mode fallback for strict-columnar index modes. These modes default to synthetic source but do not
  * support stored source, so they must fall back to {@link SourceFieldMapper.Mode#COLUMNAR_STORED} (not
- * {@link SourceFieldMapper.Mode#STORED}) when an enterprise license is absent. The exception is
- * {@link IndexMode#VECTORDB_COLUMNAR}, which supports synthetic source only and is therefore rejected outright.
+ * {@link SourceFieldMapper.Mode#STORED}) when an enterprise license is absent.
  *
  * The enforcement lives in {@link LogsdbIndexModeSettingsProvider} — the only {@code IndexSettingProvider}
  * that handles synthetic-source fallback — which is why these tests reside in the logsdb module despite
@@ -120,97 +119,48 @@ public class ColumnarSourceLicensingTests extends ESTestCase {
         return builder().put(settingsBuilder.build()).build();
     }
 
-    public void testLogsdbColumnarFallsBackToColumnarStoredWithoutEnterpriseLicense() throws IOException {
-        Settings result = provideColumnarSettings(IndexMode.LOGSDB_COLUMNAR, basicLicenseService);
-        // Use raw string comparison: INDEX_MAPPER_SOURCE_MODE_SETTING.get() cross-validates against index.mode,
-        // which is not present in the additional settings returned by the provider.
-        assertEquals(SourceFieldMapper.Mode.COLUMNAR_STORED.name(), result.get(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey()));
+    private List<IndexMode> columnarModes() {
+        var modes = new java.util.ArrayList<>(List.of(IndexMode.LOGSDB_COLUMNAR, IndexMode.COLUMNAR));
+        if (IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled()) {
+            modes.add(IndexMode.VECTORDB_COLUMNAR);
+        }
+        return modes;
     }
 
-    public void testColumnarFallsBackToColumnarStoredWithoutEnterpriseLicense() throws IOException {
-        Settings result = provideColumnarSettings(IndexMode.COLUMNAR, basicLicenseService);
-        assertEquals(SourceFieldMapper.Mode.COLUMNAR_STORED.name(), result.get(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey()));
-    }
-
-    /**
-     * Unlike the other columnar modes, vectordb_columnar supports synthetic source only, so there is no source mode to
-     * fall back to and index creation is rejected instead.
-     */
-    public void testVectordbColumnarRejectedWithoutEnterpriseLicense() {
-        assumeTrue("vectordb_columnar index mode requires snapshot build", IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled());
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> provideColumnarSettings(IndexMode.VECTORDB_COLUMNAR, basicLicenseService)
-        );
-        assertEquals(
-            "index mode [vectordb_columnar] requires synthetic source, which is not available with the current license",
-            e.getMessage()
-        );
-    }
-
-    public void testLogsdbColumnarDoesNotFallBackWithEnterpriseLicense() throws IOException {
-        Settings result = provideColumnarSettings(IndexMode.LOGSDB_COLUMNAR, enterpriseLicenseService);
-        assertFalse(
-            "enterprise license should allow synthetic source; source mode setting must not be injected",
-            IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.exists(result)
-        );
-    }
-
-    public void testColumnarDoesNotFallBackWithEnterpriseLicense() throws IOException {
-        Settings result = provideColumnarSettings(IndexMode.COLUMNAR, enterpriseLicenseService);
-        assertFalse(
-            "enterprise license should allow synthetic source; source mode setting must not be injected",
-            IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.exists(result)
-        );
-    }
-
-    public void testVectordbColumnarDoesNotFallBackWithEnterpriseLicense() throws IOException {
-        assumeTrue("vectordb_columnar index mode requires snapshot build", IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled());
-        Settings result = provideColumnarSettings(IndexMode.VECTORDB_COLUMNAR, enterpriseLicenseService);
-        assertFalse(
-            "enterprise license should allow synthetic source; source mode setting must not be injected",
-            IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.exists(result)
-        );
-    }
-
-    public void testLogsdbColumnarFallsBackToColumnarStoredWithOperatorFallbackFlag() throws IOException {
-        enterpriseLicenseService.setSyntheticSourceFallback(true);
-        try {
-            Settings result = provideColumnarSettings(IndexMode.LOGSDB_COLUMNAR, enterpriseLicenseService);
+    public void testFallsBackToColumnarStoredWithoutEnterpriseLicense() throws IOException {
+        for (IndexMode mode : columnarModes()) {
+            Settings result = provideColumnarSettings(mode, basicLicenseService);
+            // Use raw string comparison: INDEX_MAPPER_SOURCE_MODE_SETTING.get() cross-validates against index.mode,
+            // which is not present in the additional settings returned by the provider.
             assertEquals(
+                mode.getName(),
                 SourceFieldMapper.Mode.COLUMNAR_STORED.name(),
                 result.get(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey())
             );
-        } finally {
-            enterpriseLicenseService.setSyntheticSourceFallback(false);
         }
     }
 
-    public void testColumnarFallsBackToColumnarStoredWithOperatorFallbackFlag() throws IOException {
-        enterpriseLicenseService.setSyntheticSourceFallback(true);
-        try {
-            Settings result = provideColumnarSettings(IndexMode.COLUMNAR, enterpriseLicenseService);
-            assertEquals(
-                SourceFieldMapper.Mode.COLUMNAR_STORED.name(),
-                result.get(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey())
+    public void testDoesNotFallBackWithEnterpriseLicense() throws IOException {
+        for (IndexMode mode : columnarModes()) {
+            Settings result = provideColumnarSettings(mode, enterpriseLicenseService);
+            assertFalse(
+                mode.getName() + ": enterprise license should allow synthetic source; source mode setting must not be injected",
+                IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.exists(result)
             );
-        } finally {
-            enterpriseLicenseService.setSyntheticSourceFallback(false);
         }
     }
 
-    public void testVectordbColumnarRejectedWithOperatorFallbackFlag() {
-        assumeTrue("vectordb_columnar index mode requires snapshot build", IndexMode.VECTORDB_COLUMNAR_FEATURE_FLAG.isEnabled());
+    public void testFallsBackToColumnarStoredWithOperatorFallbackFlag() throws IOException {
         enterpriseLicenseService.setSyntheticSourceFallback(true);
         try {
-            IllegalArgumentException e = expectThrows(
-                IllegalArgumentException.class,
-                () -> provideColumnarSettings(IndexMode.VECTORDB_COLUMNAR, enterpriseLicenseService)
-            );
-            assertEquals(
-                "index mode [vectordb_columnar] requires synthetic source, which is not available with the current license",
-                e.getMessage()
-            );
+            for (IndexMode mode : columnarModes()) {
+                Settings result = provideColumnarSettings(mode, enterpriseLicenseService);
+                assertEquals(
+                    mode.getName(),
+                    SourceFieldMapper.Mode.COLUMNAR_STORED.name(),
+                    result.get(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey())
+                );
+            }
         } finally {
             enterpriseLicenseService.setSyntheticSourceFallback(false);
         }


### PR DESCRIPTION
columnar_stored builds the _source blob at index time by running the synthetic loaders, so an indexed dense_vector used to fail to index: the vector index it is rebuilt from does not exist yet. #158528 fixed that by leaving vectors out of the blob and patching them back on read, which removes the blocker here.

vectordb_columnar now accepts columnar_stored alongside synthetic source. Without an enterprise license it falls back to columnar_stored like the other strict columnar modes.

Related to https://github.com/elastic/elasticsearch/pull/158118
