### PR TITLE
Fix history search flake in testRetentionWhileSnapshotInProgress

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -731,9 +731,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.EsqlQueryMetricsCollectorIT
   method: testMetricsCollectorMultiFileCsv
   issue: https://github.com/elastic/elasticsearch/issues/158463
-- class: org.elasticsearch.xpack.slm.SLMSnapshotBlockingIntegTests
-  method: testRetentionWhileSnapshotInProgress
-  issue: https://github.com/elastic/elasticsearch/issues/158608
 - class: org.elasticsearch.xpack.sql.qa.security.CliSecurityIT
   issue: https://github.com/elastic/elasticsearch/issues/158631
 - class: org.elasticsearch.xpack.stateless.recovery.StatelessPreFlushRelocationIT

--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TransportRestoreSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotStatus;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -278,17 +279,23 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
 
             // Assert that the history document has been written for taking the snapshot and deleting it
             assertBusy(() -> {
-                assertResponse(
-                    prepareSearch(".slm-history*").setQuery(QueryBuilders.matchQuery("snapshot_name", completedSnapshotName)),
-                    resp -> {
-                        logger.info(
-                            "--> checking history written for {}, got: {}",
-                            completedSnapshotName,
-                            Strings.arrayToCommaDelimitedString(resp.getHits().getHits())
-                        );
-                        assertThat(resp.getHits().getTotalHits().value(), equalTo(2L));
-                    }
-                );
+                try {
+                    assertResponse(
+                        prepareSearch(".slm-history*").setQuery(QueryBuilders.matchQuery("snapshot_name", completedSnapshotName)),
+                        resp -> {
+                            logger.info(
+                                "--> checking history written for {}, got: {}",
+                                completedSnapshotName,
+                                Strings.arrayToCommaDelimitedString(resp.getHits().getHits())
+                            );
+                            assertThat(resp.getHits().getTotalHits().value(), equalTo(2L));
+                        }
+                    );
+                } catch (SearchPhaseExecutionException e) {
+                    // The history data stream is auto-created by the history store's bulk flush, so its shards may still
+                    // be initializing here. assertBusy only retries on AssertionError, so convert to one to keep waiting.
+                    throw new AssertionError("history search failed while shards were still initializing", e);
+                }
             });
         } finally {
             unblockNode(REPO, internalCluster().getMasterName());


### PR DESCRIPTION
`testRetentionWhileSnapshotInProgress` failed intermittently with `SearchPhaseExecutionException: all shards failed`, caused by
  `NoShardAvailableActionException`.

  `SnapshotHistoryStore` sets `setBulkActions(-1)` with a 50MB bulk size, so its only
  flush trigger is the 5s interval. The `.slm-history` data stream is thus auto-created
  by that late flush, and the final `assertBusy` can search it in the  window
  between the backing index being created and its shard reaching `STARTED`.
  `ESTestCase.assertBusy` retries only on `AssertionError`, so the resulting
  `SearchPhaseExecutionException` escaped the retry loop and failed the test outright.

  Fix: catch that exception inside the lambda and rethrow as `AssertionError` so the
  busy-wait retries until the shard is searchable. Scoped to that one exception, so a
  real hit-count mismatch still fails.


Closes #158608