### PR TITLE
Replace onRecoveryAborted with new FailureStrategy

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -210,6 +210,7 @@ import static org.elasticsearch.cluster.metadata.DataStream.TIMESERIES_LEAF_READ
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.indices.recovery.FailureStrategy.ABORT;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SEND;
 import static org.elasticsearch.threadpool.ThreadPool.Names.WRITE;
 
@@ -3978,7 +3979,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             if (recoveryDone) {
                 recoveryListener.onRecoveryDone(recoveryState, getTimestampRange(), getEventIngestedRange());
             } else {
-                recoveryListener.onRecoveryAborted();
+                recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, "abort recovery", null), ABORT);
             }
         }, e -> recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), FAIL_SEND));
         ActionListener.run(actionListener, action);

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -154,6 +154,7 @@ import org.elasticsearch.indices.IndexingMemoryController;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService;
+import org.elasticsearch.indices.recovery.FailureStrategy;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryCancelledException;
 import org.elasticsearch.indices.recovery.RecoveryFailedException;
@@ -210,7 +211,6 @@ import static org.elasticsearch.cluster.metadata.DataStream.TIMESERIES_LEAF_READ
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
-import static org.elasticsearch.indices.recovery.FailureStrategy.ABORT;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SEND;
 import static org.elasticsearch.threadpool.ThreadPool.Names.WRITE;
 
@@ -2887,13 +2887,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     void recoverFromLocalShards(
         BiConsumer<MappingMetadata, ActionListener<Void>> mappingUpdateConsumer,
         List<IndexShard> localShards,
-        ActionListener<Boolean> listener
+        ActionListener<Void> listener
     ) throws IOException {
         assert shardRouting.primary() : "recover from local shards only makes sense if the shard is a primary shard";
         assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS
             : "invalid recovery type: " + recoveryState.getRecoverySource();
         final List<LocalShardSnapshot> snapshots = new ArrayList<>();
-        final ActionListener<Boolean> recoveryListener = ActionListener.runBefore(listener, () -> IOUtils.close(snapshots));
+        final ActionListener<Void> recoveryListener = ActionListener.runBefore(listener, () -> IOUtils.close(snapshots));
         boolean success = false;
         try {
             for (IndexShard shard : localShards) {
@@ -2912,7 +2912,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
-    public void recoverFromStore(ActionListener<Boolean> listener) {
+    public void recoverFromStore(ActionListener<Void> listener) {
         // we are the first primary, recover from the gateway
         // if its post api allocation, the index should exists
         assert shardRouting.primary() : "recover from store only makes sense if the shard is a primary shard";
@@ -2921,7 +2921,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         storeRecovery.recoverFromStore(this, listener);
     }
 
-    public void restoreFromRepository(Repository repository, ActionListener<Boolean> listener) {
+    public void restoreFromRepository(Repository repository, ActionListener<Void> listener) {
         try {
             assert shardRouting.primary() : "recover from store only makes sense if the shard is a primary shard";
             assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT
@@ -3971,18 +3971,22 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         String reason,
         RecoveryState recoveryState,
         RecoveryListener recoveryListener,
-        CheckedConsumer<ActionListener<Boolean>, Exception> action
+        CheckedConsumer<ActionListener<Void>, Exception> action
     ) {
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         markAsRecovering(reason); // mark the shard as recovering on the cluster state thread
-        ActionListener<Boolean> actionListener = ActionListener.wrap(recoveryDone -> {
-            if (recoveryDone) {
-                recoveryListener.onRecoveryDone(recoveryState, getTimestampRange(), getEventIngestedRange());
-            } else {
-                recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, "abort recovery", null), ABORT);
-            }
-        }, e -> recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), FAIL_SEND));
+        ActionListener<Void> actionListener = ActionListener.wrap(
+            ignored -> recoveryListener.onRecoveryDone(recoveryState, getTimestampRange(), getEventIngestedRange()),
+            e -> recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), failureStrategy(e))
+        );
         ActionListener.run(actionListener, action);
+    }
+
+    private FailureStrategy failureStrategy(Exception e) {
+        if (ExceptionsHelper.unwrap(e, IndexShardClosedException.class) != null) {
+            return FailureStrategy.ABORT;
+        }
+        return FAIL_SEND;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -75,29 +75,26 @@ public final class StoreRecovery {
     }
 
     /**
-     * Recovers a shard from it's local file system store. This method required pre-knowledge about if the shard should
-     * exist on disk ie. has been previously allocated or if the shard is a brand new allocation without pre-existing index
+     * Recovers a shard from its local file system store. This method required pre-knowledge about if the shard should
+     * exist on disk ie. has been previously allocated or if the shard is a brand-new allocation without pre-existing index
      * files / transaction logs. This
      * @param indexShard the index shard instance to recovery the shard into
-     * @param listener resolves to <code>true</code> if the shard has been recovered successfully, <code>false</code> if the recovery
-     *                 has been ignored due to a concurrent modification of if the clusters state has changed due to async updates.
+     * @param listener resolves if the shard has been recovered successfully, otherwise receives an exception
+     *                 e.g. IndexShardClosedException if shard a concurrent modification has closed the shard.
      * @see Store
      */
-    void recoverFromStore(final IndexShard indexShard, ActionListener<Boolean> listener) {
-        if (canRecover(indexShard)) {
-            RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
-            assert recoveryType == RecoverySource.Type.EMPTY_STORE
-                || recoveryType == RecoverySource.Type.EXISTING_STORE
-                || recoveryType == RecoverySource.Type.RESHARD_SPLIT : "expected one of store recovery types but was: " + recoveryType;
-            logger.debug("starting recovery from store ...");
-            final var recoveryListener = recoveryListener(indexShard, listener);
-            try {
-                internalRecoverFromStore(indexShard, recoveryListener.map(ignored -> true));
-            } catch (Exception e) {
-                recoveryListener.onFailure(e);
-            }
-        } else {
-            listener.onResponse(false);
+    void recoverFromStore(final IndexShard indexShard, ActionListener<Void> listener) {
+        assertCanRecover(indexShard);
+        RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
+        assert recoveryType == RecoverySource.Type.EMPTY_STORE
+            || recoveryType == RecoverySource.Type.EXISTING_STORE
+            || recoveryType == RecoverySource.Type.RESHARD_SPLIT : "expected one of store recovery types but was: " + recoveryType;
+        logger.debug("starting recovery from store ...");
+        final var recoveryListener = recoveryListener(indexShard, listener);
+        try {
+            internalRecoverFromStore(indexShard, recoveryListener);
+        } catch (Exception e) {
+            recoveryListener.onFailure(e);
         }
     }
 
@@ -105,75 +102,70 @@ public final class StoreRecovery {
         BiConsumer<MappingMetadata, ActionListener<Void>> mappingUpdateConsumer,
         final IndexShard indexShard,
         final List<LocalShardSnapshot> shards,
-        ActionListener<Boolean> outerListener
+        ActionListener<Void> outerListener
     ) {
-        if (canRecover(indexShard)) {
-            RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
-            assert recoveryType == RecoverySource.Type.LOCAL_SHARDS : "expected local shards recovery type: " + recoveryType;
-            if (shards.isEmpty()) {
-                throw new IllegalArgumentException("shards must not be empty");
-            }
-            Set<Index> indices = shards.stream().map((s) -> s.getIndex()).collect(Collectors.toSet());
-            if (indices.size() > 1) {
-                throw new IllegalArgumentException("can't add shards from more than one index");
-            }
-            IndexMetadata sourceMetadata = shards.get(0).getIndexMetadata();
-            final var mappingStep = new SubscribableListener<Void>();
-            if (sourceMetadata.mapping() == null) {
-                mappingStep.onResponse(null);
-            } else {
-                mappingUpdateConsumer.accept(sourceMetadata.mapping(), mappingStep);
-            }
-            mappingStep.addListener(outerListener.delegateFailure((listener, ignored) -> {
-                final var recoveryListener = recoveryListener(indexShard, listener);
-
-                try {
-                    indexShard.mapperService().merge(sourceMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
-                    // now that the mapping is merged we can validate the index sort configuration.
-                    Sort indexSort = indexShard.getIndexSort();
-                    final boolean hasNested = indexShard.mapperService().hasNested();
-                    final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
-
-                    logger.debug("starting recovery from local shards {}", shards);
-                    final Directory directory = indexShard.store().directory(); // don't close this directory!!
-                    final Directory[] sources = shards.stream().map(LocalShardSnapshot::getSnapshotDirectory).toArray(Directory[]::new);
-                    final long maxSeqNo = shards.stream().mapToLong(LocalShardSnapshot::maxSeqNo).max().getAsLong();
-                    final long maxUnsafeAutoIdTimestamp = shards.stream()
-                        .mapToLong(LocalShardSnapshot::maxUnsafeAutoIdTimestamp)
-                        .max()
-                        .getAsLong();
-                    addIndices(
-                        indexShard.recoveryState().getIndex(),
-                        directory,
-                        indexSort,
-                        sources,
-                        maxSeqNo,
-                        maxUnsafeAutoIdTimestamp,
-                        indexShard.indexSettings().getIndexMetadata(),
-                        indexShard.shardId().id(),
-                        isSplit,
-                        hasNested
-                    );
-                    indexShard.ensureRecoveryNotCancelled();
-                    internalRecoverFromStore(indexShard, recoveryListener.delegateFailure((delegate, v) -> {
-                        ActionListener.completeWith(delegate, () -> {
-                            // just trigger a merge to do housekeeping on the
-                            // copied segments - we will also see them in stats etc.
-                            indexShard.getEngine().forceMerge(false, -1, false, UUIDs.randomBase64UUID());
-                            return true;
-                        });
-                    }));
-                } catch (IOException e) {
-                    recoveryListener.onFailure(
-                        new IndexShardRecoveryException(indexShard.shardId(), "failed to recover from local shards", e)
-                    );
-                } catch (Exception e) {
-                    recoveryListener.onFailure(e);
-                }
-            }));
-        } else {
-            outerListener.onResponse(false);
+        assertCanRecover(indexShard);
+        RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
+        assert recoveryType == RecoverySource.Type.LOCAL_SHARDS : "expected local shards recovery type: " + recoveryType;
+        if (shards.isEmpty()) {
+            throw new IllegalArgumentException("shards must not be empty");
         }
+        Set<Index> indices = shards.stream().map((s) -> s.getIndex()).collect(Collectors.toSet());
+        if (indices.size() > 1) {
+            throw new IllegalArgumentException("can't add shards from more than one index");
+        }
+        IndexMetadata sourceMetadata = shards.get(0).getIndexMetadata();
+        final var mappingStep = new SubscribableListener<Void>();
+        if (sourceMetadata.mapping() == null) {
+            mappingStep.onResponse(null);
+        } else {
+            mappingUpdateConsumer.accept(sourceMetadata.mapping(), mappingStep);
+        }
+        mappingStep.addListener(outerListener.delegateFailure((listener, ignored) -> {
+            final var recoveryListener = recoveryListener(indexShard, listener);
+
+            try {
+                indexShard.mapperService().merge(sourceMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
+                // now that the mapping is merged we can validate the index sort configuration.
+                Sort indexSort = indexShard.getIndexSort();
+                final boolean hasNested = indexShard.mapperService().hasNested();
+                final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
+
+                logger.debug("starting recovery from local shards {}", shards);
+                final Directory directory = indexShard.store().directory(); // don't close this directory!!
+                final Directory[] sources = shards.stream().map(LocalShardSnapshot::getSnapshotDirectory).toArray(Directory[]::new);
+                final long maxSeqNo = shards.stream().mapToLong(LocalShardSnapshot::maxSeqNo).max().getAsLong();
+                final long maxUnsafeAutoIdTimestamp = shards.stream()
+                    .mapToLong(LocalShardSnapshot::maxUnsafeAutoIdTimestamp)
+                    .max()
+                    .getAsLong();
+                addIndices(
+                    indexShard.recoveryState().getIndex(),
+                    directory,
+                    indexSort,
+                    sources,
+                    maxSeqNo,
+                    maxUnsafeAutoIdTimestamp,
+                    indexShard.indexSettings().getIndexMetadata(),
+                    indexShard.shardId().id(),
+                    isSplit,
+                    hasNested
+                );
+                indexShard.ensureRecoveryNotCancelled();
+                internalRecoverFromStore(indexShard, recoveryListener.delegateFailure((delegate, v) -> {
+                    ActionListener.completeWith(delegate, () -> {
+                        // just trigger a merge to do housekeeping on the
+                        // copied segments - we will also see them in stats etc.
+                        indexShard.getEngine().forceMerge(false, -1, false, UUIDs.randomBase64UUID());
+                        return null;
+                    });
+                }));
+            } catch (IOException e) {
+                recoveryListener.onFailure(new IndexShardRecoveryException(indexShard.shardId(), "failed to recover from local shards", e));
+            } catch (Exception e) {
+                recoveryListener.onFailure(e);
+            }
+        }));
     }
 
     static void addIndices(
@@ -310,106 +302,81 @@ public final class StoreRecovery {
      * @param listener resolves to <code>true</code> if the shard has been recovered successfully, <code>false</code> if the recovery
      *                 has been ignored due to a concurrent modification of if the clusters state has changed due to async updates.
      */
-    void recoverFromRepository(final IndexShard indexShard, Repository repository, ActionListener<Boolean> listener) {
+    void recoverFromRepository(final IndexShard indexShard, Repository repository, ActionListener<Void> listener) {
         try {
-            if (canRecover(indexShard)) {
-                RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
-                assert recoveryType == RecoverySource.Type.SNAPSHOT : "expected snapshot recovery type: " + recoveryType;
-                SnapshotRecoverySource recoverySource = (SnapshotRecoverySource) indexShard.recoveryState().getRecoverySource();
-                recoverFromRepository(indexShard, repository, recoverySource, recoveryListener(indexShard, listener).map(ignored -> true));
-            } else {
-                listener.onResponse(false);
-            }
+            assertCanRecover(indexShard);
+            RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
+            assert recoveryType == RecoverySource.Type.SNAPSHOT : "expected snapshot recovery type: " + recoveryType;
+            SnapshotRecoverySource recoverySource = (SnapshotRecoverySource) indexShard.recoveryState().getRecoverySource();
+            recoverFromRepository(indexShard, repository, recoverySource, recoveryListener(indexShard, listener));
         } catch (Exception e) {
             listener.onFailure(e);
         }
     }
 
-    private boolean canRecover(IndexShard indexShard) {
+    private void assertCanRecover(IndexShard indexShard) {
         if (indexShard.state() == IndexShardState.CLOSED) {
-            // got closed on us, just ignore this recovery
-            return false;
+            throw new IndexShardClosedException(shardId);
         }
         indexShard.ensureRecoveryNotCancelled();
         if (indexShard.routingEntry().primary() == false) {
             throw new IndexShardRecoveryException(shardId, "Trying to recover when the shard is in backup state", null);
         }
-        return true;
     }
 
-    private ActionListener<Boolean> recoveryListener(IndexShard indexShard, ActionListener<Boolean> listener) {
-        return ActionListener.wrap(res -> {
-            if (res) {
-                // Check that the gateway didn't leave the shard in init or recovering stage. it is up to the gateway
-                // to call post recovery.
-                final IndexShardState shardState = indexShard.state();
-                final RecoveryState recoveryState = indexShard.recoveryState();
-                assert shardState != IndexShardState.CREATED && shardState != IndexShardState.RECOVERING
-                    : "recovery process of " + shardId + " didn't get to post_recovery. shardState [" + shardState + "]";
+    private ActionListener<Void> recoveryListener(IndexShard indexShard, ActionListener<Void> listener) {
+        return ActionListener.wrap(ignored -> {
+            // Check that the gateway didn't leave the shard in init or recovering stage. it is up to the gateway
+            // to call post recovery.
+            final IndexShardState shardState = indexShard.state();
+            final RecoveryState recoveryState = indexShard.recoveryState();
+            assert shardState != IndexShardState.CREATED && shardState != IndexShardState.RECOVERING
+                : "recovery process of " + shardId + " didn't get to post_recovery. shardState [" + shardState + "]";
 
-                if (logger.isTraceEnabled()) {
-                    RecoveryState.Index index = recoveryState.getIndex();
-                    StringBuilder sb = new StringBuilder();
-                    sb.append("    index    : files           [")
-                        .append(index.totalFileCount())
-                        .append("] with total_size [")
-                        .append(ByteSizeValue.ofBytes(index.totalBytes()))
-                        .append("], took[")
-                        .append(TimeValue.timeValueMillis(index.time()))
-                        .append("]\n");
-                    sb.append("             : recovered_files [")
-                        .append(index.recoveredFileCount())
-                        .append("] with total_size [")
-                        .append(ByteSizeValue.ofBytes(index.recoveredBytes()))
-                        .append("]\n");
-                    sb.append("             : reusing_files   [")
-                        .append(index.reusedFileCount())
-                        .append("] with total_size [")
-                        .append(ByteSizeValue.ofBytes(index.reusedBytes()))
-                        .append("]\n");
-                    sb.append("    verify_index    : took [")
-                        .append(TimeValue.timeValueMillis(recoveryState.getVerifyIndex().time()))
-                        .append("], check_index [")
-                        .append(timeValueMillis(recoveryState.getVerifyIndex().checkIndexTime()))
-                        .append("]\n");
-                    sb.append("    translog : number_of_operations [")
-                        .append(recoveryState.getTranslog().recoveredOperations())
-                        .append("], took [")
-                        .append(TimeValue.timeValueMillis(recoveryState.getTranslog().time()))
-                        .append("]");
-                    logger.trace(
-                        "recovery completed from [shard_store], took [{}]\n{}",
-                        timeValueMillis(recoveryState.getTimer().time()),
-                        sb
-                    );
-                } else if (logger.isDebugEnabled()) {
-                    logger.debug("recovery completed from [shard_store], took [{}]", timeValueMillis(recoveryState.getTimer().time()));
-                }
+            if (logger.isTraceEnabled()) {
+                RecoveryState.Index index = recoveryState.getIndex();
+                StringBuilder sb = new StringBuilder();
+                sb.append("    index    : files           [")
+                    .append(index.totalFileCount())
+                    .append("] with total_size [")
+                    .append(ByteSizeValue.ofBytes(index.totalBytes()))
+                    .append("], took[")
+                    .append(TimeValue.timeValueMillis(index.time()))
+                    .append("]\n");
+                sb.append("             : recovered_files [")
+                    .append(index.recoveredFileCount())
+                    .append("] with total_size [")
+                    .append(ByteSizeValue.ofBytes(index.recoveredBytes()))
+                    .append("]\n");
+                sb.append("             : reusing_files   [")
+                    .append(index.reusedFileCount())
+                    .append("] with total_size [")
+                    .append(ByteSizeValue.ofBytes(index.reusedBytes()))
+                    .append("]\n");
+                sb.append("    verify_index    : took [")
+                    .append(TimeValue.timeValueMillis(recoveryState.getVerifyIndex().time()))
+                    .append("], check_index [")
+                    .append(timeValueMillis(recoveryState.getVerifyIndex().checkIndexTime()))
+                    .append("]\n");
+                sb.append("    translog : number_of_operations [")
+                    .append(recoveryState.getTranslog().recoveredOperations())
+                    .append("], took [")
+                    .append(TimeValue.timeValueMillis(recoveryState.getTranslog().time()))
+                    .append("]");
+                logger.trace("recovery completed from [shard_store], took [{}]\n{}", timeValueMillis(recoveryState.getTimer().time()), sb);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("recovery completed from [shard_store], took [{}]", timeValueMillis(recoveryState.getTimer().time()));
             }
-            listener.onResponse(res);
+            listener.onResponse(null);
         }, ex -> {
-            if (ex instanceof IndexShardRecoveryException) {
-                if (indexShard.state() == IndexShardState.CLOSED) {
-                    // got closed on us, just ignore this recovery
-                    listener.onResponse(false);
-                    return;
-                }
-                if (ex.getCause() instanceof IndexShardClosedException) {
-                    // got closed on us, just ignore this recovery
-                    listener.onResponse(false);
-                    return;
-                }
-                listener.onFailure(ex);
-            } else if (ex instanceof IndexShardClosedException) {
-                listener.onResponse(false);
-            } else {
-                if (indexShard.state() == IndexShardState.CLOSED) {
-                    // got closed on us, just ignore this recovery
-                    listener.onResponse(false);
-                } else {
-                    listener.onFailure(new IndexShardRecoveryException(shardId, "failed recovery", ex));
-                }
+            Exception finalException = ex;
+            if (indexShard.state() == IndexShardState.CLOSED) {
+                finalException = new IndexShardClosedException(shardId);
+                finalException.addSuppressed(ex);
+            } else if (ex instanceof IndexShardRecoveryException == false) {
+                finalException = new IndexShardRecoveryException(shardId, "failed recovery", ex);
             }
+            listener.onFailure(finalException);
         });
     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -84,7 +84,7 @@ public final class StoreRecovery {
      * @see Store
      */
     void recoverFromStore(final IndexShard indexShard, ActionListener<Void> listener) {
-        assertCanRecover(indexShard);
+        ensureCanRecover(indexShard);
         RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
         assert recoveryType == RecoverySource.Type.EMPTY_STORE
             || recoveryType == RecoverySource.Type.EXISTING_STORE
@@ -104,7 +104,7 @@ public final class StoreRecovery {
         final List<LocalShardSnapshot> shards,
         ActionListener<Void> outerListener
     ) {
-        assertCanRecover(indexShard);
+        ensureCanRecover(indexShard);
         RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
         assert recoveryType == RecoverySource.Type.LOCAL_SHARDS : "expected local shards recovery type: " + recoveryType;
         if (shards.isEmpty()) {
@@ -304,7 +304,7 @@ public final class StoreRecovery {
      */
     void recoverFromRepository(final IndexShard indexShard, Repository repository, ActionListener<Void> listener) {
         try {
-            assertCanRecover(indexShard);
+            ensureCanRecover(indexShard);
             RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
             assert recoveryType == RecoverySource.Type.SNAPSHOT : "expected snapshot recovery type: " + recoveryType;
             SnapshotRecoverySource recoverySource = (SnapshotRecoverySource) indexShard.recoveryState().getRecoverySource();
@@ -314,7 +314,7 @@ public final class StoreRecovery {
         }
     }
 
-    private void assertCanRecover(IndexShard indexShard) {
+    private void ensureCanRecover(IndexShard indexShard) {
         if (indexShard.state() == IndexShardState.CLOSED) {
             throw new IndexShardClosedException(shardId);
         }
@@ -369,14 +369,15 @@ public final class StoreRecovery {
             }
             listener.onResponse(null);
         }, ex -> {
-            Exception finalException = ex;
             if (indexShard.state() == IndexShardState.CLOSED) {
-                finalException = new IndexShardClosedException(shardId);
-                finalException.addSuppressed(ex);
-            } else if (ex instanceof IndexShardRecoveryException == false) {
-                finalException = new IndexShardRecoveryException(shardId, "failed recovery", ex);
+                var closedException = new IndexShardClosedException(shardId);
+                closedException.addSuppressed(ex);
+                listener.onFailure(closedException);
+            } else if (ex instanceof IndexShardRecoveryException recoveryException) {
+                listener.onFailure(recoveryException);
+            } else {
+                listener.onFailure(new IndexShardRecoveryException(shardId, "failed recovery", ex));
             }
-            listener.onFailure(finalException);
         });
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -146,6 +146,7 @@ import org.elasticsearch.indices.cluster.IndexRemovalReason;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
+import org.elasticsearch.indices.recovery.RecoveryFailedException;
 import org.elasticsearch.indices.recovery.RecoveryListener;
 import org.elasticsearch.indices.recovery.ThrottlingRecoveryService;
 import org.elasticsearch.indices.store.CompositeIndexFoldersDeletionListener;
@@ -208,6 +209,7 @@ import static org.elasticsearch.index.IndexService.IndexCreationContext.METADATA
 import static org.elasticsearch.index.IndexVersions.MINIMUM_COMPATIBLE;
 import static org.elasticsearch.index.IndexVersions.MINIMUM_READONLY_COMPATIBLE;
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQuery;
+import static org.elasticsearch.indices.recovery.FailureStrategy.ABORT;
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 public class IndicesService extends AbstractLifecycleComponent
@@ -1025,7 +1027,7 @@ public class IndicesService extends AbstractLifecycleComponent
                 final var store = indexShard.store();
                 if (store.tryIncRef() == false) {
                     assert indexShard.state() == IndexShardState.CLOSED : indexShard.state();
-                    listener.onRecoveryAborted();
+                    listener.onRecoveryFailure(new RecoveryFailedException(indexShard.recoveryState(), "index shard closed", null), ABORT);
                     return;
                 }
                 final var releaseStoreRef = Releasables.assertOnce(Releasables.releaseOnce(store::decRef));

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -1288,7 +1288,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
         @Override
         public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
-            if (failureStrategy.aborted()) {
+            if (failureStrategy == FailureStrategy.ABORT) {
                 // We don't need to notify master of anything here because recovery abortion is a
                 // symptom of a shard that is closing and this is communicated to master through other
                 // means (or the master already knows because the master initiated it, e.g. by moving the shard)

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -1288,6 +1288,12 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
         @Override
         public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
+            if (failureStrategy.aborted()) {
+                // We don't need to notify master of anything here because recovery abortion is a
+                // symptom of a shard that is closing and this is communicated to master through other
+                // means (or the master already knows because the master initiated it, e.g. by moving the shard)
+                return;
+            }
             RecoveryClusterStateDelay.ensureClusterStateVersion(
                 creationClusterStateVersion,
                 clusterService,
@@ -1299,13 +1305,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                     listener.onResponse(null);
                 }
             );
-        }
-
-        @Override
-        public void onRecoveryAborted() {
-            // We don't need to notify master of anything here because recovery abortion is a
-            // symptom of a shard that is closing and this is communicated to master through other
-            // means (or the master already knows because the master initiated it, e.g. by moving the shard)
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/FailureStrategy.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/FailureStrategy.java
@@ -10,13 +10,21 @@
 package org.elasticsearch.indices.recovery;
 
 public enum FailureStrategy {
-    FAIL_SILENT(false),
-    FAIL_SEND(true);
+    ABORT(true, false),
+    FAIL_SILENT(false, false),
+    FAIL_SEND(false, true);
 
+    private final boolean aborted;
     private final boolean notifyMaster;
 
-    FailureStrategy(boolean notifyMaster) {
+    FailureStrategy(boolean aborted, boolean notifyMaster) {
+        if (aborted) assert !notifyMaster : "never notify master on aborted recovery";
+        this.aborted = aborted;
         this.notifyMaster = notifyMaster;
+    }
+
+    public boolean aborted() {
+        return aborted;
     }
 
     public boolean notifyMaster() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/FailureStrategy.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/FailureStrategy.java
@@ -10,21 +10,14 @@
 package org.elasticsearch.indices.recovery;
 
 public enum FailureStrategy {
-    ABORT(true, false),
-    FAIL_SILENT(false, false),
-    FAIL_SEND(false, true);
+    ABORT(false),
+    FAIL_SILENT(false),
+    FAIL_SEND(true);
 
-    private final boolean aborted;
     private final boolean notifyMaster;
 
-    FailureStrategy(boolean aborted, boolean notifyMaster) {
-        if (aborted) assert !notifyMaster : "never notify master on aborted recovery";
-        this.aborted = aborted;
+    FailureStrategy(boolean notifyMaster) {
         this.notifyMaster = notifyMaster;
-    }
-
-    public boolean aborted() {
-        return aborted;
     }
 
     public boolean notifyMaster() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryListener.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryListener.java
@@ -29,9 +29,6 @@ public interface RecoveryListener {
 
         @Override
         public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {}
-
-        @Override
-        public void onRecoveryAborted() {}
     };
 
     /// Called when recovery finishes successfully.
@@ -43,9 +40,6 @@ public interface RecoveryListener {
 
     /// Called when recovery fails with an exception.
     void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy);
-
-    /// Called when recovery has been internally aborted, usually due to shard closure or shard relocation
-    void onRecoveryAborted();
 
     static RecoveryListener wrapPreservingContext(RecoveryListener listener, Supplier<ThreadContext.StoredContext> context) {
         return new RecoveryListener() {
@@ -64,13 +58,6 @@ public interface RecoveryListener {
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 try (ThreadContext.StoredContext ignore = context.get()) {
                     listener.onRecoveryFailure(e, failureStrategy);
-                }
-            }
-
-            @Override
-            public void onRecoveryAborted() {
-                try (ThreadContext.StoredContext ignore = context.get()) {
-                    listener.onRecoveryAborted();
                 }
             }
         };
@@ -96,15 +83,6 @@ public interface RecoveryListener {
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 try {
                     listener.onRecoveryFailure(e, failureStrategy);
-                } finally {
-                    runAfter.run();
-                }
-            }
-
-            @Override
-            public void onRecoveryAborted() {
-                try {
-                    listener.onRecoveryAborted();
                 } finally {
                     runAfter.run();
                 }
@@ -136,15 +114,6 @@ public interface RecoveryListener {
                     listener.onRecoveryFailure(e, failureStrategy);
                 }
             }
-
-            @Override
-            public void onRecoveryAborted() {
-                try {
-                    runBefore.run();
-                } finally {
-                    listener.onRecoveryAborted();
-                }
-            }
         };
     }
 
@@ -169,11 +138,6 @@ public interface RecoveryListener {
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 listener.onRecoveryFailure(e, failureStrategy);
             }
-
-            @Override
-            public void onRecoveryAborted() {
-                listener.onRecoveryAborted();
-            }
         };
     }
 
@@ -197,11 +161,6 @@ public interface RecoveryListener {
                 } finally {
                     listener.onRecoveryFailure(e, failureStrategy);
                 }
-            }
-
-            @Override
-            public void onRecoveryAborted() {
-                listener.onRecoveryAborted();
             }
         };
     }
@@ -246,17 +205,6 @@ public interface RecoveryListener {
                         }
                         assert false : ex;
                         throw ex;
-                    }
-                }
-
-                @Override
-                public void onRecoveryAborted() {
-                    assertFirstRun();
-                    try {
-                        delegate.onRecoveryAborted();
-                    } catch (Exception e) {
-                        assert false : new AssertionError("listener [" + delegate + "] must handle its own exceptions", e);
-                        throw e;
                     }
                 }
             };

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -258,10 +258,9 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     public void cancel(String reason) {
         if (finished.compareAndSet(false, true)) {
             try {
-                String message = "recovery canceled (reason: [" + reason + "])";
-                logger.debug(message);
+                logger.debug("recovery canceled (reason: [{}])", reason);
                 cancellableThreads.cancel(reason);
-                listener.onRecoveryFailure(new RecoveryFailedException(state(), message, null), ABORT);
+                listener.onRecoveryFailure(new RecoveryFailedException(state(), "recovery canceled", null), ABORT);
             } finally {
                 // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
                 decRef();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadataVerifier.isReadOnlyVerified;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.indices.recovery.FailureStrategy.ABORT;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SEND;
 
 /**
@@ -257,9 +258,10 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     public void cancel(String reason) {
         if (finished.compareAndSet(false, true)) {
             try {
-                logger.debug("recovery canceled (reason: [{}])", reason);
+                String message = "recovery canceled (reason: [" + reason + "])";
+                logger.debug(message);
                 cancellableThreads.cancel(reason);
-                listener.onRecoveryAborted();
+                listener.onRecoveryFailure(new RecoveryFailedException(state(), message, null), ABORT);
             } finally {
                 // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
                 decRef();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.indices.recovery.FailureStrategy.ABORT;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SEND;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SILENT;
 
@@ -182,8 +183,10 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
         }
         if (pendingRecovery == null) {
             if (serviceClosed) {
-                logger.debug("service is closed, aborting recovery: {}", recoveryState);
-                RecoveryListener.wrapPreservingContext(recoveryListener, context).onRecoveryAborted();
+                String message = "service is closed, aborting recovery: " + recoveryState;
+                logger.debug(message);
+                RecoveryListener.wrapPreservingContext(recoveryListener, context)
+                    .onRecoveryFailure(new RecoveryFailedException(recoveryState, message, null), ABORT);
             } else {
                 logger.debug("recovery cancelled at enqueue time: {}", recoveryState);
                 final RecoverySource.Type recoveryType = recoveryState.getRecoverySource().getType();
@@ -328,8 +331,10 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
             }
         }
         for (PendingRecovery pending : recoveriesToAbort) {
-            logger.trace("service closing, aborting recovery: {}", pending.recoveryState());
-            RecoveryListener.wrapPreservingContext(pending.listener, pending.context).onRecoveryAborted();
+            String message = "service closing, aborting recovery: " + pending.recoveryState();
+            logger.trace(message);
+            RecoveryListener.wrapPreservingContext(pending.listener, pending.context)
+                .onRecoveryFailure(new RecoveryFailedException(pending.recoveryState(), message, null), ABORT);
             schedulingListener.onQueuedRecoveryDiscardedOnTarget(
                 pending.recoveryState().getRecoverySource().getType(),
                 pending.priorityGroup()

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -183,10 +183,9 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
         }
         if (pendingRecovery == null) {
             if (serviceClosed) {
-                String message = "service is closed, aborting recovery: " + recoveryState;
-                logger.debug(message);
+                logger.debug("service is closed, aborting recovery: " + recoveryState);
                 RecoveryListener.wrapPreservingContext(recoveryListener, context)
-                    .onRecoveryFailure(new RecoveryFailedException(recoveryState, message, null), ABORT);
+                    .onRecoveryFailure(new RecoveryFailedException(recoveryState, "service is closed", null), ABORT);
             } else {
                 logger.debug("recovery cancelled at enqueue time: {}", recoveryState);
                 final RecoverySource.Type recoveryType = recoveryState.getRecoverySource().getType();
@@ -331,10 +330,9 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
             }
         }
         for (PendingRecovery pending : recoveriesToAbort) {
-            String message = "service closing, aborting recovery: " + pending.recoveryState();
-            logger.trace(message);
+            logger.trace("service closing, aborting recovery: " + pending.recoveryState());
             RecoveryListener.wrapPreservingContext(pending.listener, pending.context)
-                .onRecoveryFailure(new RecoveryFailedException(pending.recoveryState(), message, null), ABORT);
+                .onRecoveryFailure(new RecoveryFailedException(pending.recoveryState(), "service closing", null), ABORT);
             schedulingListener.onQueuedRecoveryDiscardedOnTarget(
                 pending.recoveryState().getRecoverySource().getType(),
                 pending.priorityGroup()

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -796,7 +796,7 @@ public class IndexModuleTests extends ESTestCase {
             closeables.add(() -> flushAndCloseShardNoCheck(indexShard));
             indexShard.markAsRecovering("test");
 
-            final PlainActionFuture<Boolean> recoveryFuture = new PlainActionFuture<>();
+            final PlainActionFuture<Void> recoveryFuture = new PlainActionFuture<>();
             indexShard.recoverFromStore(recoveryFuture);
             recoveryFuture.get();
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -5628,7 +5628,15 @@ public class IndexShardTests extends IndexShardTestCase {
                 .build();
             return new InternalEngine(configWithWarmer);
         });
-        Thread recoveryThread = new Thread(() -> expectThrows(AlreadyClosedException.class, () -> recoverShardFromStore(shard)));
+        Thread recoveryThread = new Thread(() -> {
+            IndexShardClosedException indexShardClosedException = expectThrows(
+                IndexShardClosedException.class,
+                () -> recoverShardFromStore(shard)
+            );
+            Throwable[] suppressed = indexShardClosedException.getSuppressed();
+            assertThat(suppressed.length, equalTo(1));
+            assertThat(ExceptionsHelper.unwrap(suppressed[0], AlreadyClosedException.class), notNullValue());
+        });
         recoveryThread.start();
         try {
             warmerStarted.await();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -6140,11 +6140,6 @@ public class IndexShardTests extends IndexShardTestCase {
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 assert false : "Unexpected failure";
             }
-
-            @Override
-            public void onRecoveryAborted() {
-                assert false : "Unexpected abort";
-            }
         };
         recoverReplica(replicaShard, primary, (r, sourceNode) -> new RecoveryTarget(r, sourceNode, 0L, null, null, recoveryListener) {
             @Override

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2937,7 +2937,7 @@ public class IndexShardTests extends IndexShardTestCase {
         Store targetStore = target.store();
 
         target.markAsRecovering("store");
-        final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        final PlainActionFuture<Void> future = new PlainActionFuture<>();
         target.restoreFromRepository(new RestoreOnlyRepository(randomProjectIdOrDefault(), "test") {
             @Override
             public void restoreShard(
@@ -2961,7 +2961,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 });
             }
         }, future);
-        assertTrue(future.actionGet());
+        future.actionGet(); // Fail test on throw
         assertThat(target.getLocalCheckpoint(), equalTo(2L));
         assertThat(target.seqNoStats().getMaxSeqNo(), equalTo(2L));
         assertThat(target.seqNoStats().getGlobalCheckpoint(), equalTo(0L));
@@ -3672,23 +3672,23 @@ public class IndexShardTests extends IndexShardTestCase {
             final IndexShard differentIndex = newShard(new ShardId("index_2", "index_2", 0), true);
             recoverShardFromStore(differentIndex);
             expectThrows(IllegalArgumentException.class, () -> {
-                final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+                final PlainActionFuture<Void> future = new PlainActionFuture<>();
                 targetShard.recoverFromLocalShards(mappingConsumer, Arrays.asList(sourceShard, differentIndex), future);
                 future.actionGet();
             });
             closeShards(differentIndex);
 
             // check that an error from the mapper service is handled correctly
-            final PlainActionFuture<Boolean> badMapperFuture = new PlainActionFuture<>();
+            final PlainActionFuture<Void> badMapperFuture = new PlainActionFuture<>();
             final IndexShard badMapper = spy(targetShard);
             doThrow(IllegalArgumentException.class).when(badMapper).mapperService();
             final BiConsumer<MappingMetadata, ActionListener<Void>> noopConsumer = (mapping, listener) -> listener.onResponse(null);
             badMapper.recoverFromLocalShards(noopConsumer, List.of(sourceShard), badMapperFuture);
             assertThrows(IndexShardRecoveryException.class, badMapperFuture::actionGet);
 
-            final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
             targetShard.recoverFromLocalShards(mappingConsumer, Arrays.asList(sourceShard), future);
-            assertTrue(future.actionGet());
+            future.actionGet(); // Fail test on throw
             RecoveryState recoveryState = targetShard.recoveryState();
             assertEquals(RecoveryState.Stage.DONE, recoveryState.getStage());
             assertTrue(recoveryState.getIndex().fileDetails().size() > 0);

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.indices.recovery;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -371,16 +372,12 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 future.onFailure(e);
             }
-
-            @Override
-            public void onRecoveryAborted() {
-                future.onResponse(null);
-            }
         });
         recoveryTarget.markAsDone();
 
         // The recovery fails because the post recovery step attempts to refresh the engine, but it is not open.
-        expectThrows(RecoveryFailedException.class, future::actionGet);
+        RecoveryFailedException recoveryFailedException = expectThrows(RecoveryFailedException.class, future::actionGet);
+        assertThat(recoveryFailedException.getRootCause(), instanceOf(AlreadyClosedException.class));
 
         closeShards(shard);
     }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
@@ -459,11 +459,6 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
                     public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                         assertThat(ExceptionsHelper.unwrap(e, IOException.class).getMessage(), equalTo("simulated"));
                     }
-
-                    @Override
-                    public void onRecoveryAborted() {
-                        throw new AssertionError("recovery must fail");
-                    }
                 });
             }));
             expectThrows(AlreadyClosedException.class, () -> replica.refresh("test"));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
@@ -68,6 +68,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
+import static org.elasticsearch.indices.recovery.FailureStrategy.ABORT;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SEND;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SILENT;
 import static org.elasticsearch.indices.recovery.RecoveryGateMonitor.ENABLE_RECOVERY_GATES_SETTING;
@@ -157,11 +158,6 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             @Override
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 assertThat(threadPool.getThreadContext().getHeader(Task.X_ELASTIC_PROJECT_ID_HTTP_HEADER), equalTo(projectId2.id()));
-            }
-
-            @Override
-            public void onRecoveryAborted() {
-                fail("recovery aborted");
             }
         };
 
@@ -678,14 +674,15 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
         final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));
 
         final var listener1 = new TestCaptureResultListener(ExpectedRecoveryOutcome.ABORTED);
+        RecoveryState recoveryState = newRecoveryState(ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY); // high priority
         service.enqueue(
             ProjectId.DEFAULT,
             listener1,
-            newRecoveryState(ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY), // high priority
+            recoveryState,
             newIndexMetadata(),
             UUIDs.randomBase64UUID(),
             stats,
-            RecoveryListener::onRecoveryAborted
+            l -> l.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, null), ABORT)
         );
         final var listener2 = new TestCaptureResultListener(ExpectedRecoveryOutcome.COMPLETED);
         service.enqueue(
@@ -1056,11 +1053,6 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 completed.incrementAndGet();
             }
-
-            @Override
-            public void onRecoveryAborted() {
-                completed.incrementAndGet();
-            }
         };
 
         for (int iteration = 0; iteration < 20; iteration++) {
@@ -1107,18 +1099,14 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
                                 if (randomBoolean()) {
                                     schedulingListener.onRecoveryDone(null, ShardLongFieldRange.EMPTY, ShardLongFieldRange.EMPTY);
                                 } else {
-                                    if (randomBoolean()) {
-                                        schedulingListener.onRecoveryAborted();
-                                    } else {
-                                        schedulingListener.onRecoveryFailure(
-                                            new RecoveryFailedException(
-                                                recoveryState,
-                                                null,
-                                                new RuntimeException("test recovery task injected failure")
-                                            ),
-                                            FAIL_SILENT
-                                        );
-                                    }
+                                    schedulingListener.onRecoveryFailure(
+                                        new RecoveryFailedException(
+                                            recoveryState,
+                                            null,
+                                            new RuntimeException("test recovery task injected failure")
+                                        ),
+                                        randomBoolean() ? FAIL_SILENT : ABORT
+                                    );
                                 }
                             });
                         }
@@ -1182,13 +1170,6 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
             @Override
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
-                runningOrPending.decrementAndGet();
-                tasksCompleted.incrementAndGet();
-                refCounted.decRef();
-            }
-
-            @Override
-            public void onRecoveryAborted() {
                 runningOrPending.decrementAndGet();
                 tasksCompleted.incrementAndGet();
                 refCounted.decRef();
@@ -1264,14 +1245,10 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             if (randomBoolean()) {
                 schedulingListener.onRecoveryDone(null, ShardLongFieldRange.EMPTY, ShardLongFieldRange.EMPTY);
             } else {
-                if (randomBoolean()) {
-                    schedulingListener.onRecoveryAborted();
-                } else {
-                    schedulingListener.onRecoveryFailure(
-                        new RecoveryFailedException(recoveryState, null, new RuntimeException("test recovery task injected failure")),
-                        randomBoolean() ? FAIL_SEND : FAIL_SILENT
-                    );
-                }
+                schedulingListener.onRecoveryFailure(
+                    new RecoveryFailedException(recoveryState, null, new RuntimeException("test recovery task injected failure")),
+                    randomFrom(FailureStrategy.values())
+                );
             }
         });
     }
@@ -1315,7 +1292,20 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
         public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
             assert super.isDone() == false;
             switch (expectedOutcome) {
-                case FAILED -> super.onResponse(null);
+                case FAILED -> {
+                    if (failureStrategy != ABORT) {
+                        super.onResponse(null);
+                    } else {
+                        fail(new AssertionError("unexpected recovery abortion, expected outcome: " + expectedOutcome, e));
+                    }
+                }
+                case ABORTED -> {
+                    if (failureStrategy == ABORT) {
+                        super.onResponse(null);
+                    } else {
+                        fail(new AssertionError("unexpected recovery failure, expected outcome: " + expectedOutcome, e));
+                    }
+                }
                 case CANCELLED_IN_QUEUE, CANCELLED_STARTED -> {
                     assert expectedOutcome == ExpectedRecoveryOutcome.CANCELLED_IN_QUEUE || failureStrategy.notifyMaster()
                         : "should notify the master solely when cancelling started recoveries";
@@ -1324,20 +1314,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
                     }
                     super.onResponse(null);
                 }
-                case ABORTED, COMPLETED -> fail(
-                    new AssertionError("unexpected recovery cancellation, expected outcome: " + expectedOutcome, e)
-                );
-            }
-        }
-
-        @Override
-        public void onRecoveryAborted() {
-            assert super.isDone() == false;
-            switch (expectedOutcome) {
-                case ABORTED -> super.onResponse(null);
-                case COMPLETED, CANCELLED_IN_QUEUE, CANCELLED_STARTED, FAILED -> fail(
-                    "unexpected recovery abortion, expected outcome: " + expectedOutcome
-                );
+                case COMPLETED -> fail(new AssertionError("unexpected recovery cancellation, expected outcome: " + expectedOutcome, e));
             }
         }
 
@@ -1783,11 +1760,6 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             @Override
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 fail(e, "unexpected recovery failure");
-            }
-
-            @Override
-            public void onRecoveryAborted() {
-                fail("unexpected recovery abort");
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/TransportCancelRecoveriesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/TransportCancelRecoveriesActionTests.java
@@ -495,12 +495,11 @@ public class TransportCancelRecoveriesActionTests extends ESTestCase {
 
             @Override
             public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
-                cancelled.set(true);
-            }
-
-            @Override
-            public void onRecoveryAborted() {
-                fail("recovery should be cancelled");
+                if (e instanceof RecoveryCancelledException) {
+                    cancelled.set(true);
+                } else {
+                    fail("unexpected failure");
+                }
             }
         },
             newRecoveryState(shardId),

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -121,6 +121,7 @@ import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
+import static org.elasticsearch.indices.recovery.FailureStrategy.ABORT;
 import static org.elasticsearch.indices.recovery.FailureStrategy.FAIL_SILENT;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -156,12 +157,8 @@ public abstract class IndexShardTestCase extends ESTestCase {
 
         @Override
         public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
-            throw new AssertionError(e);
-        }
-
-        @Override
-        public void onRecoveryAborted() {
             // Abortion is a normal reaction to changes in allocation or node shutdown. Don't fail here.
+            if (failureStrategy != ABORT) throw new AssertionError(e);
         }
     };
 

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -1312,9 +1312,10 @@ public abstract class IndexShardTestCase extends ESTestCase {
     }
 
     public static boolean recoverFromStore(IndexShard newShard) {
-        final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        final PlainActionFuture<Void> future = new PlainActionFuture<>();
         newShard.recoverFromStore(future);
-        return future.actionGet();
+        future.actionGet(); // Will throw if unsuccessful
+        return true;
     }
 
     /**

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -573,7 +573,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
             @Override
             protected synchronized void recoverPrimary(IndexShard primaryShard) {
                 primaryShard.markAsRecovering("remote recovery from leader");
-                final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+                final PlainActionFuture<Void> future = new PlainActionFuture<>();
                 primaryShard.restoreFromRepository(new RestoreOnlyRepository(randomProjectIdOrDefault(), index.getName()) {
                     @Override
                     public void restoreShard(

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowEngineIndexShardTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowEngineIndexShardTests.java
@@ -137,7 +137,7 @@ public class FollowEngineIndexShardTests extends IndexShardTestCase {
         Store targetStore = target.store();
 
         target.markAsRecovering("store");
-        final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        final PlainActionFuture<Void> future = new PlainActionFuture<>();
         target.restoreFromRepository(new RestoreOnlyRepository(randomProjectIdOrDefault(), "test") {
             @Override
             public void restoreShard(
@@ -161,7 +161,7 @@ public class FollowEngineIndexShardTests extends IndexShardTestCase {
                 });
             }
         }, future);
-        assertTrue(future.actionGet());
+        future.actionGet(); // Fail test on throw
         assertThat(target.getLocalCheckpoint(), equalTo(0L));
         assertThat(target.seqNoStats().getMaxSeqNo(), equalTo(2L));
         assertThat(target.seqNoStats().getGlobalCheckpoint(), equalTo(0L));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
@@ -515,9 +515,9 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         );
         restoredShard.markAsRecovering("test from snap");
         runAsSnapshot(shard.getThreadPool(), () -> {
-            final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
             restoredShard.restoreFromRepository(repository, future);
-            assertTrue(future.actionGet());
+            future.actionGet(); // Fail test on throw
         });
         assertEquals(restoredShard.recoveryState().getStage(), RecoveryState.Stage.DONE);
         assertEquals(restoredShard.recoveryState().getTranslog().recoveredOperations(), 0);


### PR DESCRIPTION
Instead of having two different failure paths, `RecoveryListener.onRecoveryFailure` and `RecoveryListener.onRecoveryAborted` we now only have `RecoveryListener.onRecoveryFailure`. The abort path is replaces with the new `FailureStrategy.ABORT`. The result is the same -> `ShardRecoveryListener` from `IndicesClusterStateService` simply ignores the call.

This change has a few benefits. Firstly it allows us to funnel all exceptions to `RecoveryListener.onRecoveryFailure` and select `FailureStrategy` depending on exception type instead of having to funnel some exceptions to `onRecoveryFailure` and some to `onRecoveryAborted`. Secondly, it aligns better with how listeners are used in elasticsearch, one success path and one failure path.

One notable change is that we no longer use an `ActionListener<Boolean>` on the non-peer recovery path (`IndexShard.executeRecovery`). That listener would take "false" to mean recovery aborted and that only happened when shard was closed concurrently with recovery. Now, we throw `IndexShardClosedException` in those cases instead and triage that exception in the slightly updated `ActionListener<Void>` where select failure strategy (ABORT) and delegate to the `RecoveryListener`.

In other places where would call `RecoveryListener.onRecoveryAborted` without an existing exception we now call `onRecoveryFailure` with a new exception: `listener.onRecoveryFailure(new RecoveryFailedException(state(), message, null), ABORT);`

This is preparatory work for https://github.com/elastic/elasticsearch-team/issues/4350