### PR TITLE
Support partitioning with PackedValuesBlockHash

### DIFF
--- a/docs/changelog/158907.yaml
+++ b/docs/changelog/158907.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158907
+summary: Support partitioning with `PackedValuesBlockHash`
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
@@ -309,4 +309,10 @@ public final class BytesRefHash extends AbstractHash implements Accountable, Byt
         }
     }
 
+    @Override
+    public void clear() {
+        bytesRefs.truncateTo(0);
+        ids.fill(0, ids.size(), 0);
+        size = 0;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefHashTable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefHashTable.java
@@ -48,6 +48,11 @@ public interface BytesRefHashTable extends Accountable, Releasable {
     /** Returns the size (number of key/value pairs) in the table.*/
     long size();
 
+    /**
+     * Removes all entries, keeping the allocated structures for reuse. The hash will be empty after this call returns.
+     */
+    void clear();
+
     /** Gets the backing bytes ref array. */
     BytesRefArray getBytesRefs();
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHashTable;
+import org.elasticsearch.common.util.PartitionedHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
@@ -73,7 +74,7 @@ import java.util.List;
  *     and the last column being the inner-most loop. See {@link Group} for more.
  * </p>
  */
-final class PackedValuesBlockHash extends BlockHash {
+final class PackedValuesBlockHash extends PartitionedBlockHash {
     static final int DEFAULT_BATCH_SIZE = Math.toIntExact(ByteSizeValue.ofKb(10).getBytes());
 
     private final int emitBatchSize;
@@ -519,6 +520,58 @@ final class PackedValuesBlockHash extends BlockHash {
     @Override
     public BitArray seenGroupIds(BigArrays bigArrays) {
         return new SeenGroupIds.Range(0, Math.toIntExact(bytesRefHash.size())).seenGroupIds(bigArrays);
+    }
+
+    @Override
+    public void ensureCapacity(int size) {
+        if (bytesRefHash instanceof BytesRefSwissHash swiss) {
+            swiss.ensureCapacity(size);
+        }
+    }
+
+    @Override
+    public void clear() {
+        seenNull = false;
+        bytesRefHash.clear();
+    }
+
+    private record PartitionedHashKeysWithSeenNull(PartitionedHashKeys delegate, boolean seenNull) implements PartitionedHashKeys {
+        @Override
+        public int keysInPartition(int partition) {
+            return delegate.keysInPartition(partition);
+        }
+
+        @Override
+        public void releasePartition(CircuitBreaker breaker, int partition) {
+            delegate.releasePartition(breaker, partition);
+        }
+
+        @Override
+        public void releaseAll(CircuitBreaker breaker) {
+            delegate.releaseAll(breaker);
+        }
+    }
+
+    @Override
+    public PartitionedHashTable.PartitionedHashKeys splitPartition(
+        CircuitBreaker breaker,
+        PartitionedHashTable.PartitionSplitter partitionSplitter
+    ) {
+        if (bytesRefHash instanceof BytesRefSwissHash swiss) {
+            PartitionedHashKeys keys = swiss.splitPartition(breaker, partitionSplitter);
+            return new PartitionedHashKeysWithSeenNull(keys, seenNull);
+        }
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " doesn't support partitioning");
+    }
+
+    @Override
+    public boolean combinePartition(PartitionedHashTable.PartitionedHashKeys keys, int partitionIndex, int[] resultIds) {
+        if (bytesRefHash instanceof BytesRefSwissHash swiss) {
+            PartitionedHashKeysWithSeenNull withSeenNull = (PartitionedHashKeysWithSeenNull) keys;
+            seenNull |= withSeenNull.seenNull;
+            return swiss.combinePartition(withSeenNull.delegate, partitionIndex, resultIds);
+        }
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " doesn't support partitioning");
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PartitionedGroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PartitionedGroupingAggregatorFunctionTestCase.java
@@ -33,6 +33,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -151,15 +152,7 @@ public abstract class PartitionedGroupingAggregatorFunctionTestCase extends Grou
             hashOperator = new HashAggregationOperator(
                 AggregatorMode.SINGLE,
                 List.of(aggregatorFunction().groupingAggregatorFactory(AggregatorMode.SINGLE, channels(AggregatorMode.SINGLE))),
-                dc -> new LongIntBlockHash(
-                    List.of(
-                        new BlockHash.GroupSpec(longKeyChannel, ElementType.LONG),
-                        new BlockHash.GroupSpec(intKeyChannel, ElementType.INT)
-                    ),
-                    dc.blockFactory(),
-                    1024,
-                    false
-                ),
+                newBlockHash(),
                 randomIntBetween(1, 1024),
                 randomDouble(),
                 randomIntBetween(128, 4096),
@@ -236,6 +229,23 @@ public abstract class PartitionedGroupingAggregatorFunctionTestCase extends Grou
                 }
             }
             return builder.build();
+        }
+    }
+
+    private Function<DriverContext, BlockHash> newBlockHash() {
+        if (randomBoolean()) {
+            return dc -> new LongIntBlockHash(
+                List.of(new BlockHash.GroupSpec(longKeyChannel, ElementType.LONG), new BlockHash.GroupSpec(intKeyChannel, ElementType.INT)),
+                dc.blockFactory(),
+                1024,
+                false
+            );
+        } else {
+            return dc -> BlockHash.buildPackedValuesBlockHash(
+                List.of(new BlockHash.GroupSpec(longKeyChannel, ElementType.LONG), new BlockHash.GroupSpec(intKeyChannel, ElementType.INT)),
+                dc.blockFactory(),
+                1024
+            );
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperatorTests.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -161,10 +162,16 @@ public class ParallelHashAggregationOperatorTests extends ComputeTestCase {
         List<Page> outputPages = new ArrayList<>();
         final DriverStatus status;
         try (SourceOperator sourceOperator = new CannedSourceOperator(inputPages.iterator())) {
+            final Function<DriverContext, BlockHash> blockHashSupplier;
+            if (randomBoolean()) {
+                blockHashSupplier = dc -> BlockHash.build(groupSpecs, dc.blockFactory(), between(128, 1024), false);
+            } else {
+                blockHashSupplier = dc -> BlockHash.buildPackedValuesBlockHash(groupSpecs, dc.blockFactory(), between(128, 1024));
+            }
             HashAggregationOperator hashOperator = new HashAggregationOperator(
                 AggregatorMode.FINAL,
                 aggregatorFactories,
-                dc -> BlockHash.build(groupSpecs, dc.blockFactory(), between(128, 1024), false),
+                blockHashSupplier,
                 randomIntBetween(1, 1024),
                 randomDouble(),
                 randomIntBetween(128, 4096),


### PR DESCRIPTION
This change adds partitioning support to PackedValuesBlockHash, building on the BytesRefSwissHash partitioning implemented by Parker (in #158419). More extensive tests will be added either in this PR or in a follow-up.

<img width="398" height="105" alt="q35" src="https://github.com/user-attachments/assets/d8dab124-8c06-49d0-ac1a-cc0a050b376f" />

<img width="410" height="102" alt="q18" src="https://github.com/user-attachments/assets/0d36a465-e760-49b0-8cf2-28ff5fd3a919" />

<img width="402" height="100" alt="q14" src="https://github.com/user-attachments/assets/1683d26b-26da-4845-9f55-6274a8a84d82" />

Relates #158419