### PR TITLE
Added shard-level failure counters for query and fetch phases, and index mode attribute to existing latency metrics

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchPhaseAPMMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchPhaseAPMMetrics.java
@@ -10,12 +10,13 @@
 package org.elasticsearch.index.search.stats;
 
 import org.elasticsearch.action.search.SearchRequestAttributesExtractor;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -26,11 +27,15 @@ public final class ShardSearchPhaseAPMMetrics implements SearchOperationListener
     public static final String DFS_SEARCH_PHASE_METRIC = "es.search.shards.phases.dfs.duration.histogram";
     public static final String QUERY_SEARCH_PHASE_METRIC = "es.search.shards.phases.query.duration.histogram";
     public static final String FETCH_SEARCH_PHASE_METRIC = "es.search.shards.phases.fetch.duration.histogram";
+    public static final String QUERY_SEARCH_PHASE_FAILURE_METRIC = "es.search.shards.phases.query.failure.total";
+    public static final String FETCH_SEARCH_PHASE_FAILURE_METRIC = "es.search.shards.phases.fetch.failure.total";
 
     private final LongHistogram canMatchPhaseMetric;
     private final LongHistogram dfsPhaseMetric;
     private final LongHistogram queryPhaseMetric;
     private final LongHistogram fetchPhaseMetric;
+    private final LongCounter queryPhaseFailures;
+    private final LongCounter fetchPhaseFailures;
 
     public ShardSearchPhaseAPMMetrics(MeterRegistry meterRegistry) {
         this.canMatchPhaseMetric = meterRegistry.registerLongHistogram(
@@ -54,6 +59,16 @@ public final class ShardSearchPhaseAPMMetrics implements SearchOperationListener
             "Fetch search phase execution times at the shard level, expressed as a histogram",
             "ms"
         );
+        this.queryPhaseFailures = meterRegistry.registerLongCounter(
+            QUERY_SEARCH_PHASE_FAILURE_METRIC,
+            "Number of query search phases that failed at the shard level",
+            "unit"
+        );
+        this.fetchPhaseFailures = meterRegistry.registerLongCounter(
+            FETCH_SEARCH_PHASE_FAILURE_METRIC,
+            "Number of fetch search phases that failed at the shard level",
+            "unit"
+        );
     }
 
     @Override
@@ -63,36 +78,45 @@ public final class ShardSearchPhaseAPMMetrics implements SearchOperationListener
 
     @Override
     public void onDfsPhase(SearchContext searchContext, long tookInNanos) {
-        SearchExecutionContext searchExecutionContext = searchContext.getSearchExecutionContext();
-        Long timeRangeFilterFromMillis = searchExecutionContext.getTimeRangeFilterFromMillis();
-        recordPhaseLatency(dfsPhaseMetric, tookInNanos, searchContext.request(), timeRangeFilterFromMillis);
+        recordPhaseLatency(dfsPhaseMetric, tookInNanos, searchContext);
     }
 
     @Override
     public void onQueryPhase(SearchContext searchContext, long tookInNanos) {
-        SearchExecutionContext searchExecutionContext = searchContext.getSearchExecutionContext();
-        Long timeRangeFilterFromMillis = searchExecutionContext.getTimeRangeFilterFromMillis();
-        recordPhaseLatency(queryPhaseMetric, tookInNanos, searchContext.request(), timeRangeFilterFromMillis);
+        recordPhaseLatency(queryPhaseMetric, tookInNanos, searchContext);
+    }
+
+    @Override
+    public void onFailedQueryPhase(SearchContext searchContext, Throwable e) {
+        queryPhaseFailures.incrementBy(1, failureAttributes(searchContext, e));
     }
 
     @Override
     public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
-        SearchExecutionContext searchExecutionContext = searchContext.getSearchExecutionContext();
-        Long timeRangeFilterFromMillis = searchExecutionContext.getTimeRangeFilterFromMillis();
-        recordPhaseLatency(fetchPhaseMetric, tookInNanos, searchContext.request(), timeRangeFilterFromMillis);
+        recordPhaseLatency(fetchPhaseMetric, tookInNanos, searchContext);
     }
 
-    private static void recordPhaseLatency(
-        LongHistogram histogramMetric,
-        long tookInNanos,
-        ShardSearchRequest request,
-        Long timeRangeFilterFromMillis
-    ) {
+    @Override
+    public void onFailedFetchPhase(SearchContext searchContext, Throwable e) {
+        fetchPhaseFailures.incrementBy(1, failureAttributes(searchContext, e));
+    }
+
+    private static void recordPhaseLatency(LongHistogram histogramMetric, long tookInNanos, SearchContext searchContext) {
+        ShardSearchRequest request = searchContext.request();
         Map<String, Object> attributes = SearchRequestAttributesExtractor.extractAttributes(
             request,
-            timeRangeFilterFromMillis,
+            searchContext.getSearchExecutionContext().getTimeRangeFilterFromMillis(),
             request.nowInMillis()
         );
+        attributes.put(MetricAttributes.ES_INDEX_MODE, indexMode(searchContext));
         histogramMetric.record(TimeUnit.NANOSECONDS.toMillis(tookInNanos), attributes);
+    }
+
+    private static Map<String, Object> failureAttributes(SearchContext searchContext, Throwable e) {
+        return Map.of(MetricAttributes.ES_INDEX_MODE, indexMode(searchContext), MetricAttributes.ERROR_TYPE, MetricAttributes.errorType(e));
+    }
+
+    private static String indexMode(SearchContext searchContext) {
+        return searchContext.indexShard().indexSettings().getMode().getName();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
@@ -70,7 +70,7 @@ public final class ShardSearchStats implements SearchOperationListener {
     }
 
     @Override
-    public void onFailedQueryPhase(SearchContext searchContext) {
+    public void onFailedQueryPhase(SearchContext searchContext, Throwable e) {
         computeStats(searchContext, statsHolder -> {
             if (searchContext.hasOnlySuggest()) {
                 statsHolder.suggestCurrent.dec();
@@ -100,7 +100,7 @@ public final class ShardSearchStats implements SearchOperationListener {
     }
 
     @Override
-    public void onFailedFetchPhase(SearchContext searchContext) {
+    public void onFailedFetchPhase(SearchContext searchContext, Throwable e) {
         computeStats(searchContext, statsHolder -> {
             statsHolder.fetchCurrent.dec();
             statsHolder.fetchFailure.inc();

--- a/server/src/main/java/org/elasticsearch/index/shard/SearchOperationListener.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/SearchOperationListener.java
@@ -31,8 +31,9 @@ public interface SearchOperationListener {
     /**
      * Executed if a query phased failed.
      * @param searchContext the current search context
+     * @param e the failure
      */
-    default void onFailedQueryPhase(SearchContext searchContext) {}
+    default void onFailedQueryPhase(SearchContext searchContext, Throwable e) {}
 
     /**
      * Executed after the query phase successfully finished.
@@ -40,7 +41,7 @@ public interface SearchOperationListener {
      * @param searchContext the current search context
      * @param tookInNanos the number of nanoseconds the query execution took
      *
-     * @see #onFailedQueryPhase(SearchContext)
+     * @see #onFailedQueryPhase(SearchContext, Throwable)
      */
     default void onQueryPhase(SearchContext searchContext, long tookInNanos) {}
 
@@ -53,8 +54,9 @@ public interface SearchOperationListener {
     /**
      * Executed if a fetch phased failed.
      * @param searchContext the current search context
+     * @param e the failure
      */
-    default void onFailedFetchPhase(SearchContext searchContext) {}
+    default void onFailedFetchPhase(SearchContext searchContext, Throwable e) {}
 
     /**
      * Executed after the fetch phase successfully finished.
@@ -62,7 +64,7 @@ public interface SearchOperationListener {
      * @param searchContext the current search context
      * @param tookInNanos the number of nanoseconds the fetch execution took
      *
-     * @see #onFailedFetchPhase(SearchContext)
+     * @see #onFailedFetchPhase(SearchContext, Throwable)
      */
     default void onFetchPhase(SearchContext searchContext, long tookInNanos) {}
 
@@ -78,15 +80,16 @@ public interface SearchOperationListener {
      * @param searchContext the current search context
      * @param tookInNanos the number of nanoseconds the query execution took
      *
-     * @see #onFailedQueryPhase(SearchContext)
+     * @see #onFailedQueryPhase(SearchContext, Throwable)
      */
     default void onDfsPhase(SearchContext searchContext, long tookInNanos) {}
 
     /**
      * Executed if a dfs phased failed.
      * @param searchContext the current search context
+     * @param e the failure
      */
-    default void onFailedDfsPhase(SearchContext searchContext) {}
+    default void onFailedDfsPhase(SearchContext searchContext, Throwable e) {}
 
     /**
      * Executed after the can-match phase successfully finished.
@@ -160,12 +163,12 @@ public interface SearchOperationListener {
         }
 
         @Override
-        public void onFailedQueryPhase(SearchContext searchContext) {
+        public void onFailedQueryPhase(SearchContext searchContext, Throwable e) {
             for (SearchOperationListener listener : listeners) {
                 try {
-                    listener.onFailedQueryPhase(searchContext);
-                } catch (Exception e) {
-                    logger.warn(() -> "onFailedQueryPhase listener [" + listener + "] failed", e);
+                    listener.onFailedQueryPhase(searchContext, e);
+                } catch (Exception ex) {
+                    logger.warn(() -> "onFailedQueryPhase listener [" + listener + "] failed", ex);
                 }
             }
         }
@@ -193,12 +196,12 @@ public interface SearchOperationListener {
         }
 
         @Override
-        public void onFailedFetchPhase(SearchContext searchContext) {
+        public void onFailedFetchPhase(SearchContext searchContext, Throwable e) {
             for (SearchOperationListener listener : listeners) {
                 try {
-                    listener.onFailedFetchPhase(searchContext);
-                } catch (Exception e) {
-                    logger.warn(() -> "onFailedFetchPhase listener [" + listener + "] failed", e);
+                    listener.onFailedFetchPhase(searchContext, e);
+                } catch (Exception ex) {
+                    logger.warn(() -> "onFailedFetchPhase listener [" + listener + "] failed", ex);
                 }
             }
         }
@@ -226,12 +229,12 @@ public interface SearchOperationListener {
         }
 
         @Override
-        public void onFailedDfsPhase(SearchContext searchContext) {
+        public void onFailedDfsPhase(SearchContext searchContext, Throwable e) {
             for (SearchOperationListener listener : listeners) {
                 try {
-                    listener.onFailedDfsPhase(searchContext);
-                } catch (Exception e) {
-                    logger.warn(() -> "onFailedDfsPhase listener [" + listener + "] failed", e);
+                    listener.onFailedDfsPhase(searchContext, e);
+                } catch (Exception ex) {
+                    logger.warn(() -> "onFailedDfsPhase listener [" + listener + "] failed", ex);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/SearchPhaseExecutor.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchPhaseExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.search;
+
+import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.search.internal.SearchContext;
+
+/**
+ * Runs a shard search phase body while driving the {@link SearchOperationListener} protocol: the pre hook, then exactly one of the
+ * success or failure hooks. The failure hook fires for any {@link Throwable}, so a shard counter cannot be left dangling by an error.
+ */
+public final class SearchPhaseExecutor {
+
+    private SearchPhaseExecutor() {}
+
+    public static <E extends Exception> void executeDfsPhase(
+        SearchOperationListener listener,
+        SearchContext searchContext,
+        CheckedRunnable<E> body
+    ) throws E {
+        listener.onPreDfsPhase(searchContext);
+        long start = System.nanoTime();
+        try {
+            body.run();
+        } catch (Throwable t) {
+            listener.onFailedDfsPhase(searchContext, t);
+            throw t;
+        }
+        listener.onDfsPhase(searchContext, System.nanoTime() - start);
+    }
+
+    public static <E extends Exception> void executeQueryPhase(
+        SearchOperationListener listener,
+        SearchContext searchContext,
+        CheckedRunnable<E> body
+    ) throws E {
+        listener.onPreQueryPhase(searchContext);
+        long start = System.nanoTime();
+        try {
+            body.run();
+        } catch (Throwable t) {
+            listener.onFailedQueryPhase(searchContext, t);
+            throw t;
+        }
+        listener.onQueryPhase(searchContext, System.nanoTime() - start);
+    }
+
+    public static <E extends Exception> void executeFetchPhase(
+        SearchOperationListener listener,
+        SearchContext searchContext,
+        CheckedRunnable<E> body
+    ) throws E {
+        listener.onPreFetchPhase(searchContext);
+        long start = System.nanoTime();
+        try {
+            body.run();
+        } catch (Throwable t) {
+            listener.onFailedFetchPhase(searchContext, t);
+            throw t;
+        }
+        listener.onFetchPhase(searchContext, System.nanoTime() - start);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -771,18 +771,11 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             Releasable ignored = readerContext.markAsUsed(getKeepAlive(request));
             SearchContext context = createContext(readerContext, request, task, ResultsType.DFS, false)
         ) {
-            final long beforeQueryTime = System.nanoTime();
-            var opsListener = context.indexShard().getSearchOperationListener();
-            opsListener.onPreDfsPhase(context);
-            try {
-                DfsPhase.execute(context);
-                opsListener.onDfsPhase(context, System.nanoTime() - beforeQueryTime);
-                opsListener = null;
-            } finally {
-                if (opsListener != null) {
-                    opsListener.onFailedDfsPhase(context);
-                }
-            }
+            SearchPhaseExecutor.executeDfsPhase(
+                context.indexShard().getSearchOperationListener(),
+                context,
+                () -> DfsPhase.execute(context)
+            );
             DfsSearchResult result = context.dfsResult();
             setDirectoryMetrics(result, metricsDelta, context);
             return result;
@@ -1029,22 +1022,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             SearchContext context = createContext(readerContext, request, task, ResultsType.QUERY, true)
         ) {
             tracer.startTrace("executeQueryPhase", Map.of());
-            final long afterQueryTime;
-            final long beforeQueryTime = System.nanoTime();
-            var opsListener = context.indexShard().getSearchOperationListener();
-            opsListener.onPreQueryPhase(context);
             try {
-                loadOrExecuteQueryPhase(request, context);
-                if (context.queryResult().hasSearchContext() == false && readerContext.singleSession()) {
-                    freeReaderContext(readerContext.id(), "query phase produced no search context (single session)");
-                }
-                afterQueryTime = System.nanoTime();
-                opsListener.onQueryPhase(context, afterQueryTime - beforeQueryTime);
-                opsListener = null;
+                SearchPhaseExecutor.executeQueryPhase(context.indexShard().getSearchOperationListener(), context, () -> {
+                    loadOrExecuteQueryPhase(request, context);
+                    if (context.queryResult().hasSearchContext() == false && readerContext.singleSession()) {
+                        freeReaderContext(readerContext.id(), "query phase produced no search context (single session)");
+                    }
+                });
             } finally {
-                if (opsListener != null) {
-                    opsListener.onFailedQueryPhase(context);
-                }
                 tracer.stopTrace(task);
             }
             if (request.numberOfShards() == 1 && (request.source() == null || request.source().rankBuilder() == null)) {
@@ -1061,7 +1046,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     });
                 }
                 context.addFetchResult();
-                QueryFetchSearchResult result = executeFetchPhase(readerContext, context, afterQueryTime);
+                QueryFetchSearchResult result = executeFetchPhase(readerContext, context);
                 setDirectoryMetrics(result, metricsDelta, context);
                 return result;
             } else {
@@ -1137,20 +1122,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }, wrapFailureListener(listener, readerContext, markAsUsed));
     }
 
-    private QueryFetchSearchResult executeFetchPhase(ReaderContext reader, SearchContext context, long afterQueryTime) {
-        var opsListener = context.indexShard().getSearchOperationListener();
+    private QueryFetchSearchResult executeFetchPhase(ReaderContext reader, SearchContext context) {
         try (Releasable scope = tracer.withScope(context.getTask());) {
-            opsListener.onPreFetchPhase(context);
-            fetchPhase.execute(context, shortcutDocIdsToLoad(context), null);
-            if (reader.singleSession()) {
-                freeReaderContext(reader.id(), "fetch phase complete (single session)");
-            }
-            opsListener.onFetchPhase(context, System.nanoTime() - afterQueryTime);
-            opsListener = null;
-        } finally {
-            if (opsListener != null) {
-                opsListener.onFailedFetchPhase(context);
-            }
+            SearchPhaseExecutor.executeFetchPhase(context.indexShard().getSearchOperationListener(), context, () -> {
+                fetchPhase.execute(context, shortcutDocIdsToLoad(context), null);
+                if (reader.singleSession()) {
+                    freeReaderContext(reader.id(), "fetch phase complete (single session)");
+                }
+            });
         }
         // This will incRef the QuerySearchResult when it gets created
         return QueryFetchSearchResult.of(context.queryResult(), context.fetchResult());
@@ -1243,7 +1222,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     );
                 } catch (Exception e) {
                     try {
-                        opsListener.onFailedFetchPhase(searchContext);
+                        opsListener.onFailedFetchPhase(searchContext, e);
                     } finally {
                         Releasables.close(closeOnce, fetchResult::decRef);
                     }
@@ -1282,7 +1261,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         return ActionListener.runAfter(ActionListener.wrap(ignored -> {
             setFetchDirectoryMetrics(fetchResult, searchContext);
             opsListener.onFetchPhase(searchContext, System.nanoTime() - startTime);
-        }, e -> opsListener.onFailedFetchPhase(searchContext)), closeOnce::close);
+        }, e -> opsListener.onFailedFetchPhase(searchContext, e)), closeOnce::close);
     }
 
     /**
@@ -1325,20 +1304,11 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             final Supplier<DirectoryMetrics> metricsDelta = directoryMetricsDelta();
             final ShardSearchRequest shardSearchRequest = readerContext.getShardSearchRequest(null);
             try (SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, ResultsType.QUERY, false);) {
-                var opsListener = searchContext.indexShard().getSearchOperationListener();
-                final long beforeQueryTime = System.nanoTime();
-                opsListener.onPreQueryPhase(searchContext);
-                try {
+                SearchPhaseExecutor.executeQueryPhase(searchContext.indexShard().getSearchOperationListener(), searchContext, () -> {
                     searchContext.searcher().setAggregatedDfs(readerContext.getAggregatedDfs(null));
                     processScroll(request, searchContext);
                     QueryPhase.execute(searchContext);
-                    opsListener.onQueryPhase(searchContext, System.nanoTime() - beforeQueryTime);
-                    opsListener = null;
-                } finally {
-                    if (opsListener != null) {
-                        opsListener.onFailedQueryPhase(searchContext);
-                    }
-                }
+                });
                 readerContext.setRescoreDocIds(searchContext.rescoreDocIds());
                 // ScrollQuerySearchResult will incRef the QuerySearchResult when it gets constructed.
                 ScrollQuerySearchResult result = new ScrollQuerySearchResult(searchContext.queryResult(), searchContext.shardTarget());
@@ -1386,25 +1356,15 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 final Supplier<DirectoryMetrics> metricsDelta = directoryMetricsDelta();
                 readerContext.setAggregatedDfs(request.dfs());
                 try (SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, ResultsType.QUERY, true);) {
-                    final QuerySearchResult queryResult;
-                    var opsListener = searchContext.indexShard().getSearchOperationListener();
-                    final long before = System.nanoTime();
-                    opsListener.onPreQueryPhase(searchContext);
-                    try {
+                    SearchPhaseExecutor.executeQueryPhase(searchContext.indexShard().getSearchOperationListener(), searchContext, () -> {
                         searchContext.searcher().setAggregatedDfs(request.dfs());
                         QueryPhase.execute(searchContext);
-                        queryResult = searchContext.queryResult();
-                        if (queryResult.hasSearchContext() == false && readerContext.singleSession()) {
+                        if (searchContext.queryResult().hasSearchContext() == false && readerContext.singleSession()) {
                             // no hits, we can release the context since there will be no fetch phase
                             freeReaderContext(readerContext.id(), "query phase produced no hits (single session)");
                         }
-                        opsListener.onQueryPhase(searchContext, System.nanoTime() - before);
-                        opsListener = null;
-                    } finally {
-                        if (opsListener != null) {
-                            opsListener.onFailedQueryPhase(searchContext);
-                        }
-                    }
+                    });
+                    final QuerySearchResult queryResult = searchContext.queryResult();
                     // Pass the rescoreDocIds to the queryResult to send them the coordinating node
                     // and receive them back in the fetch phase.
                     // We also pass the rescoreDocIds to the LegacyReaderContext in case the search state needs to stay in the data node.
@@ -1459,25 +1419,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             final Supplier<DirectoryMetrics> metricsDelta = directoryMetricsDelta();
             final ShardSearchRequest shardSearchRequest = readerContext.getShardSearchRequest(null);
             try (SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, ResultsType.FETCH, false);) {
-                var opsListener = readerContext.indexShard().getSearchOperationListener();
-                final long beforeQueryTime = System.nanoTime();
-                final long afterQueryTime;
-                try {
-                    opsListener.onPreQueryPhase(searchContext);
+                SearchPhaseExecutor.executeQueryPhase(readerContext.indexShard().getSearchOperationListener(), searchContext, () -> {
                     searchContext.assignRescoreDocIds(readerContext.getRescoreDocIds(null));
                     searchContext.searcher().setAggregatedDfs(readerContext.getAggregatedDfs(null));
                     processScroll(request, searchContext);
                     searchContext.addQueryResult();
                     QueryPhase.execute(searchContext);
-                    afterQueryTime = System.nanoTime();
-                    opsListener.onQueryPhase(searchContext, afterQueryTime - beforeQueryTime);
-                    opsListener = null;
-                } finally {
-                    if (opsListener != null) {
-                        opsListener.onFailedQueryPhase(searchContext);
-                    }
-                }
-                QueryFetchSearchResult fetchSearchResult = executeFetchPhase(readerContext, searchContext, afterQueryTime);
+                });
+                QueryFetchSearchResult fetchSearchResult = executeFetchPhase(readerContext, searchContext);
                 ScrollQueryFetchSearchResult result = new ScrollQueryFetchSearchResult(fetchSearchResult, searchContext.shardTarget());
                 setDirectoryMetrics(result, metricsDelta, searchContext);
                 return result;

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollectorManager;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.SearchPhaseExecutor;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
@@ -229,45 +230,38 @@ public class DfsPhase {
                 knnVectorQueryBuilder.addFilterQuery(context.request().getAliasFilter().getQueryBuilder());
             }
         }
-        List<DfsKnnResults> knnResults = new ArrayList<>(knnVectorQueryBuilders.size());
-        final long afterQueryTime;
-        final long beforeQueryTime = System.nanoTime();
-        var opsListener = context.indexShard().getSearchOperationListener();
-        opsListener.onPreQueryPhase(context);
-
         if (timeoutRunnable != null) {
             context.searcher().addQueryCancellation(timeoutRunnable);
         }
         try {
-            for (int i = 0; i < knnSearch.size(); i++) {
-                String knnField = knnVectorQueryBuilders.get(i).getFieldName();
-                String knnNestedPath = searchExecutionContext.nestedLookup().getNestedParent(knnField);
-                Query knnQuery = searchExecutionContext.toQuery(knnVectorQueryBuilders.get(i)).query();
-                knnResults.add(singleKnnSearch(knnQuery, knnSearch.get(i).k(), context.getProfilers(), context.searcher(), knnNestedPath));
+            SearchPhaseExecutor.executeQueryPhase(context.indexShard().getSearchOperationListener(), context, () -> {
+                try {
+                    List<DfsKnnResults> knnResults = new ArrayList<>(knnVectorQueryBuilders.size());
+                    for (int i = 0; i < knnSearch.size(); i++) {
+                        String knnField = knnVectorQueryBuilders.get(i).getFieldName();
+                        String knnNestedPath = searchExecutionContext.nestedLookup().getNestedParent(knnField);
+                        Query knnQuery = searchExecutionContext.toQuery(knnVectorQueryBuilders.get(i)).query();
+                        knnResults.add(
+                            singleKnnSearch(knnQuery, knnSearch.get(i).k(), context.getProfilers(), context.searcher(), knnNestedPath)
+                        );
 
-                // Re-throw so the catch block below can handle KNN timeout consistently.
-                if (context.searcher().timeExceeded()) {
-                    context.searcher().throwTimeExceededException();
+                        // Re-throw so the catch block below can handle KNN timeout consistently.
+                        if (context.searcher().timeExceeded()) {
+                            context.searcher().throwTimeExceededException();
+                        }
+                    }
+                    context.dfsResult().knnResults(knnResults);
+                } catch (ContextIndexSearcher.TimeExceededException e) {
+                    // a timeout is a partial success, so it still records as a completed query phase
+                    context.dfsResult().knnResults(List.of());
+                    handleDfsTimeout(context);
                 }
-            }
-            afterQueryTime = System.nanoTime();
-            opsListener.onQueryPhase(context, afterQueryTime - beforeQueryTime);
-            opsListener = null;
-        } catch (ContextIndexSearcher.TimeExceededException e) {
-            context.dfsResult().knnResults(List.of());
-            handleDfsTimeout(context);
-            opsListener.onQueryPhase(context, System.nanoTime() - beforeQueryTime);
-            opsListener = null;
-            return;
+            });
         } finally {
             if (timeoutRunnable != null) {
                 context.searcher().removeQueryCancellation(timeoutRunnable);
             }
-            if (opsListener != null) {
-                opsListener.onFailedQueryPhase(context);
-            }
         }
-        context.dfsResult().knnResults(knnResults);
     }
 
     static DfsKnnResults singleKnnSearch(Query knnQuery, int k, Profilers profilers, ContextIndexSearcher searcher, String nestedPath)

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/MetricAttributes.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/MetricAttributes.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.telemetry.metric;
 
+import org.elasticsearch.ExceptionsHelper;
+
+import java.io.IOException;
 import java.util.Set;
 
 public interface MetricAttributes {
@@ -26,6 +29,9 @@ public interface MetricAttributes {
 
     // refers to https://opentelemetry.io/docs/specs/semconv/registry/attributes/error/#error-type
     String ERROR_TYPE = "error_type";
+
+    /** Index mode of the metered shard; the value is {@link org.elasticsearch.index.IndexMode#getName()}. */
+    String ES_INDEX_MODE = "es_index_mode";
 
     /** The version of the stack. */
     String ES_STACK_VERSION = "es_stack_version";
@@ -77,4 +83,13 @@ public interface MetricAttributes {
         "elastic-synthetics"
     );
 
+    /**
+     * The {@link #ERROR_TYPE} value for a failure: the simple class name of the corruption exception if one is anywhere in the cause or
+     * suppressed chain, otherwise of the innermost non-wrapper cause.
+     */
+    static String errorType(Throwable t) {
+        IOException corruption = ExceptionsHelper.unwrapCorruption(t);
+        Throwable cause = corruption != null ? corruption : ExceptionsHelper.unwrapCause(t);
+        return cause.getClass().getSimpleName();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
@@ -51,8 +51,9 @@ public class SearchOperationListenerTests extends ESTestCase {
             }
 
             @Override
-            public void onFailedQueryPhase(SearchContext searchContext) {
+            public void onFailedQueryPhase(SearchContext searchContext, Throwable e) {
                 assertNotNull(searchContext);
+                assertNotNull(e);
                 failedQuery.incrementAndGet();
             }
 
@@ -71,8 +72,9 @@ public class SearchOperationListenerTests extends ESTestCase {
             }
 
             @Override
-            public void onFailedFetchPhase(SearchContext searchContext) {
+            public void onFailedFetchPhase(SearchContext searchContext, Throwable e) {
                 assertNotNull(searchContext);
+                assertNotNull(e);
                 failedFetch.incrementAndGet();
             }
 
@@ -191,7 +193,7 @@ public class SearchOperationListenerTests extends ESTestCase {
             assertEquals(0, freeScrollContext.get());
             assertEquals(0, validateSearchContext.get());
 
-            compositeListener.onFailedFetchPhase(ctx);
+            compositeListener.onFailedFetchPhase(ctx, new RuntimeException());
             assertEquals(2, preFetch.get());
             assertEquals(2, preQuery.get());
             assertEquals(2, failedFetch.get());
@@ -204,7 +206,7 @@ public class SearchOperationListenerTests extends ESTestCase {
             assertEquals(0, freeScrollContext.get());
             assertEquals(0, validateSearchContext.get());
 
-            compositeListener.onFailedQueryPhase(ctx);
+            compositeListener.onFailedQueryPhase(ctx, new RuntimeException());
             assertEquals(2, preFetch.get());
             assertEquals(2, preQuery.get());
             assertEquals(2, failedFetch.get());

--- a/server/src/test/java/org/elasticsearch/search/SearchPhaseExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchPhaseExecutorTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.search;
+
+import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TestSearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class SearchPhaseExecutorTests extends ESTestCase {
+
+    public void testExecutePhaseReportsExactlyOneOutcome() throws Exception {
+        List<String> events = new ArrayList<>();
+        List<Throwable> failures = new ArrayList<>();
+        SearchOperationListener listener = new SearchOperationListener() {
+            @Override
+            public void onPreDfsPhase(SearchContext searchContext) {
+                events.add("pre");
+            }
+
+            @Override
+            public void onDfsPhase(SearchContext searchContext, long tookInNanos) {
+                assertThat(tookInNanos, greaterThanOrEqualTo(0L));
+                events.add("success");
+            }
+
+            @Override
+            public void onFailedDfsPhase(SearchContext searchContext, Throwable e) {
+                events.add("failure");
+                failures.add(e);
+            }
+
+            @Override
+            public void onPreQueryPhase(SearchContext searchContext) {
+                onPreDfsPhase(searchContext);
+            }
+
+            @Override
+            public void onQueryPhase(SearchContext searchContext, long tookInNanos) {
+                onDfsPhase(searchContext, tookInNanos);
+            }
+
+            @Override
+            public void onFailedQueryPhase(SearchContext searchContext, Throwable e) {
+                onFailedDfsPhase(searchContext, e);
+            }
+
+            @Override
+            public void onPreFetchPhase(SearchContext searchContext) {
+                onPreDfsPhase(searchContext);
+            }
+
+            @Override
+            public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
+                onDfsPhase(searchContext, tookInNanos);
+            }
+
+            @Override
+            public void onFailedFetchPhase(SearchContext searchContext, Throwable e) {
+                onFailedDfsPhase(searchContext, e);
+            }
+        };
+        try (SearchContext ctx = new TestSearchContext((SearchExecutionContext) null)) {
+            for (int phase : new int[] { 0, 1, 2 }) {
+                events.clear();
+                failures.clear();
+                // an Error must reach the failure hook too, otherwise the shard-level current-phase gauges would never be decremented
+                Throwable failure = randomFrom(new IOException("io"), new IllegalStateException("state"), new AssertionError("error"));
+                CheckedRunnable<Exception> body = () -> {
+                    if (failure instanceof Error error) {
+                        throw error;
+                    }
+                    throw (Exception) failure;
+                };
+                Throwable thrown = expectThrows(Throwable.class, () -> execute(phase, listener, ctx, body));
+                assertThat(thrown, sameInstance(failure));
+                assertEquals(List.of("pre", "failure"), events);
+                assertEquals(List.of(failure), failures);
+
+                events.clear();
+                execute(phase, listener, ctx, () -> {});
+                assertEquals(List.of("pre", "success"), events);
+            }
+        }
+    }
+
+    private static void execute(int phase, SearchOperationListener listener, SearchContext ctx, CheckedRunnable<Exception> body)
+        throws Exception {
+        switch (phase) {
+            case 0 -> SearchPhaseExecutor.executeDfsPhase(listener, ctx, body);
+            case 1 -> SearchPhaseExecutor.executeQueryPhase(listener, ctx, body);
+            case 2 -> SearchPhaseExecutor.executeFetchPhase(listener, ctx, body);
+            default -> throw new AssertionError("unknown phase " + phase);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/stats/ShardSearchStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/stats/ShardSearchStatsTests.java
@@ -83,7 +83,7 @@ public class ShardSearchStatsTests extends IndexShardTestCase {
     public void testDfsPhase_Failure() {
         try (SearchContext sc = createSearchContext(false)) {
             shardSearchStatsListener.onPreDfsPhase(sc);
-            shardSearchStatsListener.onFailedDfsPhase(sc);
+            shardSearchStatsListener.onFailedDfsPhase(sc, new RuntimeException());
 
             SearchStats.Stats stats = shardSearchStatsListener.stats().getTotal();
             assertEquals(0.0, stats.getSearchLoadRate(), 0);
@@ -169,7 +169,7 @@ public class ShardSearchStatsTests extends IndexShardTestCase {
     public void testQueryPhase_SuggestOnly_Failure() {
         try (SearchContext sc = createSearchContext(true)) {
             shardSearchStatsListener.onPreQueryPhase(sc);
-            shardSearchStatsListener.onFailedQueryPhase(sc);
+            shardSearchStatsListener.onFailedQueryPhase(sc, new RuntimeException());
 
             SearchStats.Stats stats = shardSearchStatsListener.stats().getTotal();
             assertEquals(0, stats.getSuggestCurrent());
@@ -184,7 +184,7 @@ public class ShardSearchStatsTests extends IndexShardTestCase {
     public void testQueryPhase_Failure() {
         try (SearchContext sc = createSearchContext(false)) {
             shardSearchStatsListener.onPreQueryPhase(sc);
-            shardSearchStatsListener.onFailedQueryPhase(sc);
+            shardSearchStatsListener.onFailedQueryPhase(sc, new RuntimeException());
 
             SearchStats.Stats stats = shardSearchStatsListener.stats().getTotal();
             assertEquals(0, stats.getQueryCurrent());
@@ -230,7 +230,7 @@ public class ShardSearchStatsTests extends IndexShardTestCase {
     public void testFetchPhase_Failure() {
         try (SearchContext sc = createSearchContext(false)) {
             shardSearchStatsListener.onPreFetchPhase(sc);
-            shardSearchStatsListener.onFailedFetchPhase(sc);
+            shardSearchStatsListener.onFailedFetchPhase(sc, new RuntimeException());
 
             SearchStats.Stats stats = shardSearchStatsListener.stats().getTotal();
             assertEquals(0, stats.getFetchCurrent());

--- a/server/src/test/java/org/elasticsearch/search/telemetry/ShardSearchPhaseAPMMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/telemetry/ShardSearchPhaseAPMMetricsTests.java
@@ -11,23 +11,31 @@ package org.elasticsearch.search.telemetry;
 
 import org.elasticsearch.action.search.SearchRequestAttributesExtractor;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.indices.ExecutorNames;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.SystemIndexPlugin;
+import org.elasticsearch.script.MockScriptEngine;
+import org.elasticsearch.script.MockScriptPlugin;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.rescore.QueryRescorerBuilder;
 import org.elasticsearch.search.retriever.RescorerRetrieverBuilder;
 import org.elasticsearch.search.retriever.StandardRetrieverBuilder;
 import org.elasticsearch.telemetry.Measurement;
 import org.elasticsearch.telemetry.TestTelemetryPlugin;
+import org.elasticsearch.telemetry.metric.MetricAttributes;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -38,12 +46,15 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
 import static org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics.CAN_MATCH_SEARCH_PHASE_METRIC;
 import static org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics.DFS_SEARCH_PHASE_METRIC;
+import static org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics.FETCH_SEARCH_PHASE_FAILURE_METRIC;
 import static org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics.FETCH_SEARCH_PHASE_METRIC;
+import static org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics.QUERY_SEARCH_PHASE_FAILURE_METRIC;
 import static org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics.QUERY_SEARCH_PHASE_METRIC;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
@@ -56,7 +67,8 @@ import static org.hamcrest.Matchers.hasSize;
 public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
 
     private static final String indexName = "test_search_metrics2";
-    private final int num_primaries = randomIntBetween(2, 7);
+    // three or more shards so the two docs never cover every shard; the failure tests need a surviving shard with partial results allowed
+    private final int num_primaries = randomIntBetween(3, 7);
 
     @Override
     protected boolean resetNodeAfterTest() {
@@ -94,7 +106,7 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(TestTelemetryPlugin.class, TestSystemIndexPlugin.class);
+        return pluginList(TestTelemetryPlugin.class, TestSystemIndexPlugin.class, ThrowingScriptPlugin.class);
     }
 
     public void testMetricsDfsQueryThenFetch() {
@@ -169,7 +181,7 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
             int systemTarget = 0;
             for (Measurement measurement : queryMeasurements) {
                 Map<String, Object> attributes = measurement.attributes();
-                assertEquals(4, attributes.size());
+                assertEquals(5, attributes.size());
 
                 String target = attributes.get("target").toString();
                 if (target.equals("user")) {
@@ -191,7 +203,7 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
             int systemTarget = 0;
             for (Measurement measurement : fetchMeasurements) {
                 Map<String, Object> attributes = measurement.attributes();
-                assertEquals(4, attributes.size());
+                assertEquals(5, attributes.size());
 
                 String target = attributes.get("target").toString();
                 if (target.equals("user")) {
@@ -288,7 +300,7 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
     private static void assertAttributes(List<Measurement> measurements, boolean isSystem, boolean isScroll) {
         for (Measurement measurement : measurements) {
             Map<String, Object> attributes = measurement.attributes();
-            assertEquals(isScroll ? 5 : 4, attributes.size());
+            assertEquals(isScroll ? 6 : 5, attributes.size());
             if (isSystem) {
                 assertEquals(".others", attributes.get("target"));
             } else {
@@ -300,6 +312,63 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
                 assertEquals("scroll", attributes.get("pit_scroll"));
             }
             assertEquals(isSystem, attributes.get(SearchRequestAttributesExtractor.SYSTEM_THREAD_ATTRIBUTE_NAME));
+            assertEquals(IndexMode.STANDARD.getName(), attributes.get(MetricAttributes.ES_INDEX_MODE));
+        }
+    }
+
+    public void testQueryPhaseFailure() {
+        // the script only runs against docs, so only the shards that hold one of the two docs fail; the empty shards succeed.
+        // Partial results stay allowed: disallowing them makes the coordinator cancel the search on the first shard failure, and a
+        // sibling shard still running would then fail with TaskCancelledException and be counted under that error type instead
+        assertResponse(
+            client().prepareSearch(indexName)
+                .setQuery(
+                    QueryBuilders.scriptQuery(new Script(ScriptType.INLINE, MockScriptEngine.NAME, ThrowingScriptPlugin.THROW, Map.of()))
+                ),
+            response -> {
+                final List<Measurement> failures = getTestTelemetryPlugin().getLongCounterMeasurement(QUERY_SEARCH_PHASE_FAILURE_METRIC);
+                assertFailureMeasurements(failures, response.getShardFailures());
+                final List<Measurement> successes = getTestTelemetryPlugin().getLongHistogramMeasurement(QUERY_SEARCH_PHASE_METRIC);
+                assertEquals(num_primaries, successes.size() + failures.size());
+                assertThat(getTestTelemetryPlugin().getLongCounterMeasurement(FETCH_SEARCH_PHASE_FAILURE_METRIC), Matchers.empty());
+            }
+        );
+    }
+
+    public void testFetchPhaseFailure() {
+        // script fields only run in the fetch phase and only over hits, so every query phase succeeds and every fetch fails.
+        // Partial results stay allowed for the same reason as in testQueryPhaseFailure
+        assertResponse(
+            client().prepareSearch(indexName)
+                .setQuery(QueryBuilders.matchAllQuery())
+                .addScriptField(
+                    randomAlphanumericOfLength(8),
+                    new Script(ScriptType.INLINE, MockScriptEngine.NAME, ThrowingScriptPlugin.THROW, Map.of())
+                ),
+            response -> {
+                final List<Measurement> failures = getTestTelemetryPlugin().getLongCounterMeasurement(FETCH_SEARCH_PHASE_FAILURE_METRIC);
+                assertFailureMeasurements(failures, response.getShardFailures());
+                assertThat(getTestTelemetryPlugin().getLongHistogramMeasurement(FETCH_SEARCH_PHASE_METRIC), Matchers.empty());
+                assertThat(getTestTelemetryPlugin().getLongHistogramMeasurement(QUERY_SEARCH_PHASE_METRIC), hasSize(num_primaries));
+                assertThat(getTestTelemetryPlugin().getLongCounterMeasurement(QUERY_SEARCH_PHASE_FAILURE_METRIC), Matchers.empty());
+            }
+        );
+    }
+
+    private static void assertFailureMeasurements(List<Measurement> failures, ShardSearchFailure[] shardFailures) {
+        assertThat(failures, hasSize(shardFailures.length));
+        assertThat(failures, hasSize(Matchers.greaterThanOrEqualTo(1)));
+        for (Measurement measurement : failures) {
+            assertEquals(1L, measurement.getLong());
+            assertEquals(
+                Map.of(
+                    MetricAttributes.ES_INDEX_MODE,
+                    IndexMode.STANDARD.getName(),
+                    MetricAttributes.ERROR_TYPE,
+                    IllegalStateException.class.getSimpleName()
+                ),
+                measurement.attributes()
+            );
         }
     }
 
@@ -350,7 +419,7 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
     private static void assertTimeRangeAttributes(List<Measurement> measurements, String target, boolean isSystem, boolean isPit) {
         for (Measurement measurement : measurements) {
             Map<String, Object> attributes = measurement.attributes();
-            assertEquals(isPit ? 7 : 6, attributes.size());
+            assertEquals(isPit ? 8 : 7, attributes.size());
             assertEquals(target, attributes.get("target"));
             assertEquals("hits_only", attributes.get("query_type"));
             assertEquals("_score", attributes.get("sort"));
@@ -392,7 +461,7 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
         assertThat(queryMeasurements.size(), Matchers.lessThanOrEqualTo(2));
         for (Measurement measurement : queryMeasurements) {
             Map<String, Object> attributes = measurement.attributes();
-            assertEquals(5, attributes.size());
+            assertEquals(6, attributes.size());
             assertEquals("user", attributes.get("target"));
             assertEquals("hits_only", attributes.get("query_type"));
             assertEquals("_score", attributes.get("sort"));
@@ -405,7 +474,7 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
         // in this case, each shard queried has results to be fetched
         for (Measurement measurement : fetchMeasurements) {
             Map<String, Object> attributes = measurement.attributes();
-            assertEquals(5, attributes.size());
+            assertEquals(6, attributes.size());
             assertEquals("user", attributes.get("target"));
             assertEquals("hits_only", attributes.get("query_type"));
             assertEquals("_score", attributes.get("sort"));
@@ -477,6 +546,15 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
 
     private TestTelemetryPlugin getTestTelemetryPlugin() {
         return getInstanceFromNode(PluginsService.class).filterPlugins(TestTelemetryPlugin.class).toList().get(0);
+    }
+
+    public static class ThrowingScriptPlugin extends MockScriptPlugin {
+        static final String THROW = "throw";
+
+        @Override
+        protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            return Map.of(THROW, vars -> { throw new IllegalStateException("simulated script failure"); });
+        }
     }
 
     public static class TestSystemIndexPlugin extends Plugin implements SystemIndexPlugin {

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -2326,7 +2326,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 }
 
                 @Override
-                public void onFailedQueryPhase(SearchContext searchContext) {
+                public void onFailedQueryPhase(SearchContext searchContext, Throwable e) {
                     // only count failed queries that have a timeout set (to be sure we are listening for our test query)
                     if (searchContext.timeout().millis() > -1) {
                         if (failedQueryLatch.get().getCount() > 0) {


### PR DESCRIPTION
This change is one of several that introduces new metrics to provide better dashboarding and monitoring capabilities for storage engine.

This change introduces failure metrics to query and fetch phases. Namely:
- `es.search.shards.phases.query.failure.total`, with attributes `error_type`, `es_index_mode`
- `es.search.shards.phases.fetch.failure.total`, with attributes `error_type`, `es_index_mode`

This change also adds the `index_mode` attribute to existing latency metrics:
- `es.search.shards.phases.dfs.duration.histogram`
- `es.search.shards.phases.query.duration.histogram`
- `es.search.shards.phases.fetch.duration.histogram`

In the worst case, we're looking at ~8 (index modes) * E (error types) of unique metrics.

Note, technically we already have per-index mode failure counters, but similar to https://github.com/elastic/elasticsearch/pull/158890, these counters are aggregates (sums over a time range) and adding `error_type` to them is difficult. Furthermore, the existing metrics go against [NAMING.md](https://github.com/elastic/elasticsearch/blob/main/modules/apm/NAMING.md), which forbids metric names from having dynamic segments; ie. the index mode baked into the metric name. This is exactly how the old metrics are: `es.indices.<mode>.query.failure.total`. We can consider deprecating these in the future.

Note also, the new `es_index_mode` attribute is included in existing metrics as well:
- `es.search.shards.phases.dfs.duration.histogram`
- `es.search.shards.phases.query.duration.histogram`
- `es.search.shards.phases.fetch.duration.histogram`

Following [NAMING.md](https://github.com/elastic/elasticsearch/blob/main/modules/apm/NAMING.md), I've verified that no dashboards and alarms in `elasticsearch-o11y-resources` will be impacted by this new attributes:
- There are no alarms/alerts that reference them
- One existing dashboard `dashboard_serverless-es-search-latency` references them, but only plots p95 percentiles -  a percentile over a histogram field merges the bucket counts of every matching document in the interval.