### PR TITLE
ESQL: Enables late materialization for LIMIT BY

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -2111,15 +2111,13 @@ public class ComputeService {
                     // Fallback to a regular top n reduction without loading new fields.
                     .orElseGet(() -> runNodeLevelReduction ? placePlanBetweenExchanges.apply(topN.plan()) : passThroughReduction);
                 case PlannerUtils.TopNReduction topN when runNodeLevelReduction -> placePlanBetweenExchanges.apply(topN.plan());
-                case PlannerUtils.TopNByReduction topNBy when reduceNodeLateMaterialization
-                    && LateMaterializationPlanner.ESQL_LATE_MATERIALIZATION_LIMIT_BY_FEATURE_FLAG.isEnabled() -> LateMaterializationPlanner
-                        .planReduceDriverTopNBy(contextFactory, originalPlan)
-                        .orElseGet(() -> runNodeLevelReduction ? placePlanBetweenExchanges.apply(topNBy.plan()) : passThroughReduction);
+                case PlannerUtils.TopNByReduction topNBy when reduceNodeLateMaterialization -> LateMaterializationPlanner
+                    .planReduceDriverTopNBy(contextFactory, originalPlan)
+                    .orElseGet(() -> runNodeLevelReduction ? placePlanBetweenExchanges.apply(topNBy.plan()) : passThroughReduction);
                 case PlannerUtils.TopNByReduction topNBy when runNodeLevelReduction -> placePlanBetweenExchanges.apply(topNBy.plan());
-                case PlannerUtils.LimitByReduction limitBy when reduceNodeLateMaterialization
-                    && LateMaterializationPlanner.ESQL_LATE_MATERIALIZATION_LIMIT_BY_FEATURE_FLAG.isEnabled() -> LateMaterializationPlanner
-                        .planReduceDriverLimitBy(contextFactory, originalPlan)
-                        .orElseGet(() -> runNodeLevelReduction ? placePlanBetweenExchanges.apply(limitBy.plan()) : passThroughReduction);
+                case PlannerUtils.LimitByReduction limitBy when reduceNodeLateMaterialization -> LateMaterializationPlanner
+                    .planReduceDriverLimitBy(contextFactory, originalPlan)
+                    .orElseGet(() -> runNodeLevelReduction ? placePlanBetweenExchanges.apply(limitBy.plan()) : passThroughReduction);
                 case PlannerUtils.LimitByReduction limitBy when runNodeLevelReduction -> placePlanBetweenExchanges.apply(limitBy.plan());
                 // Not a TopN/TopNBy/LimitBy - must be an agg or a limit
                 case PlannerUtils.ReducedPlan rp when runNodeLevelReduction -> placePlanBetweenExchanges.apply(rp.plan());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/LateMaterializationPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/LateMaterializationPlanner.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -85,15 +84,6 @@ import java.util.function.Function;
 *  Note the above does not project the {@code x} field anymore (this was an enhancement made by #137920)
 */
 class LateMaterializationPlanner {
-    /**
-     * Gates late materialization on the node-reduce driver for {@link TopNBy} and {@link LimitBy} queries.
-     * Enabled automatically in snapshot builds; override in release with
-     * {@code -Des.esql_node_late_materialization_limit_by_feature_flag_enabled=true}.
-     */
-    public static final FeatureFlag ESQL_LATE_MATERIALIZATION_LIMIT_BY_FEATURE_FLAG = new FeatureFlag(
-        "esql_node_late_materialization_limit_by"
-    );
-
     public static Optional<ReductionPlan> planReduceDriverTopN(
         Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory,
         ExchangeSinkExec originalPlan

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/LateMaterializationPlannerGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/LateMaterializationPlannerGoldenTests.java
@@ -35,21 +35,6 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
         Stage.NODE_REDUCE_LOCAL_PHYSICAL_OPTIMIZATION
     );
 
-    private void checkLimitByLateMaterializationFeatureFlag() {
-        assumeTrue(
-            "late materialization for LimitBy/TopNBy requires "
-                + LateMaterializationPlanner.ESQL_LATE_MATERIALIZATION_LIMIT_BY_FEATURE_FLAG,
-            LateMaterializationPlanner.ESQL_LATE_MATERIALIZATION_LIMIT_BY_FEATURE_FLAG.isEnabled()
-        );
-    }
-
-    private void checkLimitByLateMaterializationFeatureFlagDisabled() {
-        assumeFalse(
-            "test requires " + LateMaterializationPlanner.ESQL_LATE_MATERIALIZATION_LIMIT_BY_FEATURE_FLAG + " to be disabled",
-            LateMaterializationPlanner.ESQL_LATE_MATERIALIZATION_LIMIT_BY_FEATURE_FLAG.isEnabled()
-        );
-    }
-
     public void testBasicTopNLateMaterialization() {
         String query = """
             FROM employees
@@ -260,7 +245,6 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
     }
 
     public void testBasicTopNByLateMaterialization() {
-        checkLimitByLateMaterializationFeatureFlag();
         String query = """
             FROM employees
             | keep hire_date, salary, languages, emp_no
@@ -271,7 +255,6 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
     }
 
     public void testMultipleTopNBy() {
-        checkLimitByLateMaterializationFeatureFlag();
         String query = """
             FROM employees
             | keep hire_date, salary, languages, gender, emp_no
@@ -284,7 +267,6 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
     }
 
     public void testTopNByWithFilter() {
-        checkLimitByLateMaterializationFeatureFlag();
         String query = """
             FROM employees
             | keep hire_date, salary, languages, emp_no
@@ -296,7 +278,6 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
     }
 
     public void testTopNByWithMissingSortField() {
-        checkLimitByLateMaterializationFeatureFlag();
         String query = """
             FROM employees
             | keep hire_date, salary, languages, emp_no
@@ -307,7 +288,6 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
     }
 
     public void testBasicLimitByLateMaterialization() {
-        checkLimitByLateMaterializationFeatureFlag();
         String query = """
             FROM employees
             | keep salary, languages, emp_no
@@ -317,7 +297,6 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
     }
 
     public void testLimitByMultipleGroupings() {
-        checkLimitByLateMaterializationFeatureFlag();
         String query = """
             FROM employees
             | keep salary, languages, gender, emp_no
@@ -327,36 +306,12 @@ public class LateMaterializationPlannerGoldenTests extends GoldenTestCase {
     }
 
     public void testLimitByWithMissingGroupField() {
-        checkLimitByLateMaterializationFeatureFlag();
         String query = """
             FROM employees
             | keep salary, languages, emp_no
             | LIMIT 5 BY languages
             """;
         runGoldenTest(query, STAGES, missingFieldStats("languages"));
-    }
-
-    // Late materialization for TOP N BY is disabled in releases
-    public void testBasicTopNByNodeReduceWithoutLateMaterialization() {
-        checkLimitByLateMaterializationFeatureFlagDisabled();
-        String query = """
-            FROM employees
-            | keep hire_date, salary, languages, emp_no
-            | SORT hire_date
-            | LIMIT 5 BY languages
-            """;
-        runGoldenTest(query, STAGES, unindexedStats());
-    }
-
-    // Late materialization for LIMIT BY is disabled in releases
-    public void testBasicLimitByNodeReduceWithoutLateMaterialization() {
-        checkLimitByLateMaterializationFeatureFlagDisabled();
-        String query = """
-            FROM employees
-            | keep salary, languages, emp_no
-            | LIMIT 5 BY languages
-            """;
-        runGoldenTest(query, STAGES, unindexedStats());
     }
 
     // Prevents TopN pushdown.


### PR DESCRIPTION
Part of https://github.com/elastic/esql-planning/issues/449

Cleans the feature flag, late materialization was only enabled in snapshot releases. Now enabled by default.

The charts showed late materialization cut times in half for big keys:


<img width="600" src="https://github.com/user-attachments/assets/d1ef22da-f0d3-4876-817b-2a72ad3c0648" />
