### PR TITLE
[Docs] Document SharePoint Online expand_site_group_members setting (8.19)

### DIFF
--- a/docs/reference/connector/docs/connectors-sharepoint-online.asciidoc
+++ b/docs/reference/connector/docs/connectors-sharepoint-online.asciidoc
@@ -292,6 +292,15 @@ If left empty the default value `true` will be used for these granular permissio
 Note that these settings may increase sync times.
 ====
 
+Expand site group members::
+Available when document level security is enabled.
+When enabled, SharePoint site group members are written individually onto each document's access control list.
+For large site groups, turn this off to store compact `site_group:` tokens on documents instead.
+Membership is resolved during access control syncs.
+Default value is `true`.
+Changing this setting requires a full content sync and access control sync.
+Introduced in 8.19.22.
+
 [discrete#es-connectors-sharepoint-online-documents-syncs]
 ===== Documents and syncs
 
@@ -487,6 +496,10 @@ Document-level security (DLS) enables you to restrict access to documents based 
 This feature is available by default for this connector.
 
 Refer to <<es-connectors-sharepoint-online-configuration,configuration>> on this page for how to enable DLS for this connector.
+
+When **Expand site group members** is disabled, content documents store compact `site_group:<site_id>:<group_id>` tokens instead of every site group member.
+Direct user, Entra group, and site user permissions are unchanged on the document.
+Access control syncs enrich identity documents with site group memberships so DLS term overlap still resolves access.
 
 [TIP]
 ====
@@ -849,6 +862,15 @@ If left empty the default value `true` will be used for these granular permissio
 Note that these settings may increase sync times.
 ====
 
+`expand_site_group_members`::
+Available when document level security is enabled.
+When enabled, SharePoint site group members are written individually onto each document's access control list.
+For large site groups, turn this off to store compact `site_group:` tokens on documents instead.
+Membership is resolved during access control syncs.
+Default value is `True`.
+Changing this setting requires a full content sync and access control sync.
+Introduced in 8.19.22.
+
 [discrete#es-connectors-sharepoint-online-client-docker]
 ===== Deployment using Docker
 
@@ -1050,6 +1072,10 @@ Document-level security (DLS) enables you to restrict access to documents based 
 This feature is available by default for this connector.
 
 Refer to <<es-connectors-sharepoint-online-client-configuration,configuration>> on this page for how to enable DLS for this connector.
+
+When **Expand site group members** is disabled, content documents store compact `site_group:<site_id>:<group_id>` tokens instead of every site group member.
+Direct user, Entra group, and site user permissions are unchanged on the document.
+Access control syncs enrich identity documents with site group memberships so DLS term overlap still resolves access.
 
 [TIP]
 ====


### PR DESCRIPTION
Backport of documentation for `expand_site_group_members` to `8.19`.

Documents the `expand_site_group_members` configuration field from [elastic/connectors#4396](https://github.com/elastic/connectors/pull/4396) and [elastic/kibana#288070](https://github.com/elastic/kibana/pull/288070).

Part of [elastic/chat-program#47](https://github.com/elastic/chat-program/issues/47).

Because `8.19` uses legacy asciidoc docs (with separate managed/native and self-managed configuration sections), the field is documented in **both** sections of `connectors-sharepoint-online.asciidoc`:
- Managed (native) section: **Expand site group members** UI toggle
- Self-managed section: `expand_site_group_members` config key

Both sections also describe compact site-group DLS behavior in **Document-level security**. Introduced in 8.19.22.

Docs-only change; no code or console snippets affected.

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [ ] If submitting code, have you built your formula locally prior to submission with `gradle check`? (N/A — docs-only change)
- [ ] If submitting code, is your pull request against main? (This is a backport to `8.19`.)
- [x] If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?