### PR TITLE
Prevent page leak in ParallelHashAggregationOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperator.java
@@ -438,8 +438,14 @@ public final class ParallelHashAggregationOperator implements Operator {
 
         void processOnePage(Page page) {
             if (initialized == false) {
-                initialized = true;
-                op.blockHash.ensureCapacity(partitionKeysThreshold);
+                try {
+                    op.blockHash.ensureCapacity(partitionKeysThreshold);
+                    initialized = true;
+                } finally {
+                    if (initialized == false) {
+                        Releasables.close(page);
+                    }
+                }
             }
             op.addInput(page);
             if (op.blockHash.numKeys() >= partitionKeysThreshold) {


### PR DESCRIPTION
`testCranky` found this one: we fail to release the incoming page if resizing the block hash fails.

Relates #158508