### PR TITLE
Added failure and latency metrics to merge and indexing operations

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -61,7 +61,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.mapper.MapperMetrics;
@@ -804,7 +803,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             MapperMetrics.NOOP,
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP
+            ShardMetrics.NOOP
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
@@ -69,6 +69,7 @@ class BulkPrimaryExecutionContext {
     private BulkItemResponse executionResult;
     private int updateRetryCounter;
     private long noopMappingUpdateRetryForMappingVersion;
+    private int completedItems;
 
     BulkPrimaryExecutionContext(BulkShardRequest request, IndexShard primary) {
         this(request, primary, IndexingPressure.PrimaryExpansionTracker.noop());
@@ -406,9 +407,21 @@ class BulkPrimaryExecutionContext {
         if (translatedResponse.isFailed() == false && requestToExecute != null && requestToExecute != getCurrent()) {
             request.items()[currentIndex] = new BulkItemRequest(request.items()[currentIndex].id(), requestToExecute);
         }
+
+        // failures are recorded per item for their error type; the operation count is tallied here and recorded once at the end
+        completedItems++;
+        if (translatedResponse.isFailed()) {
+            primary.recordBulkItemFailure(translatedResponse.getFailure().getCause());
+        }
+
         getCurrentItem().setPrimaryResponse(translatedResponse);
         currentItemState = ItemProcessingState.COMPLETED;
         advance();
+
+        // record the operation count at the end
+        if (hasMoreOperationsToExecute() == false) {
+            primary.recordBulkItemsCompleted(completedItems);
+        }
     }
 
     /** builds the bulk shard response to return to the user */

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -43,7 +43,6 @@ import org.elasticsearch.index.cache.query.IndexQueryCache;
 import org.elasticsearch.index.cache.query.QueryCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperMetrics;
@@ -55,6 +54,7 @@ import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.MutableOperationGate;
 import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.FsDirectoryFactory;
@@ -196,7 +196,7 @@ public final class IndexModule {
     private final MapperMetrics mapperMetrics;
     private final IndexingStatsSettings indexingStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
     private final PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder;
 
     /**
@@ -207,7 +207,7 @@ public final class IndexModule {
      * @param analysisRegistry   the analysis registry
      * @param engineFactory      the engine factory
      * @param directoryFactories the available store types
-     * @param mergeMetrics
+     * @param shardMetrics       the node-wide shard metrics bundle
      */
     public IndexModule(
         final IndexSettings indexSettings,
@@ -222,7 +222,7 @@ public final class IndexModule {
         final List<SearchOperationListener> searchOperationListeners,
         final IndexingStatsSettings indexingStatsSettings,
         final SearchStatsSettings searchStatsSettings,
-        final MergeMetrics mergeMetrics,
+        final ShardMetrics shardMetrics,
         final PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder
     ) {
         this.indexSettings = indexSettings;
@@ -239,7 +239,7 @@ public final class IndexModule {
         this.mapperMetrics = mapperMetrics;
         this.indexingStatsSettings = indexingStatsSettings;
         this.searchStatsSettings = searchStatsSettings;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
         this.metricHolder = metricHolder;
     }
 
@@ -583,7 +583,7 @@ public final class IndexModule {
                 mapperMetrics,
                 indexingStatsSettings,
                 searchStatsSettings,
-                mergeMetrics,
+                shardMetrics,
                 metricHolder
             );
             success = true;

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -49,7 +49,6 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.cache.query.QueryCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -79,6 +78,7 @@ import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.MutableOperationGate;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.index.shard.ShardNotInPrimaryModeException;
 import org.elasticsearch.index.shard.ShardPath;
@@ -174,7 +174,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final MapperMetrics mapperMetrics;
     private final IndexingStatsSettings indexingStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
     private final PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder;
 
     @SuppressWarnings("this-escape")
@@ -215,7 +215,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         MapperMetrics mapperMetrics,
         IndexingStatsSettings indexingStatsSettings,
         SearchStatsSettings searchStatsSettings,
-        MergeMetrics mergeMetrics,
+        ShardMetrics shardMetrics,
         PluggableDirectoryMetricsHolder<StoreMetrics> metricHolder
     ) {
         super(indexSettings);
@@ -310,7 +310,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         }
         this.indexingStatsSettings = indexingStatsSettings;
         this.searchStatsSettings = searchStatsSettings;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
         this.metricHolder = metricHolder;
         updateFsyncTaskIfNecessary();
     }
@@ -611,7 +611,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 mapperMetrics,
                 indexingStatsSettings,
                 searchStatsSettings,
-                mergeMetrics
+                shardMetrics
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.TranslogConfig;
 import org.elasticsearch.indices.IndexingMemoryController;
@@ -159,7 +160,7 @@ public final class EngineConfig {
 
     private final EngineResetLock engineResetLock;
 
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
 
     /**
      * Allows to pass an {@link ElasticsearchIndexDeletionPolicy} wrapper to egine implementations.
@@ -196,7 +197,7 @@ public final class EngineConfig {
         boolean promotableToPrimary,
         MapperService mapperService,
         EngineResetLock engineResetLock,
-        MergeMetrics mergeMetrics,
+        ShardMetrics shardMetrics,
         Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> indexDeletionPolicyWrapper
     ) {
         this.shardId = shardId;
@@ -246,7 +247,7 @@ public final class EngineConfig {
         // always use compound on flush - reduces # of file-handles on refresh
         this.useCompoundFile = indexSettings.getSettings().getAsBoolean(USE_COMPOUND_FILE, true);
         this.engineResetLock = engineResetLock;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
         this.indexDeletionPolicyWrapper = indexDeletionPolicyWrapper;
     }
 
@@ -497,8 +498,8 @@ public final class EngineConfig {
         return engineResetLock;
     }
 
-    public MergeMetrics getMergeMetrics() {
-        return mergeMetrics;
+    public ShardMetrics getShardMetrics() {
+        return shardMetrics;
     }
 
     /**
@@ -538,7 +539,7 @@ public final class EngineConfig {
         private boolean promotableToPrimary;
         private MapperService mapperService;
         private EngineResetLock engineResetLock;
-        private MergeMetrics mergeMetrics;
+        private ShardMetrics shardMetrics;
         private Function<ElasticsearchIndexDeletionPolicy, ElasticsearchIndexDeletionPolicy> indexDeletionPolicyWrapper;
 
         Builder() {}
@@ -573,7 +574,7 @@ public final class EngineConfig {
             this.promotableToPrimary = config.promotableToPrimary;
             this.mapperService = config.mapperService;
             this.engineResetLock = config.engineResetLock;
-            this.mergeMetrics = config.mergeMetrics;
+            this.shardMetrics = config.shardMetrics;
             this.indexDeletionPolicyWrapper = config.indexDeletionPolicyWrapper;
         }
 
@@ -722,8 +723,8 @@ public final class EngineConfig {
             return this;
         }
 
-        public Builder mergeMetrics(MergeMetrics mergeMetrics) {
-            this.mergeMetrics = mergeMetrics;
+        public Builder shardMetrics(ShardMetrics shardMetrics) {
+            this.shardMetrics = shardMetrics;
             return this;
         }
 
@@ -765,7 +766,7 @@ public final class EngineConfig {
                 promotableToPrimary,
                 mapperService,
                 engineResetLock,
-                mergeMetrics,
+                shardMetrics,
                 indexDeletionPolicyWrapper
             );
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -286,7 +286,7 @@ public class InternalEngine extends Engine {
                 engineConfig.getShardId(),
                 engineConfig.getIndexSettings(),
                 engineConfig.getThreadPoolMergeExecutorService(),
-                engineConfig.getMergeMetrics()
+                engineConfig.getShardMetrics().merge()
             );
             scheduler = mergeScheduler.getMergeScheduler();
             throttle = new IndexThrottle(pauseIndexingOnThrottle);

--- a/server/src/main/java/org/elasticsearch/index/engine/MergeMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/MergeMetrics.java
@@ -10,13 +10,16 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.index.MergePolicy;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.merge.OnGoingMerge;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.telemetry.metric.LongWithAttributes;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class MergeMetrics {
@@ -28,12 +31,14 @@ public class MergeMetrics {
     public static final String MERGE_SEGMENTS_MERGED_SIZE = "es.merge.segments.merged.size";
     public static final String MERGE_QUEUED_ESTIMATED_MEMORY_SIZE = "es.merge.segments.memory.size";
     public static final String MERGE_TIME_IN_SECONDS = "es.merge.time";
+    public static final String MERGE_FAILURE_TOTAL = "es.merge.failure.total";
     public static MergeMetrics NOOP = new MergeMetrics(TelemetryProvider.NOOP.getMeterRegistry());
 
     private final LongCounter mergeSizeInBytes;
     private final LongCounter mergeMergedSegmentSizeInBytes;
     private final LongCounter mergeNumDocs;
     private final LongHistogram mergeTimeInSeconds;
+    private final LongCounter mergeFailures;
 
     private final AtomicLong runningMergeSizeInBytes = new AtomicLong();
     private final AtomicLong queuedMergeSizeInBytes = new AtomicLong();
@@ -60,6 +65,11 @@ public class MergeMetrics {
         );
         mergeNumDocs = meterRegistry.registerLongCounter(MERGE_DOCS_TOTAL, "Total number of documents merged", "documents");
         mergeTimeInSeconds = meterRegistry.registerLongHistogram(MERGE_TIME_IN_SECONDS, "Merge time in seconds", "seconds");
+        mergeFailures = meterRegistry.registerLongCounter(
+            MERGE_FAILURE_TOTAL,
+            "Number of merges that failed or were aborted after they started",
+            "unit"
+        );
         meterRegistry.registerLongAsyncGauge(
             MERGE_QUEUED_ESTIMATED_MEMORY_SIZE,
             "Estimated memory usage for queued merges",
@@ -84,11 +94,19 @@ public class MergeMetrics {
         runningMergeSizeInBytes.getAndAdd(-currentMerge.getTotalBytesSize());
     }
 
-    public void markMergeMetrics(MergePolicy.OneMerge currentMerge, long mergedSegmentSize, long tookMillis) {
-        mergeSizeInBytes.incrementBy(currentMerge.totalBytesSize());
-        mergeMergedSegmentSizeInBytes.incrementBy(mergedSegmentSize);
-        mergeNumDocs.incrementBy(currentMerge.totalNumDocs());
-        mergeTimeInSeconds.record(tookMillis / 1000);
+    public void markMergeMetrics(MergePolicy.OneMerge currentMerge, long mergedSegmentSize, long tookMillis, IndexMode indexMode) {
+        Map<String, Object> attributes = Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName());
+        mergeSizeInBytes.incrementBy(currentMerge.totalBytesSize(), attributes);
+        mergeMergedSegmentSizeInBytes.incrementBy(mergedSegmentSize, attributes);
+        mergeNumDocs.incrementBy(currentMerge.totalNumDocs(), attributes);
+        mergeTimeInSeconds.record(tookMillis / 1000, attributes);
+    }
+
+    public void onFailure(IndexMode indexMode, Throwable error) {
+        mergeFailures.incrementBy(
+            1,
+            Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName(), MetricAttributes.ERROR_TYPE, MetricAttributes.errorType(error))
+        );
     }
 
     public long getQueuedMergeSizeInBytes() {

--- a/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeScheduler.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MergeSchedulerConfig;
 import org.elasticsearch.index.merge.MergeStats;
@@ -72,6 +73,7 @@ public class ThreadPoolMergeScheduler extends MergeScheduler implements Elastics
     protected final Logger logger;
     private final MergeTracking mergeTracking;
     private final MergeMetrics mergeMetrics;
+    private final IndexMode indexMode;
     private final ThreadPoolMergeExecutorService threadPoolMergeExecutorService;
     private final PriorityQueue<MergeTask> backloggedMergeTasks = new PriorityQueue<>(
         16,
@@ -116,6 +118,7 @@ public class ThreadPoolMergeScheduler extends MergeScheduler implements Elastics
         this.config = indexSettings.getMergeSchedulerConfig();
         this.logger = Loggers.getLogger(getClass(), shardId);
         this.mergeMetrics = mergeMetrics;
+        this.indexMode = indexSettings.getMode();
         this.mergeTracking = new MergeTracking(
             logger,
             () -> this.config.isAutoThrottle()
@@ -490,12 +493,19 @@ public class ThreadPoolMergeScheduler extends MergeScheduler implements Elastics
         } catch (Throwable t) {
             // OK to ignore MergeAbortedException. This is what Lucene's ConcurrentMergeScheduler does.
             if (t instanceof MergePolicy.MergeAbortedException == false) {
+                mergeMetrics.onFailure(indexMode, t);
                 // A merge thread that thrown a tragic exception that closed the IndexWriter causes other merge threads to be aborted, but
                 // it is not itself aborted: instead the current merge is just completed and the thrown exception is set in the package
                 // private OneMerge#error field. Here we set such merge as aborted too so that it is not considered as successful later.
                 oneMerge.setAborted();
                 handleMergeException(t);
+                // engine subclasses swallow the exception and return here, so do not count the abort set above as a second failure
+                return;
             }
+        }
+        if (oneMerge.isAborted()) {
+            // IndexWriter swallows its MergeAbortedException, so an aborted merge returns normally with isAborted() set.
+            mergeMetrics.onFailure(indexMode, new MergePolicy.MergeAbortedException("merge aborted"));
         }
     }
 
@@ -628,7 +638,7 @@ public class ThreadPoolMergeScheduler extends MergeScheduler implements Elastics
                         long tookMS = TimeValue.nsecToMSec(System.nanoTime() - mergeStartTimeNS.get());
                         if (success) {
                             long newSegmentSize = getNewSegmentSize(onGoingMerge.getMerge());
-                            mergeMetrics.markMergeMetrics(onGoingMerge.getMerge(), newSegmentSize, tookMS);
+                            mergeMetrics.markMergeMetrics(onGoingMerge.getMerge(), newSegmentSize, tookMS, indexMode);
                         }
                         mergeTracking.mergeFinished(onGoingMerge.getMerge(), onGoingMerge, tookMS);
                     }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -102,7 +102,6 @@ import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineException;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.IndexOperationBatch;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ReadOnlyEngine;
 import org.elasticsearch.index.engine.RefreshFailedEngineException;
 import org.elasticsearch.index.engine.SafeCommitInfo;
@@ -247,7 +246,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     private final SearchOperationListener searchOperationListener;
 
-    private final ShardBulkStats bulkOperationListener;
+    private final ShardBulkStats bulkStats;
+    private final BulkOperationListener bulkOperationListener;
     private final GlobalCheckpointListeners globalCheckpointListeners;
     private final PendingReplicationActions pendingReplicationActions;
     private final ReplicationTracker replicationTracker;
@@ -289,7 +289,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final MeanMetric externalRefreshMetric = new MeanMetric();
     private final MeanMetric flushMetric = new MeanMetric();
     private final CounterMetric periodicFlushMetric = new CounterMetric();
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
 
     private final ShardEventListener shardEventListener = new ShardEventListener();
 
@@ -370,7 +370,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final MapperMetrics mapperMetrics,
         final IndexingStatsSettings indexingStatsSettings,
         final SearchStatsSettings searchStatsSettings,
-        final MergeMetrics mergeMetrics
+        final ShardMetrics shardMetrics
     ) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
@@ -409,7 +409,17 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             CollectionUtils.appendToCopyNoNullElements(listeners, internalIndexingStats, indexingFailuresDebugListener),
             logger
         );
-        this.bulkOperationListener = new ShardBulkStats();
+        this.bulkStats = new ShardBulkStats();
+        this.bulkOperationListener = new BulkOperationListener() {
+            @Override
+            public void afterBulk(long bulkShardSizeInBytes, long tookInNanos) {
+                bulkStats.afterBulk(bulkShardSizeInBytes, tookInNanos);
+                // read the live routing, not the constructor argument: shards start as replicas and may be promoted later.
+                if (routingEntry().primary() && routingEntry().isRelocationTarget() == false) {
+                    shardMetrics.indexing().onBulk(indexSettings.getMode(), tookInNanos);
+                }
+            }
+        };
         this.globalCheckpointSyncer = globalCheckpointSyncer;
         this.retentionLeaseSyncer = Objects.requireNonNull(retentionLeaseSyncer);
         this.searchStats = new ShardSearchStats(searchStatsSettings);
@@ -476,7 +486,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.refreshFieldHasValueListener = new RefreshFieldHasValueListener();
         this.relativeTimeInNanosSupplier = relativeTimeInNanosSupplier;
         this.indexCommitListener = indexCommitListener;
-        this.mergeMetrics = mergeMetrics;
+        this.shardMetrics = shardMetrics;
     }
 
     public ThreadPool getThreadPool() {
@@ -512,6 +522,18 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     public BulkOperationListener getBulkOperationListener() {
         return this.bulkOperationListener;
+    }
+
+    /** Records the final failure of one bulk item executed on this primary; see {@link IndexingMetrics} for what is and is not counted. */
+    public void recordBulkItemFailure(Exception failure) {
+        assert routingEntry().primary() : "bulk items are only executed on primaries: " + routingEntry();
+        shardMetrics.indexing().onBulkItemFailed(indexSettings.getMode(), failure);
+    }
+
+    /** Records how many bulk items, successful or not, one shard bulk request completed on this primary. */
+    public void recordBulkItemsCompleted(int count) {
+        assert routingEntry().primary() : "bulk items are only executed on primaries: " + routingEntry();
+        shardMetrics.indexing().onBulkItemsCompleted(indexSettings.getMode(), count);
     }
 
     public ShardIndexWarmerService warmerService() {
@@ -1695,7 +1717,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public BulkStats bulkStats() {
-        return bulkOperationListener.stats();
+        return bulkStats.stats();
     }
 
     /**
@@ -4158,7 +4180,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             .promotableToPrimary(routingEntry().isPromotableToPrimary())
             .mapperService(mapperService())
             .engineResetLock(engineResetLock)
-            .mergeMetrics(mergeMetrics)
+            .shardMetrics(shardMetrics)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexingMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexingMetrics.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.telemetry.metric.DoubleHistogram;
+import org.elasticsearch.telemetry.metric.LongCounter;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
+
+import java.util.Map;
+
+/**
+ * Node-wide APM instruments for bulk execution on primary shards. Only primaries record, and the latency histogram additionally skips a
+ * primary that is a relocation target. Every bulk item that completes on the primary is counted, including deletes and items that fail.
+ * Not counted, by construction of the hook in {@link org.elasticsearch.action.bulk.BulkPrimaryExecutionContext}: CCR follower replication,
+ * which bypasses the shard bulk action and is not client ingest; whole-request indexing pressure rejections; and items aborted by request
+ * filters before they reach the shard.
+ */
+public class IndexingMetrics {
+
+    public static final String INDEXING_DURATION_HISTOGRAM = "es.indexing.shards.duration.histogram";
+    public static final String INDEXING_OPERATIONS_TOTAL = "es.indexing.shards.operations.total";
+    public static final String INDEXING_FAILURE_TOTAL = "es.indexing.shards.failure.total";
+
+    private final DoubleHistogram bulkDurationInSeconds;
+    private final LongCounter operations;
+    private final LongCounter failures;
+
+    public IndexingMetrics(MeterRegistry meterRegistry) {
+        // seconds rather than milliseconds: the default bucket ladder spans 2^-8 to 2^17, so in seconds it resolves ~4 ms at the low end
+        // and reaches ~36 h at the top, whereas in milliseconds everything above ~2.2 min collapses into the overflow bucket
+        bulkDurationInSeconds = meterRegistry.registerDoubleHistogram(
+            INDEXING_DURATION_HISTOGRAM,
+            "Time to execute a bulk request on a primary shard in seconds",
+            "s"
+        );
+        operations = meterRegistry.registerLongCounter(
+            INDEXING_OPERATIONS_TOTAL,
+            "Number of bulk items (index, create, update, delete) completed on a primary, successful or not",
+            "unit"
+        );
+        failures = meterRegistry.registerLongCounter(INDEXING_FAILURE_TOTAL, "Number of bulk items that failed on a primary", "unit");
+    }
+
+    public void onBulk(IndexMode indexMode, long tookInNanos) {
+        bulkDurationInSeconds.record(tookInNanos / 1_000_000_000.0, Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName()));
+    }
+
+    /** Counts the bulk items, successful or not, that completed within one shard bulk request. */
+    public void onBulkItemsCompleted(IndexMode indexMode, int count) {
+        operations.incrementBy(count, Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName()));
+    }
+
+    /** Counts one bulk item that failed with its final error. */
+    public void onBulkItemFailed(IndexMode indexMode, Exception failure) {
+        failures.incrementBy(
+            1,
+            Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName(), MetricAttributes.ERROR_TYPE, MetricAttributes.errorType(failure))
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardMetrics.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.index.engine.MergeMetrics;
+import org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+
+/**
+ * Node-wide APM instruments that shards record into.
+ */
+public record ShardMetrics(MergeMetrics merge, ShardSearchPhaseAPMMetrics search, IndexingMetrics indexing) {
+
+    public static final ShardMetrics NOOP = new ShardMetrics(
+        MergeMetrics.NOOP,
+        new ShardSearchPhaseAPMMetrics(MeterRegistry.NOOP),
+        new IndexingMetrics(MeterRegistry.NOOP)
+    );
+
+    public static ShardMetrics create(MeterRegistry meterRegistry) {
+        return new ShardMetrics(
+            new MergeMetrics(meterRegistry),
+            new ShardSearchPhaseAPMMetrics(meterRegistry),
+            new IndexingMetrics(meterRegistry)
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -102,7 +102,6 @@ import org.elasticsearch.index.cache.request.ShardRequestCache;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.engine.ReadOnlyEngine;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
@@ -137,6 +136,7 @@ import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.DirectoryMetrics;
 import org.elasticsearch.index.store.PluggableDirectoryMetricsHolder;
 import org.elasticsearch.index.store.StoreMetrics;
@@ -293,7 +293,7 @@ public class IndicesService extends AbstractLifecycleComponent
     final ActionLoggingFieldsProvider loggingFieldsProvider; // pkg-private for testingå
     private final IndexingStatsSettings indexStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
-    private final MergeMetrics mergeMetrics;
+    private final ShardMetrics shardMetrics;
     private final PluggableDirectoryMetricsHolder<StoreMetrics> storeMetricHolder;
     private final Map<String, PluggableDirectoryMetricsHolder<?>> directoryMetricHolderMap;
     private final ThrottlingRecoveryService throttlingRecoveryService;
@@ -372,7 +372,7 @@ public class IndicesService extends AbstractLifecycleComponent
         this.requestCacheKeyDifferentiator = builder.requestCacheKeyDifferentiator;
         this.queryRewriteInterceptor = builder.queryRewriteInterceptor;
         this.mapperMetrics = builder.mapperMetrics;
-        this.mergeMetrics = builder.mergeMetrics;
+        this.shardMetrics = builder.shardMetrics;
         // doClose() is called when shutting down a node, yet there might still be ongoing requests
         // that we need to wait for before closing some resources such as the caches. In order to
         // avoid closing these resources while ongoing requests are still being processed, we use a
@@ -837,7 +837,7 @@ public class IndicesService extends AbstractLifecycleComponent
             searchOperationListeners,
             indexStatsSettings,
             searchStatsSettings,
-            mergeMetrics,
+            shardMetrics,
             storeMetricHolder
         );
         for (IndexingOperationListener operationListener : indexingOperationListeners) {
@@ -937,7 +937,7 @@ public class IndicesService extends AbstractLifecycleComponent
             searchOperationListeners,
             indexStatsSettings,
             searchStatsSettings,
-            mergeMetrics,
+            shardMetrics,
             storeMetricHolder
         );
         pluginsService.forEach(p -> p.onIndexModule(indexModule));

--- a/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
@@ -27,10 +27,10 @@ import org.elasticsearch.index.ActionLoggingFieldsProvider;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.PluggableDirectoryMetricsHolder;
 import org.elasticsearch.index.store.StoreMetrics;
 import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
@@ -86,7 +86,7 @@ public class IndicesServiceBuilder {
     @Nullable
     CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator;
     MapperMetrics mapperMetrics;
-    MergeMetrics mergeMetrics;
+    ShardMetrics shardMetrics;
     List<SearchOperationListener> searchOperationListener = List.of();
     QueryRewriteInterceptor queryRewriteInterceptor = null;
     ActionLoggingFieldsProvider loggingFieldsProvider = (context) -> new ActionLoggingFields(context) {};
@@ -196,8 +196,8 @@ public class IndicesServiceBuilder {
         return this;
     }
 
-    public IndicesServiceBuilder mergeMetrics(MergeMetrics mergeMetrics) {
-        this.mergeMetrics = mergeMetrics;
+    public IndicesServiceBuilder shardMetrics(ShardMetrics shardMetrics) {
+        this.shardMetrics = shardMetrics;
         return this;
     }
 
@@ -244,7 +244,7 @@ public class IndicesServiceBuilder {
         Objects.requireNonNull(indexFoldersDeletionListeners);
         Objects.requireNonNull(snapshotCommitSuppliers);
         Objects.requireNonNull(mapperMetrics);
-        Objects.requireNonNull(mergeMetrics);
+        Objects.requireNonNull(shardMetrics);
         Objects.requireNonNull(searchOperationListener);
         Objects.requireNonNull(loggingFieldsProvider);
         Objects.requireNonNull(throttlingRecoveryService);

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -140,8 +140,8 @@ import org.elasticsearch.index.mapper.DefaultRootObjectMapperNamespaceValidator;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.RootObjectMapperNamespaceValidator;
 import org.elasticsearch.index.mapper.SourceFieldMetrics;
-import org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.indices.ExecutorSelector;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
@@ -919,11 +919,9 @@ class NodeConstruction {
         TokenCountingMetrics tokenCountingMetrics = new TokenCountingMetrics(telemetryProvider.getMeterRegistry());
         MapperMetrics mapperMetrics = new MapperMetrics(sourceFieldMetrics, tokenCountingMetrics);
 
-        MergeMetrics mergeMetrics = new MergeMetrics(telemetryProvider.getMeterRegistry());
+        ShardMetrics shardMetrics = ShardMetrics.create(telemetryProvider.getMeterRegistry());
 
-        final List<SearchOperationListener> searchOperationListeners = List.of(
-            new ShardSearchPhaseAPMMetrics(telemetryProvider.getMeterRegistry())
-        );
+        final List<SearchOperationListener> searchOperationListeners = List.of(shardMetrics.search());
 
         List<? extends ActionLoggingFieldsProvider> loggingFieldsProviders = pluginsService.loadServiceProviders(
             ActionLoggingFieldsProvider.class
@@ -982,7 +980,7 @@ class NodeConstruction {
             .valuesSourceRegistry(searchModule.getValuesSourceRegistry())
             .requestCacheKeyDifferentiator(searchModule.getRequestCacheKeyDifferentiator())
             .mapperMetrics(mapperMetrics)
-            .mergeMetrics(mergeMetrics)
+            .shardMetrics(shardMetrics)
             .searchOperationListeners(searchOperationListeners)
             .loggingFieldsProvider(loggingFieldsProvider)
             .throttlingRecoveryService(throttlingRecoveryService)
@@ -1523,7 +1521,7 @@ class NodeConstruction {
             b.bind(FailureStoreMetrics.class).toInstance(failureStoreMetrics);
             b.bind(ShutdownPrepareService.class).toInstance(shutdownPrepareService);
             b.bind(OnlinePrewarmingService.class).toInstance(onlinePrewarmingService);
-            b.bind(MergeMetrics.class).toInstance(mergeMetrics);
+            b.bind(MergeMetrics.class).toInstance(shardMetrics.merge());
             b.bind(ProjectRoutingResolver.class).toInstance(projectRoutingResolver);
             b.bind(ActionLoggingFieldsProvider.class).toInstance(loggingFieldsProvider);
             b.bind(ActivityLogWriterProvider.class).toInstance(logWriterProvider);

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/MetricAttributes.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/MetricAttributes.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.telemetry.metric;
 
+import org.elasticsearch.ExceptionsHelper;
+
+import java.io.IOException;
 import java.util.Set;
 
 public interface MetricAttributes {
@@ -26,6 +29,9 @@ public interface MetricAttributes {
 
     // refers to https://opentelemetry.io/docs/specs/semconv/registry/attributes/error/#error-type
     String ERROR_TYPE = "error_type";
+
+    /** Index mode of the metered shard; the value is {@link org.elasticsearch.index.IndexMode#getName()}. */
+    String ES_INDEX_MODE = "es_index_mode";
 
     /** The version of the stack. */
     String ES_STACK_VERSION = "es_stack_version";
@@ -77,4 +83,13 @@ public interface MetricAttributes {
         "elastic-synthetics"
     );
 
+    /**
+     * The {@link #ERROR_TYPE} value for a failure: the simple class name of the corruption exception if one is anywhere in the cause or
+     * suppressed chain, otherwise of the innermost non-wrapper cause.
+     */
+    static String errorType(Throwable t) {
+        IOException corruption = ExceptionsHelper.unwrapCorruption(t);
+        Throwable cause = corruption != null ? corruption : ExceptionsHelper.unwrapCause(t);
+        return cause.getClass().getSimpleName();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -81,6 +81,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -715,8 +716,51 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                 assertThat(failure.getStatus(), equalTo(RestStatus.CONFLICT));
 
                 verify(documentParsingProvider, times(retries + 1)).newMeteringParserDecorator(any());
+                // retries collapse into one final outcome, so the APM counters see the item exactly once
+                verify(shard, times(1)).recordBulkItemFailure(any());
+                verify(shard).recordBulkItemFailure(err);
+                verify(shard, times(1)).recordBulkItemsCompleted(1);
             }
         }
+    }
+
+    public void testBulkItemOutcomesAreRecordedOnThePrimary() throws Exception {
+        Exception err = new ElasticsearchException(randomAlphaOfLength(8));
+        BulkItemRequest[] items = new BulkItemRequest[2];
+        for (int i = 0; i < items.length; i++) {
+            IndexRequest request = new IndexRequest("index").id("id_" + i)
+                .source(Requests.INDEX_CONTENT_TYPE, "foo", randomAlphaOfLength(5));
+            items[i] = new BulkItemRequest(i, request);
+        }
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, SplitShardCountSummary.IRRELEVANT, RefreshPolicy.NONE, items);
+
+        IndexShard shard = mockShard(null, null);
+        when(shard.applyIndexOperationOnPrimary(anyLong(), any(), any(), anyLong(), anyLong(), anyLong(), anyBoolean())).thenReturn(
+            new FakeIndexResult(1, 1, 13, true, new Translog.Location(42, 42, 42), "id_0"),
+            new Engine.IndexResult(err, 0, 0, 0, "id_1")
+        );
+        when(shard.routingEntry()).thenReturn(newShardRouting(ShardRouting.Role.DEFAULT));
+
+        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
+        while (context.hasMoreOperationsToExecute()) {
+            TransportShardBulkAction.executeBulkItemRequest(
+                context,
+                null,
+                threadPool::absoluteTimeInMillis,
+                new NoopMappingUpdatePerformer(),
+                (listener, mappingVersion) -> {},
+                ASSERTING_DONE_LISTENER,
+                DocumentParsingProvider.EMPTY_INSTANCE
+            );
+        }
+
+        assertFalse(bulkShardRequest.items()[0].getPrimaryResponse().isFailed());
+        assertTrue(bulkShardRequest.items()[1].getPrimaryResponse().isFailed());
+        verify(shard, times(1)).recordBulkItemFailure(any());
+        verify(shard).recordBulkItemFailure(err);
+        // the operation count is recorded once for the whole request, not once per item
+        verify(shard, times(1)).recordBulkItemsCompleted(anyInt());
+        verify(shard).recordBulkItemsCompleted(2);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -61,7 +61,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -78,6 +77,7 @@ import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.similarity.NonNegativeScoresSimilarity;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -269,7 +269,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
         module.setReaderWrapper(s -> new Wrapper());
@@ -301,7 +301,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -331,7 +331,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -714,7 +714,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -744,7 +744,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
 
@@ -859,7 +859,7 @@ public class IndexModuleTests extends ESTestCase {
             emptyList(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/engine/MergeMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/MergeMetricsTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.index.MergePolicy;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MergeMetricsTests extends ESTestCase {
+
+    public void testMarkMergeMetricsCarriesIndexMode() {
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        MergeMetrics metrics = new MergeMetrics(registry);
+        IndexMode indexMode = randomFrom(IndexMode.values());
+        MergePolicy.OneMerge merge = mock(MergePolicy.OneMerge.class);
+        when(merge.totalBytesSize()).thenReturn(randomNonNegativeLong());
+        when(merge.totalNumDocs()).thenReturn(randomNonNegativeInt());
+        long tookMillis = randomLongBetween(0, 100_000);
+
+        metrics.markMergeMetrics(merge, randomNonNegativeLong(), tookMillis, indexMode);
+
+        Map<String, Object> expected = Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName());
+        for (String counter : List.of(
+            MergeMetrics.MERGE_SEGMENTS_SIZE,
+            MergeMetrics.MERGE_SEGMENTS_MERGED_SIZE,
+            MergeMetrics.MERGE_DOCS_TOTAL
+        )) {
+            assertThat(counter, single(registry, InstrumentType.LONG_COUNTER, counter).attributes(), equalTo(expected));
+        }
+        Measurement seconds = single(registry, InstrumentType.LONG_HISTOGRAM, MergeMetrics.MERGE_TIME_IN_SECONDS);
+        assertThat(seconds.attributes(), equalTo(expected));
+        assertThat(seconds.getLong(), equalTo(tookMillis / 1000));
+        assertThat(registry.getRecorder().getMeasurements(InstrumentType.LONG_COUNTER, MergeMetrics.MERGE_FAILURE_TOTAL), hasSize(0));
+    }
+
+    public void testFailureCarriesIndexModeAndErrorType() {
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        MergeMetrics metrics = new MergeMetrics(registry);
+        IndexMode indexMode = randomFrom(IndexMode.values());
+        Throwable error = randomFrom(new IOException(randomAlphaOfLength(5)), new IllegalStateException(randomAlphaOfLength(5)));
+
+        metrics.onFailure(indexMode, error);
+
+        Map<String, Object> expected = Map.of(
+            MetricAttributes.ES_INDEX_MODE,
+            indexMode.getName(),
+            MetricAttributes.ERROR_TYPE,
+            error.getClass().getSimpleName()
+        );
+        Measurement failure = single(registry, InstrumentType.LONG_COUNTER, MergeMetrics.MERGE_FAILURE_TOTAL);
+        assertThat(failure.getLong(), equalTo(1L));
+        assertThat(failure.attributes(), equalTo(expected));
+    }
+
+    private static Measurement single(RecordingMeterRegistry registry, InstrumentType type, String name) {
+        List<Measurement> measurements = registry.getRecorder().getMeasurements(type, name);
+        assertThat(name, measurements, hasSize(1));
+        return measurements.get(0);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MergeSchedulerConfig;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler.MergeTask;
@@ -47,6 +48,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -111,7 +115,7 @@ public class ThreadPoolMergeSchedulerTests extends ESTestCase {
             // verify metrics are reported for each merge
             verify(mergeMetrics, times(mergeCount)).moveQueuedMergeBytesToRunning(any(), anyLong());
             verify(mergeMetrics, times(mergeCount)).decrementRunningMergeBytes(any());
-            verify(mergeMetrics, times(mergeCount)).markMergeMetrics(any(), anyLong(), anyLong());
+            verify(mergeMetrics, times(mergeCount)).markMergeMetrics(any(), anyLong(), anyLong(), any());
 
             // assert merges are executed in ascending size order
             for (int i = 1; i < mergeCount; i++) {
@@ -606,7 +610,7 @@ public class ThreadPoolMergeSchedulerTests extends ESTestCase {
                 // verify metrics are recorded for each merge
                 verify(mergeMetrics, times(mergeCount)).moveQueuedMergeBytesToRunning(any(), anyLong());
                 verify(mergeMetrics, times(mergeCount)).decrementRunningMergeBytes(any());
-                verify(mergeMetrics, times(mergeCount)).markMergeMetrics(any(), anyLong(), anyLong());
+                verify(mergeMetrics, times(mergeCount)).markMergeMetrics(any(), anyLong(), anyLong(), any());
             }
         }
     }
@@ -843,7 +847,70 @@ public class ThreadPoolMergeSchedulerTests extends ESTestCase {
             verify(mergeMetrics, times(mergeCount)).decrementRunningMergeBytes(any());
 
             // verify we did not mark the merges as merged
-            verify(mergeMetrics, times(0)).markMergeMetrics(any(), anyLong(), anyLong());
+            verify(mergeMetrics, times(0)).markMergeMetrics(any(), anyLong(), anyLong(), any());
+            // merges aborted before they ever ran are not counted as failures either
+            verify(mergeMetrics, times(0)).onFailure(any(), any());
+        }
+    }
+
+    public void testFailedOrAbortedMergeIsCountedAsFailure() throws IOException {
+        DeterministicTaskQueue threadPoolTaskQueue = new DeterministicTaskQueue();
+        Settings settings = Settings.builder()
+            // disable fs available disk space feature for this test
+            .put(ThreadPoolMergeExecutorService.INDICES_MERGE_DISK_CHECK_INTERVAL_SETTING.getKey(), "0s")
+            .build();
+        nodeEnvironment = newNodeEnvironment(settings);
+        ThreadPoolMergeExecutorService threadPoolMergeExecutorService = ThreadPoolMergeExecutorServiceTests
+            .getThreadPoolMergeExecutorService(threadPoolTaskQueue.getThreadPool(), settings, nodeEnvironment);
+        IndexMode indexMode = randomFrom(IndexMode.STANDARD, IndexMode.LOGSDB, IndexMode.LOOKUP);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "index",
+            Settings.builder().put(IndexSettings.MODE.getKey(), indexMode).build()
+        );
+        var mergeMetrics = mock(MergeMetrics.class);
+        // the engines' schedulers swallow the exception in handleMergeException and return; the base scheduler rethrows it
+        boolean rethrowMergeException = randomBoolean();
+        try (
+            ThreadPoolMergeScheduler threadPoolMergeScheduler = new ThreadPoolMergeScheduler(
+                new ShardId("index", "_na_", 1),
+                indexSettings,
+                threadPoolMergeExecutorService,
+                merge -> 0,
+                mergeMetrics
+            ) {
+                @Override
+                protected void handleMergeException(Throwable t) {
+                    if (rethrowMergeException) {
+                        super.handleMergeException(t);
+                    }
+                }
+            }
+        ) {
+            MergeSource mergeSource = mock(MergeSource.class);
+            OneMerge oneMerge = mock(OneMerge.class);
+            when(oneMerge.getStoreMergeInfo()).thenReturn(getNewMergeInfo(randomLongBetween(1L, 10L)));
+            when(oneMerge.getMergeProgress()).thenReturn(new MergePolicy.OneMergeProgress());
+            when(mergeSource.getNextMerge()).thenReturn(oneMerge, (OneMerge) null);
+            // IndexWriter swallows aborts, so an aborted merge returns normally with isAborted() set while a failed merge throws
+            Throwable error = randomBoolean() ? null : randomFrom(new IOException("boom"), new IllegalStateException("boom"));
+            doAnswer(invocation -> {
+                when(oneMerge.isAborted()).thenReturn(true);
+                if (error != null) {
+                    throw error;
+                }
+                return null;
+            }).when(mergeSource).merge(any(OneMerge.class));
+            threadPoolMergeScheduler.merge(mergeSource, randomFrom(MergeTrigger.values()));
+            if (error == null || rethrowMergeException == false) {
+                threadPoolTaskQueue.runAllTasks();
+            } else {
+                assertSame(error, expectThrows(MergePolicy.MergeException.class, threadPoolTaskQueue::runAllTasks).getCause());
+            }
+
+            // exactly once: a real failure sets the merge aborted too, which must not be counted a second time as an abort
+            verify(mergeMetrics, times(1)).onFailure(any(), any());
+            verify(mergeMetrics).onFailure(eq(indexMode), error == null ? isA(MergePolicy.MergeAbortedException.class) : same(error));
+            verify(mergeMetrics, times(0)).markMergeMetrics(any(), anyLong(), anyLong(), any());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardBulkMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardBulkMetricsTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.routing.AllocationId;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Drives the bulk latency histogram through a real {@link IndexShard}, covering the primary gate across a replica promotion.
+ */
+public class IndexShardBulkMetricsTests extends IndexShardTestCase {
+
+    private final RecordingMeterRegistry registry = new RecordingMeterRegistry();
+    private final ShardMetrics shardMetrics = ShardMetrics.create(registry);
+
+    @Override
+    protected ShardMetrics shardMetrics() {
+        return shardMetrics;
+    }
+
+    public void testBulkLatencyIsRecordedOncePromotedToPrimary() throws IOException {
+        IndexShard shard = newStartedShard(false);
+        long tookNanos = randomLongBetween(1, TimeUnit.SECONDS.toNanos(5));
+
+        shard.getBulkOperationListener().afterBulk(randomLongBetween(0, ByteSizeValue.ofGb(1).getBytes()), tookNanos);
+        assertThat(
+            registry.getRecorder().getMeasurements(InstrumentType.DOUBLE_HISTOGRAM, IndexingMetrics.INDEXING_DURATION_HISTOGRAM),
+            empty()
+        );
+
+        ShardRouting replicaRouting = shard.routingEntry();
+        promoteReplica(
+            shard,
+            Set.of(replicaRouting.allocationId().getId()),
+            new IndexShardRoutingTable.Builder(replicaRouting.shardId()).addShard(
+                TestShardRouting.newShardRouting(replicaRouting.shardId(), "ignored", true, ShardRoutingState.STARTED)
+            ).addShard(replicaRouting).build()
+        );
+        assertTrue(shard.routingEntry().primary());
+
+        shard.getBulkOperationListener().afterBulk(randomLongBetween(0, ByteSizeValue.ofGb(1).getBytes()), tookNanos);
+        List<Measurement> durations = registry.getRecorder()
+            .getMeasurements(InstrumentType.DOUBLE_HISTOGRAM, IndexingMetrics.INDEXING_DURATION_HISTOGRAM);
+        assertThat(durations, hasSize(1));
+        assertThat(durations.get(0).getDouble(), equalTo(tookNanos / 1_000_000_000.0));
+        assertThat(
+            durations.get(0).attributes(),
+            equalTo(Map.of(MetricAttributes.ES_INDEX_MODE, shard.indexSettings().getMode().getName()))
+        );
+        closeShards(shard);
+    }
+
+    public void testBulkLatencyIsNotRecordedOnPrimaryRelocationTarget() throws IOException {
+        ShardRouting relocationTargetRouting = shardRoutingBuilder(
+            new ShardId("index", "_na_", 0),
+            "local_node",
+            true,
+            ShardRoutingState.INITIALIZING
+        ).withRelocatingNodeId("other_node")
+            .withRecoverySource(RecoverySource.PeerRecoverySource.INSTANCE)
+            .withAllocationId(AllocationId.newRelocation(AllocationId.newInitializing()))
+            .build();
+        IndexShard shard = newShard(relocationTargetRouting, DiscoveryNodeUtils.create("other_node"));
+        assertTrue(shard.routingEntry().primary());
+        assertTrue(shard.routingEntry().isRelocationTarget());
+
+        shard.getBulkOperationListener()
+            .afterBulk(randomLongBetween(0, ByteSizeValue.ofGb(1).getBytes()), randomLongBetween(1, TimeUnit.SECONDS.toNanos(5)));
+        assertThat(
+            registry.getRecorder().getMeasurements(InstrumentType.DOUBLE_HISTOGRAM, IndexingMetrics.INDEXING_DURATION_HISTOGRAM),
+            empty()
+        );
+        closeShards(shard);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexingMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexingMetricsTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class IndexingMetricsTests extends ESTestCase {
+
+    public void testCompletedItemsAndFailuresFeedSeparateCounters() {
+        RecordingMeterRegistry registry = new RecordingMeterRegistry();
+        IndexingMetrics metrics = new IndexingMetrics(registry);
+        IndexMode indexMode = randomFrom(IndexMode.values());
+        int count = randomIntBetween(1, 10_000);
+        Exception error = randomFrom(new IOException(randomAlphaOfLength(5)), new IllegalStateException(randomAlphaOfLength(5)));
+
+        metrics.onBulkItemsCompleted(indexMode, count);
+        metrics.onBulkItemFailed(indexMode, error);
+
+        Measurement operations = single(registry, InstrumentType.LONG_COUNTER, IndexingMetrics.INDEXING_OPERATIONS_TOTAL);
+        assertThat(operations.getLong(), equalTo((long) count));
+        assertThat(operations.attributes(), equalTo(Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName())));
+        Measurement failure = single(registry, InstrumentType.LONG_COUNTER, IndexingMetrics.INDEXING_FAILURE_TOTAL);
+        assertThat(failure.getLong(), equalTo(1L));
+        assertThat(
+            failure.attributes(),
+            equalTo(
+                Map.of(MetricAttributes.ES_INDEX_MODE, indexMode.getName(), MetricAttributes.ERROR_TYPE, error.getClass().getSimpleName())
+            )
+        );
+    }
+
+    private static Measurement single(RecordingMeterRegistry registry, InstrumentType type, String name) {
+        List<Measurement> measurements = registry.getRecorder().getMeasurements(type, name);
+        assertThat(name, measurements, hasSize(1));
+        return measurements.get(0);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -44,7 +44,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -172,7 +171,7 @@ public class RefreshListenersTests extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(EngineTestCase.createMapperService())
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
         engine = new InternalEngine(config);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -109,12 +109,12 @@ import org.elasticsearch.index.IndexSettingProvider;
 import org.elasticsearch.index.IndexSettingProviders;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.seqno.GlobalCheckpointSyncAction;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
 import org.elasticsearch.index.shard.PrimaryReplicaSyncer;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
@@ -694,7 +694,7 @@ public class SnapshotResiliencyTestHelper {
                     .client(client)
                     .metaStateService(new MetaStateService(nodeEnv, namedXContentRegistry))
                     .mapperMetrics(MapperMetrics.NOOP)
-                    .mergeMetrics(MergeMetrics.NOOP)
+                    .shardMetrics(ShardMetrics.NOOP)
                     .throttlingRecoveryService(throttlingRecoveryService)
                     .build();
 

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -105,6 +105,7 @@ import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.SearcherHelper;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
@@ -177,7 +178,7 @@ public abstract class EngineTestCase extends ESTestCase {
 
     protected InternalEngine engine;
     protected InternalEngine replicaEngine;
-    protected MergeMetrics mergeMetrics;
+    protected ShardMetrics shardMetrics;
 
     protected IndexSettings defaultSettings;
     protected String codecName;
@@ -262,7 +263,7 @@ public abstract class EngineTestCase extends ESTestCase {
         }
         mapperService = createMapperService(defaultSettings.getSettings(), defaultMapping, extraMappers());
         translogHandler = createTranslogHandler(mapperService);
-        mergeMetrics = MergeMetrics.NOOP;
+        shardMetrics = ShardMetrics.NOOP;
         engine = createEngine(defaultSettings, store, primaryTranslogDir, newMergePolicy());
         LiveIndexWriterConfig currentIndexWriterConfig = engine.getCurrentIndexWriterConfig();
 
@@ -892,7 +893,7 @@ public abstract class EngineTestCase extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(mapperService)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(mergeMetrics)
+            .shardMetrics(shardMetrics)
             .indexDeletionPolicyWrapper(indexDeletionPolicyWrapper == null ? Function.identity() : indexDeletionPolicyWrapper)
             .build();
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -57,7 +57,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.mapper.MapperMetrics;
@@ -741,7 +740,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 MapperMetrics.NOOP,
                 new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
                 new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-                MergeMetrics.NOOP
+                shardMetrics()
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             success = true;
@@ -1119,6 +1118,11 @@ public abstract class IndexShardTestCase extends ESTestCase {
             inSyncIdsWithReplica,
             newRoutingTable
         );
+    }
+
+    /** The APM instruments shards created by {@link #newShard} record into; override to observe them. */
+    protected ShardMetrics shardMetrics() {
+        return ShardMetrics.NOOP;
     }
 
     /**

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.engine.ThreadPoolMergeExecutorService;
 import org.elasticsearch.index.engine.ThreadPoolMergeScheduler;
 import org.elasticsearch.index.engine.TranslogHandler;
@@ -51,6 +50,7 @@ import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
@@ -292,7 +292,7 @@ public class FollowingEngineTests extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(mapperService)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -49,10 +49,10 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.search.stats.SearchStatsSettings;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.StoreMetrics;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -530,7 +530,7 @@ public class SecurityTests extends ESTestCase {
             List.of(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
         security.onIndexModule(indexModule);

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -1823,7 +1823,7 @@ public class StatelessPlugin extends Plugin
             refreshManagerService.get(),
             reshardIndexService.get(),
             documentParsingProvider.get(),
-            new IndexEngine.EngineMetrics(translogReplicatorMetrics.get(), newConfig.getMergeMetrics(), hollowShardMetrics.get()),
+            new IndexEngine.EngineMetrics(translogReplicatorMetrics.get(), newConfig.getShardMetrics().merge(), hollowShardMetrics.get()),
             indexEngineDynamicSettings.get()
         );
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
@@ -59,6 +59,7 @@ import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.EngineResetLock;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
 import org.elasticsearch.index.translog.Translog;
@@ -462,7 +463,7 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             .promotableToPrimary(true)
             .mapperService(mapperService)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }
@@ -648,7 +649,7 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             })
             .primaryTermSupplier(primaryTermSupplier)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(
@@ -773,7 +774,7 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             })
             .primaryTermSupplier(directory.getCurrentCommit()::primaryTerm)
             .engineResetLock(new EngineResetLock())
-            .mergeMetrics(MergeMetrics.NOOP)
+            .shardMetrics(ShardMetrics.NOOP)
             .indexDeletionPolicyWrapper(Function.identity())
             .build();
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
@@ -14,10 +14,10 @@ import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.InternalEngineFactory;
-import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.search.stats.SearchStatsSettings;
 import org.elasticsearch.index.shard.IndexingStatsSettings;
+import org.elasticsearch.index.shard.ShardMetrics;
 import org.elasticsearch.index.store.StoreMetrics;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -80,7 +80,7 @@ public class WatcherPluginTests extends ESTestCase {
             List.of(),
             new IndexingStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
             new SearchStatsSettings(ClusterSettings.createBuiltInClusterSettings()),
-            MergeMetrics.NOOP,
+            ShardMetrics.NOOP,
             StoreMetrics.NOOP_HOLDER
         );
         // this will trip an assertion if the watcher indexing operation listener is null (which it is) but we try to add it


### PR DESCRIPTION
This change is one of several that introduces new metrics to provide better dashboarding and monitoring capabilities for storage engine.

This change introduces failure and latency metrics for merge and indexing operations. Namely:

Merge:
- `es.merge.failure.total`, with attributes `es_index_mode`, `error_type`

Note, there is already an existing merge time metric: `es.merge.time`.

Indexing:
- `es.indexing.shards.duration.histogram` (ms), with attributes `es_index_mode`
- `es.indexing.shards.failure.total`, with attributes `es_index_mode`, `error_type`
- `es.indexing.shards.operations.total`, with attributes `es_index_mode`

Note, technically we already have failure and latency metrics for indexing: 
- `es.indexing.indexing.failed.total` and `es.indices.<mode>.indexing.failure.total`
- `es.indexing.time` and `es.indices.<mode>.indexing.time`

In the worst case, we're looking at ~8 (index modes) * E (error types) of unique metrics.

However, these have shortcomings. They're are actually aggregates (sums over a time period), which makes them difficult to work with. For failure counts, including `error_type` in a running sum is not possible without some kind of disambiguation logic that determines how many failures are of what `error_type`. For latencies, plotting percentiles is not possible with sums, only the mean.

Note also, the new `es_index_mode` attribute is included in existing metrics as well:
- `es.merge.segments.size`
- `es.merge.segments.merged.size`
- `es.merge.docs.total`
- `es.merge.time`

Following [NAMING.md](https://github.com/elastic/elasticsearch/blob/main/modules/apm/NAMING.md), I've verified that no dashboards and alarms in `elasticsearch-o11y-resources` will be impacted by this new attributes:
- There are no alarms/alerts that reference them
- One existing dashboard `dashboard_serverless-es-merge-metrics` references them, but only plots percentiles, sum, and max, all of which take all attributes into account.