### PR TITLE
Don't simulate total-heap changes for non-indexing nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
@@ -153,7 +153,7 @@ public class ClusterInfoSimulator {
 
     // Visible for testing
     public Map<String, NodeHeapMetrics> computeNodeHeapMetrics() {
-        return nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics();
+        return nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics(allocation.nodes());
     }
 
     /**
@@ -229,7 +229,7 @@ public class ClusterInfoSimulator {
                 mostAvailableSpaceUsage,
                 shardSizes.toImmutableMap(),
                 Map.of(),
-                nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics(),
+                nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics(allocation.nodes()),
                 estimatedShardHeapUsages,
                 shardMovementWriteLoadSimulator.simulatedNodeUsageStatsForThreadPools(),
                 shardMoveNodeCacheCommitmentSimulator.getShardCacheRequirements(),

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
@@ -153,7 +153,7 @@ public class ClusterInfoSimulator {
 
     // Visible for testing
     public Map<String, NodeHeapMetrics> computeNodeHeapMetrics() {
-        return nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics(allocation.nodes());
+        return nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics();
     }
 
     /**
@@ -229,7 +229,7 @@ public class ClusterInfoSimulator {
                 mostAvailableSpaceUsage,
                 shardSizes.toImmutableMap(),
                 Map.of(),
-                nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics(allocation.nodes()),
+                nodeHeapMemoryShardMovementSimulator.getSimulatedHeapMetrics(),
                 estimatedShardHeapUsages,
                 shardMovementWriteLoadSimulator.simulatedNodeUsageStatsForThreadPools(),
                 shardMoveNodeCacheCommitmentSimulator.getShardCacheRequirements(),

--- a/server/src/main/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulator.java
@@ -120,15 +120,18 @@ class NodeHeapMemoryShardMovementSimulator {
 
     /**
      * Apply the deltas to the initial estimates, clamping the results to 0 to avoid producing negative estimates.
+     * <p>
+     * Deltas are applied to total and hosted-shards heap estimates for indexing nodes, while only the hosted-shards estimate
+     * is adjusted for non-indexing nodes. For non-indexing nodes, the total heap estimate will always return 0.
      */
-    Map<String, NodeHeapMetrics> getSimulatedHeapMetrics(DiscoveryNodes nodes) {
+    Map<String, NodeHeapMetrics> getSimulatedHeapMetrics() {
         // If there was no shard movement, just return the unchanged metrics
         if (usageDeltaByNode.isEmpty()) {
             return initialNodeHeapMetrics;
         }
         return initialNodeHeapMetrics.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> {
-            boolean nodeIsIndexingNode = nodeIsIndexingNode(entry.getKey(), nodes);
             if (usageDeltaByNode.containsKey(entry.getKey())) {
+                final boolean nodeIsIndexingNode = nodeIsIndexingNode(entry.getKey());
                 NodeHeapMetrics initialMetrics = entry.getValue();
                 final var adjustedTotalUsage = nodeIsIndexingNode
                     ? Math.max(0, Math.addExact(initialMetrics.nodeHeapEstimates().totalHeapUsage(), usageDeltaByNode.get(entry.getKey())))
@@ -147,8 +150,18 @@ class NodeHeapMemoryShardMovementSimulator {
         }));
     }
 
-    private boolean nodeIsIndexingNode(String nodeId, DiscoveryNodes discoveryNodes) {
-        DiscoveryNode discoveryNode = discoveryNodes.get(nodeId);
-        return discoveryNode != null && discoveryNode.getRoles().contains(DiscoveryNodeRole.INDEX_ROLE);
+    /**
+     * Is the specified node an indexing node?
+     *
+     * @param nodeId The node ID to query
+     * @return True if the node is an indexing node, false if it is not, or is absent from the {@link DiscoveryNodes}
+     */
+    private boolean nodeIsIndexingNode(String nodeId) {
+        RoutingNode routingNode = routingNodes.node(nodeId);
+        if (routingNode != null) {
+            DiscoveryNode discoveryNode = routingNode.node();
+            return discoveryNode != null && discoveryNode.hasRole(DiscoveryNodeRole.INDEX_ROLE.roleName());
+        }
+        return false;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulator.java
@@ -12,6 +12,9 @@ package org.elasticsearch.cluster;
 import com.carrotsearch.hppc.ObjectLongHashMap;
 import com.carrotsearch.hppc.ObjectLongMap;
 
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -118,18 +121,18 @@ class NodeHeapMemoryShardMovementSimulator {
     /**
      * Apply the deltas to the initial estimates, clamping the results to 0 to avoid producing negative estimates.
      */
-    Map<String, NodeHeapMetrics> getSimulatedHeapMetrics() {
+    Map<String, NodeHeapMetrics> getSimulatedHeapMetrics(DiscoveryNodes nodes) {
         // If there was no shard movement, just return the unchanged metrics
         if (usageDeltaByNode.isEmpty()) {
             return initialNodeHeapMetrics;
         }
         return initialNodeHeapMetrics.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> {
+            boolean nodeIsIndexingNode = nodeIsIndexingNode(entry.getKey(), nodes);
             if (usageDeltaByNode.containsKey(entry.getKey())) {
                 NodeHeapMetrics initialMetrics = entry.getValue();
-                final var adjustedTotalUsage = Math.max(
-                    0,
-                    Math.addExact(initialMetrics.nodeHeapEstimates().totalHeapUsage(), usageDeltaByNode.get(entry.getKey()))
-                );
+                final var adjustedTotalUsage = nodeIsIndexingNode
+                    ? Math.max(0, Math.addExact(initialMetrics.nodeHeapEstimates().totalHeapUsage(), usageDeltaByNode.get(entry.getKey())))
+                    : 0;
                 final var adjustedHostedShardsUsage = Math.max(
                     0,
                     Math.addExact(initialMetrics.nodeHeapEstimates().hostedShardsHeapUsage(), usageDeltaByNode.get(entry.getKey()))
@@ -142,5 +145,10 @@ class NodeHeapMemoryShardMovementSimulator {
             }
             return entry.getValue();
         }));
+    }
+
+    private boolean nodeIsIndexingNode(String nodeId, DiscoveryNodes discoveryNodes) {
+        DiscoveryNode discoveryNode = discoveryNodes.get(nodeId);
+        return discoveryNode != null && discoveryNode.getRoles().contains(DiscoveryNodeRole.INDEX_ROLE);
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulatorTests.java
@@ -11,6 +11,9 @@ package org.elasticsearch.cluster;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.GlobalRoutingTable;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -23,8 +26,10 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.UNASSIGNED;
 import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
@@ -39,7 +44,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
         var initialMetrics = Map.of(nodeId, nodeHeapMetrics(nodeId, randomIntBetween(100, 300), randomIntBetween(0, 100)));
         var simulator = newSimulator(initialMetrics, Map.of(), ShardAndIndexHeapUsage.ZERO, emptyRoutingNodes());
 
-        assertThat(simulator.getSimulatedHeapMetrics(), sameInstance(initialMetrics));
+        assertThat(simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId)), sameInstance(initialMetrics));
     }
 
     /**
@@ -73,7 +78,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateShardStarted(relocationShards.v2(), true);
 
-        var result = simulator.getSimulatedHeapMetrics();
+        var result = simulator.getSimulatedHeapMetrics(state.nodes());
         // nodeA: remove shardHeap + indexHeap > 82 delta; initial total=50 → max(0, 50 - shardHeap - indexHeap) = 0
         assertThat(result.get(nodeA).nodeHeapEstimates().totalHeapUsage(), equalTo(0L));
         // nodeA: remove shardHeap + indexHeap; initial hosted=30 → max(0, 30 - shardHeap - indexHeap) = 0
@@ -122,12 +127,93 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateShardStarted(relocationShards.v2(), true);
 
-        var result = simulator.getSimulatedHeapMetrics();
+        var result = simulator.getSimulatedHeapMetrics(state.nodes());
         // nodeA: non-last shard removed → no index heap delta; only shard heap delta = -100
         // totalHeap: 200 - 100 = 100 (not clamped)
         assertThat(result.get(nodeA).nodeHeapEstimates().totalHeapUsage(), equalTo(100L));
         // hostedShardsHeap: 30 - 100 = -70 → clamped to 0
         assertThat(result.get(nodeA).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(0L));
+    }
+
+    /**
+     * Non-indexing nodes (nodes without the {@link DiscoveryNodeRole#INDEX_ROLE}, such as stateless search nodes) always have
+     * totalHeapUsage reported as zero when a delta is present, regardless of the delta magnitude.
+     * hostedShardsHeapUsage is still computed with the normal clamped adjustment.
+     * In contrast, indexing nodes have their totalHeapUsage updated by the delta as normal.
+     * This is verified via both the simulateAddIndexToNode and simulateShardStarted paths.
+     */
+    public void testNonIndexingNodeTotalHeapEstimateIsZeroWhenDeltaIsPresent() {
+        var searchNodeId = "search-node";
+        var indexingNodeId = "indexing-node";
+        long indexingInitialTotal = randomLongBetween(200, 500);
+        long indexingInitialHosted = randomLongBetween(50, 150);
+        long searchInitialHosted = randomLongBetween(50, 150);
+        long shardHeap = randomLongBetween(10, 50);
+        long indexHeap = randomLongBetween(10, 40);
+        var indexMetadata = IndexMetadata.builder("test-index").settings(indexSettings(IndexVersion.current(), 1, 1)).build();
+        var index = indexMetadata.getIndex();
+        var shardId0 = new ShardId(index, 0);
+        var initialMetrics = Map.of(
+            searchNodeId,
+            nodeHeapMetrics(searchNodeId, 0, searchInitialHosted),
+            indexingNodeId,
+            nodeHeapMetrics(indexingNodeId, indexingInitialTotal, indexingInitialHosted)
+        );
+        var shardHeapUsages = Map.of(shardId0, new ShardAndIndexHeapUsage(shardHeap, indexHeap));
+
+        // Both branches produce expectedDelta = shardHeap + indexHeap per node, via different call paths.
+        NodeHeapMemoryShardMovementSimulator simulator;
+
+        var irtBuilder = IndexRoutingTable.builder(index);
+        final var unassignedPrimary = newShardRouting(shardId0, null, true, UNASSIGNED);
+        final var unassignedReplica = newShardRouting(shardId0, null, false, UNASSIGNED);
+        irtBuilder.addShard(unassignedPrimary);
+        irtBuilder.addShard(unassignedReplica);
+        final var state = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(createDiscoveryNodes(Set.of(indexingNodeId), Set.of(searchNodeId)))
+            .metadata(Metadata.builder().put(ProjectMetadata.builder(ProjectId.DEFAULT).put(indexMetadata, false)).build())
+            .routingTable(
+                GlobalRoutingTable.builder().put(ProjectId.DEFAULT, RoutingTable.builder().add(irtBuilder.build()).build()).build()
+            )
+            .build();
+        final var routingNodes = state.mutableRoutingNodes();
+        final var initializingPrimary = routingNodes.initializeShard(
+            unassignedPrimary,
+            indexingNodeId,
+            null,
+            0L,
+            RoutingChangesObserver.NOOP
+        );
+        final var startedPrimary = routingNodes.startShard(initializingPrimary, RoutingChangesObserver.NOOP, 0L);
+        final var initializingReplica = routingNodes.initializeShard(
+            unassignedReplica,
+            searchNodeId,
+            null,
+            0L,
+            RoutingChangesObserver.NOOP
+        );
+        final var startedReplica = routingNodes.startShard(initializingReplica, RoutingChangesObserver.NOOP, 0L);
+
+        if (randomBoolean()) {
+            // add shard and index usage separately
+            simulator = newSimulator(initialMetrics, shardHeapUsages, ShardAndIndexHeapUsage.ZERO, routingNodes);
+            simulator.simulateShardStarted(startedPrimary, false);
+            simulator.simulateShardStarted(startedReplica, false);
+            simulator.simulateAddIndexToNode(searchNodeId, index);
+            simulator.simulateAddIndexToNode(indexingNodeId, index);
+        } else {
+            // or add shard and index usage together
+            simulator = newSimulator(initialMetrics, shardHeapUsages, ShardAndIndexHeapUsage.ZERO, routingNodes);
+            simulator.simulateShardStarted(startedPrimary, true);
+            simulator.simulateShardStarted(startedReplica, true);
+        }
+
+        long expectedDelta = shardHeap + indexHeap;
+        var result = simulator.getSimulatedHeapMetrics(createDiscoveryNodes(Set.of(indexingNodeId), Set.of(searchNodeId)));
+        assertThat(result.get(searchNodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(0L));
+        assertThat(result.get(searchNodeId).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(searchInitialHosted + expectedDelta));
+        assertThat(result.get(indexingNodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(indexingInitialTotal + expectedDelta));
+        assertThat(result.get(indexingNodeId).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(indexingInitialHosted + expectedDelta));
     }
 
     /** Nodes not present in the initial metrics map are silently skipped; results for known nodes are unaffected. */
@@ -156,7 +242,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateShardStarted(relocationShards.v2(), true);
 
-        assertThat(simulator.getSimulatedHeapMetrics().size(), equalTo(0));
+        assertThat(simulator.getSimulatedHeapMetrics(state.nodes()).size(), equalTo(0));
     }
 
     /** simulateAddIndexToNode increases totalHeapUsage and hostedShardsHeapUsage by the index heap amount. */
@@ -175,7 +261,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateAddIndexToNode(nodeId, index);
 
-        var result = simulator.getSimulatedHeapMetrics();
+        var result = simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId));
         assertThat(result.get(nodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(initialTotal + indexHeap));
         assertThat(result.get(nodeId).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(initialHosted + indexHeap));
     }
@@ -196,7 +282,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateRemoveIndexFromNode(nodeId, index);
 
-        var result = simulator.getSimulatedHeapMetrics();
+        var result = simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId));
         assertThat(result.get(nodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(initialTotal - indexHeap));
         assertThat(result.get(nodeId).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(initialHosted - indexHeap));
     }
@@ -206,9 +292,10 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
         var index = new Index("test-index", "_na_");
         var simulator = newSimulator(Map.of(), Map.of(), ShardAndIndexHeapUsage.ZERO, emptyRoutingNodes());
 
-        simulator.simulateAddIndexToNode("unknown-node", index);
+        final var nodeId = "unknown-node";
+        simulator.simulateAddIndexToNode(nodeId, index);
 
-        assertThat(simulator.getSimulatedHeapMetrics().size(), equalTo(0));
+        assertThat(simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId)).size(), equalTo(0));
     }
 
     /** simulateRemoveIndexFromNode is a no-op for nodes absent from the initial metrics map. */
@@ -216,9 +303,10 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
         var index = new Index("test-index", "_na_");
         var simulator = newSimulator(Map.of(), Map.of(), ShardAndIndexHeapUsage.ZERO, emptyRoutingNodes());
 
-        simulator.simulateRemoveIndexFromNode("unknown-node", index);
+        final var nodeId = "unknown-node";
+        simulator.simulateRemoveIndexFromNode(nodeId, index);
 
-        assertThat(simulator.getSimulatedHeapMetrics().size(), equalTo(0));
+        assertThat(simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId)).size(), equalTo(0));
     }
 
     // --- helpers ---
@@ -268,7 +356,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
         }
         var routingTable = RoutingTable.builder().add(irtBuilder.build()).build();
         return ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().add(newNode(primaryNode)).add(newNode(otherNode)).build())
+            .nodes(createDiscoveryNodes(primaryNode, otherNode))
             .metadata(Metadata.builder().put(indexMetadata, false))
             .routingTable(routingTable)
             .build();
@@ -289,5 +377,20 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
             }
         }
         throw new AssertionError("no started shard with id " + shardNum + " on node " + nodeId);
+    }
+
+    private static DiscoveryNodes createDiscoveryNodes(String... indexingNodeIds) {
+        return createDiscoveryNodes(Set.of(indexingNodeIds), Set.of());
+    }
+
+    private static DiscoveryNodes createDiscoveryNodes(Set<String> indexingNodeIds, Set<String> searchNodeIds) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        for (String nodeId : indexingNodeIds) {
+            builder.add(newNode(nodeId, Set.of(DiscoveryNodeRole.INDEX_ROLE)));
+        }
+        for (String nodeId : searchNodeIds) {
+            builder.add(newNode(nodeId, Set.of(DiscoveryNodeRole.SEARCH_ROLE)));
+        }
+        return builder.build();
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeHeapMemoryShardMovementSimulatorTests.java
@@ -42,9 +42,9 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
     public void testNoDeltasReturnsSameMetricsReference() {
         var nodeId = "node-0";
         var initialMetrics = Map.of(nodeId, nodeHeapMetrics(nodeId, randomIntBetween(100, 300), randomIntBetween(0, 100)));
-        var simulator = newSimulator(initialMetrics, Map.of(), ShardAndIndexHeapUsage.ZERO, emptyRoutingNodes());
+        var simulator = newSimulator(initialMetrics, Map.of(), ShardAndIndexHeapUsage.ZERO, routingNodes(nodeId));
 
-        assertThat(simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId)), sameInstance(initialMetrics));
+        assertThat(simulator.getSimulatedHeapMetrics(), sameInstance(initialMetrics));
     }
 
     /**
@@ -78,7 +78,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateShardStarted(relocationShards.v2(), true);
 
-        var result = simulator.getSimulatedHeapMetrics(state.nodes());
+        var result = simulator.getSimulatedHeapMetrics();
         // nodeA: remove shardHeap + indexHeap > 82 delta; initial total=50 → max(0, 50 - shardHeap - indexHeap) = 0
         assertThat(result.get(nodeA).nodeHeapEstimates().totalHeapUsage(), equalTo(0L));
         // nodeA: remove shardHeap + indexHeap; initial hosted=30 → max(0, 30 - shardHeap - indexHeap) = 0
@@ -127,7 +127,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateShardStarted(relocationShards.v2(), true);
 
-        var result = simulator.getSimulatedHeapMetrics(state.nodes());
+        var result = simulator.getSimulatedHeapMetrics();
         // nodeA: non-last shard removed → no index heap delta; only shard heap delta = -100
         // totalHeap: 200 - 100 = 100 (not clamped)
         assertThat(result.get(nodeA).nodeHeapEstimates().totalHeapUsage(), equalTo(100L));
@@ -209,7 +209,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
         }
 
         long expectedDelta = shardHeap + indexHeap;
-        var result = simulator.getSimulatedHeapMetrics(createDiscoveryNodes(Set.of(indexingNodeId), Set.of(searchNodeId)));
+        var result = simulator.getSimulatedHeapMetrics();
         assertThat(result.get(searchNodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(0L));
         assertThat(result.get(searchNodeId).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(searchInitialHosted + expectedDelta));
         assertThat(result.get(indexingNodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(indexingInitialTotal + expectedDelta));
@@ -242,7 +242,7 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
 
         simulator.simulateShardStarted(relocationShards.v2(), true);
 
-        assertThat(simulator.getSimulatedHeapMetrics(state.nodes()).size(), equalTo(0));
+        assertThat(simulator.getSimulatedHeapMetrics().size(), equalTo(0));
     }
 
     /** simulateAddIndexToNode increases totalHeapUsage and hostedShardsHeapUsage by the index heap amount. */
@@ -256,12 +256,12 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
             Map.of(nodeId, nodeHeapMetrics(nodeId, initialTotal, initialHosted)),
             Map.of(new ShardId(index, 0), new ShardAndIndexHeapUsage(shardHeap, indexHeap)),
             ShardAndIndexHeapUsage.ZERO,
-            emptyRoutingNodes()
+            routingNodes(nodeId)
         );
 
         simulator.simulateAddIndexToNode(nodeId, index);
 
-        var result = simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId));
+        var result = simulator.getSimulatedHeapMetrics();
         assertThat(result.get(nodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(initialTotal + indexHeap));
         assertThat(result.get(nodeId).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(initialHosted + indexHeap));
     }
@@ -277,12 +277,12 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
             Map.of(nodeId, nodeHeapMetrics(nodeId, initialTotal, initialHosted)),
             Map.of(new ShardId(index, 0), new ShardAndIndexHeapUsage(shardHeap, indexHeap)),
             ShardAndIndexHeapUsage.ZERO,
-            emptyRoutingNodes()
+            routingNodes(nodeId)
         );
 
         simulator.simulateRemoveIndexFromNode(nodeId, index);
 
-        var result = simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId));
+        var result = simulator.getSimulatedHeapMetrics();
         assertThat(result.get(nodeId).nodeHeapEstimates().totalHeapUsage(), equalTo(initialTotal - indexHeap));
         assertThat(result.get(nodeId).nodeHeapEstimates().hostedShardsHeapUsage(), equalTo(initialHosted - indexHeap));
     }
@@ -290,23 +290,23 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
     /** simulateAddIndexToNode is a no-op for nodes absent from the initial metrics map. */
     public void testSimulateAddIndexToNodeSkipsUnknownNodes() {
         var index = new Index("test-index", "_na_");
-        var simulator = newSimulator(Map.of(), Map.of(), ShardAndIndexHeapUsage.ZERO, emptyRoutingNodes());
+        var simulator = newSimulator(Map.of(), Map.of(), ShardAndIndexHeapUsage.ZERO, routingNodes());
 
         final var nodeId = "unknown-node";
         simulator.simulateAddIndexToNode(nodeId, index);
 
-        assertThat(simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId)).size(), equalTo(0));
+        assertThat(simulator.getSimulatedHeapMetrics().size(), equalTo(0));
     }
 
     /** simulateRemoveIndexFromNode is a no-op for nodes absent from the initial metrics map. */
     public void testSimulateRemoveIndexFromNodeSkipsUnknownNodes() {
         var index = new Index("test-index", "_na_");
-        var simulator = newSimulator(Map.of(), Map.of(), ShardAndIndexHeapUsage.ZERO, emptyRoutingNodes());
+        var simulator = newSimulator(Map.of(), Map.of(), ShardAndIndexHeapUsage.ZERO, routingNodes());
 
         final var nodeId = "unknown-node";
         simulator.simulateRemoveIndexFromNode(nodeId, index);
 
-        assertThat(simulator.getSimulatedHeapMetrics(createDiscoveryNodes(nodeId)).size(), equalTo(0));
+        assertThat(simulator.getSimulatedHeapMetrics().size(), equalTo(0));
     }
 
     // --- helpers ---
@@ -324,8 +324,8 @@ public class NodeHeapMemoryShardMovementSimulatorTests extends ESAllocationTestC
         return new NodeHeapMemoryShardMovementSimulator(initialMetrics, shardHeapUsages, defaultHeapUsage, routingNodes);
     }
 
-    private static RoutingNodes emptyRoutingNodes() {
-        return RoutingNodes.immutable(GlobalRoutingTable.EMPTY_ROUTING_TABLE, DiscoveryNodes.EMPTY_NODES);
+    private static RoutingNodes routingNodes(String... indexingNodes) {
+        return RoutingNodes.immutable(GlobalRoutingTable.EMPTY_ROUTING_TABLE, createDiscoveryNodes(indexingNodes));
     }
 
     /**


### PR DESCRIPTION
In #158697 we began producing heap estimates for search nodes. Search nodes only estimate their "hosted shards" heap usage and not their total heap usage.

This PR updates the `ClusterInfoSimulator` so that it doesn't apply the "total heap" deltas to search nodes, for consistency. The total deltas being applied to search nodes in simulation isn't an issue in practice because the legacy heap decider is only active for indexing nodes, but they may be confusing for anyone observing them.