### PR TITLE
[Docs] Document SharePoint Online expand_site_group_members setting

### DIFF
--- a/docs/reference/search-connectors/es-connectors-sharepoint-online.md
+++ b/docs/reference/search-connectors/es-connectors-sharepoint-online.md
@@ -267,6 +267,8 @@ Use the following configuration fields to set up the connector:
 
         ::::
 
+`expand_site_group_members`
+:   Available when document level security is enabled. When enabled, SharePoint site group members are written individually onto each document’s access control list. For large site groups, turn this off to store compact `site_group:` tokens on documents instead. Membership is resolved during access control syncs. Default value is `True`. Changing this setting requires a full content sync and access control sync. Introduced in 9.4.7, 9.5.4, and 9.6.
 
 
 ### Deployment using Docker [es-connectors-sharepoint-online-client-docker]
@@ -520,6 +522,8 @@ POST INDEX_NAME/_update_by_query?conflicts=proceed
 Document-level security (DLS) enables you to restrict access to documents based on a user’s permissions. This feature is available by default for this connector.
 
 Refer to [configuration](#es-connectors-sharepoint-online-client-configuration) on this page for how to enable DLS for this connector.
+
+When **Expand site group members** is disabled, content documents store compact `site_group:<site_id>:<group_id>` tokens instead of every site group member. Direct user, Entra group, and site user permissions are unchanged on the document. Access control syncs enrich identity documents with site group memberships so DLS term overlap still resolves access.
 
 ::::{tip}
 Refer to [DLS in Search Applications](/reference/search-connectors/es-dls-e2e-guide.md) to learn how to ingest data from SharePoint Online with DLS enabled, when building a search application.


### PR DESCRIPTION
Documents the `expand_site_group_members` configuration field added to the SharePoint Online connector in [elastic/connectors#4396](https://github.com/elastic/connectors/pull/4396) and exposed in Fleet via [elastic/kibana#288070](https://github.com/elastic/kibana/pull/288070).

Part of [elastic/chat-program#47](https://github.com/elastic/chat-program/issues/47).

Changes:
- `es-connectors-sharepoint-online.md`: adds `expand_site_group_members` to **Configuration** and describes compact site-group DLS behavior in **Document-level security**.

Docs-only change; no code or console snippets affected.

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [ ] If submitting code, have you built your formula locally prior to submission with `gradle check`? (N/A — docs-only change)
- [x] If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- [x] If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?