### PR TITLE
Fix BlockRefreshUponIndexCreationIT.testRefreshesAreBlockedUntilBlockIsRemoved

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -192,9 +192,6 @@ tests:
 - class: org.elasticsearch.upgrades.TransformSurvivesUpgradeIT
   method: testTransformRollingUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/150442
-- class: org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT
-  method: testRefreshesAreBlockedUntilBlockIsRemoved
-  issue: https://github.com/elastic/elasticsearch/issues/150492
 - class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
   method: testDatafeedWithCcsRemoteUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/150541

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/BlockRefreshUponIndexCreationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/BlockRefreshUponIndexCreationIT.java
@@ -310,6 +310,9 @@ public class BlockRefreshUponIndexCreationIT extends AbstractStatelessPluginInte
         }
 
         ensureGreen(indices.toArray(new String[] {}));
+        // Trigger a new commit now that every search shard is assigned, so shards whose recovery may have raced and
+        // missed the last notification catch up. See: https://github.com/elastic/elasticsearch/issues/150492
+        assertNoFailures(safeGet(indexDocsWithRefreshPolicy(indices, 10, WriteRequest.RefreshPolicy.IMMEDIATE)));
 
         concurrentBulkFutures.forEach(bulkFuture -> assertNoFailures(safeGet(bulkFuture)));
         concurrentRefreshFutures.forEach(refreshFuture -> assertNoFailures(safeGet(refreshFuture)));

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -375,30 +375,6 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
         return routingTable.hasIndex(shardId.getIndex()) ? Optional.of(routingTable.shardRoutingTable(shardId)) : Optional.empty();
     }
 
-    private static void maybeSleepAfterCommitRoutingSnapshot(
-        ShardId shardId,
-        long generation,
-        Optional<IndexShardRoutingTable> shardRoutingTable
-    ) {
-        final long sleepMillis = Long.getLong("es.stateless.debug.sleep_after_commit_routing_snapshot_millis", 0L);
-        if (sleepMillis == 0L) {
-            return;
-        }
-
-        logger.info(
-            "{} captured routing for commit generation [{}]. Snapshot recipients: {}. Sleeping for [{}]ms",
-            shardId,
-            generation,
-            shardRoutingTable.map(IndexShardRoutingTable::assignedUnpromotableShards).orElse(List.of()),
-            sleepMillis
-        );
-        try {
-            Thread.sleep(sleepMillis);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
     /**
      * A releasable backed by inc-ref and dec-ref the recovered commits with
      */
@@ -719,7 +695,6 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
             final VirtualBatchedCompoundCommit virtualBcc;
             final boolean commitAfterRelocationStarted;
             final Optional<IndexShardRoutingTable> shardRoutingTable = shardRoutingFinder.apply(shardId);
-            maybeSleepAfterCommitRoutingSnapshot(shardId, generation, shardRoutingTable);
             // reads the timestamp field value range outside the commit state synchronized block (because this does blocking IO)
             var timestampFieldValueRange = readTimestampFieldValueRange(commitState, reference);
             synchronized (commitState) {
@@ -2433,14 +2408,6 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                     + state;
 
             lastNewCommitNotificationSentTimestamp = threadPool.relativeTimeInMillis();
-            final var currentRoutingSnapshot = shardRoutingFinder.apply(shardId);
-            logger.info(
-                "{} sending CC commit notification for generation [{}]. Snapshot recipients: {}. Current recipients: {}",
-                shardId,
-                lastCompoundCommit.generation(),
-                shardRoutingTable.assignedUnpromotableShards(),
-                currentRoutingSnapshot.map(IndexShardRoutingTable::assignedUnpromotableShards).orElse(List.of())
-            );
             statelessCommitNotificationPublisher.sendNewCommitNotification(
                 shardRoutingTable,
                 lastCompoundCommit,
@@ -3748,19 +3715,6 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 compoundCommitGeneration,
                 nodeId,
                 l.map(registrationResponse -> {
-                    if (Boolean.getBoolean("es.stateless.debug.log_recovery_commit_registration")) {
-                        logger.info(
-                            "{} registering search node [{}] requested BCC [{}], commit [{}], returning BCC [{}], commit [{}]",
-                            shardId,
-                            nodeId,
-                            batchedCompoundGeneration,
-                            compoundCommitGeneration,
-                            registrationResponse.getLatestUploadedBatchedCompoundCommitTermAndGen(),
-                            registrationResponse.getCompoundCommit() == null
-                                ? PrimaryTermAndGeneration.ZERO
-                                : registrationResponse.getCompoundCommit().primaryTermAndGeneration()
-                        );
-                    }
                     if (Assertions.ENABLED) {
                         assert registrationResponse.getCompoundCommit() != null;
                         var cc = registrationResponse.getCompoundCommit().primaryTermAndGeneration();

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -375,6 +375,30 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
         return routingTable.hasIndex(shardId.getIndex()) ? Optional.of(routingTable.shardRoutingTable(shardId)) : Optional.empty();
     }
 
+    private static void maybeSleepAfterCommitRoutingSnapshot(
+        ShardId shardId,
+        long generation,
+        Optional<IndexShardRoutingTable> shardRoutingTable
+    ) {
+        final long sleepMillis = Long.getLong("es.stateless.debug.sleep_after_commit_routing_snapshot_millis", 0L);
+        if (sleepMillis == 0L) {
+            return;
+        }
+
+        logger.info(
+            "{} captured routing for commit generation [{}]. Snapshot recipients: {}. Sleeping for [{}]ms",
+            shardId,
+            generation,
+            shardRoutingTable.map(IndexShardRoutingTable::assignedUnpromotableShards).orElse(List.of()),
+            sleepMillis
+        );
+        try {
+            Thread.sleep(sleepMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     /**
      * A releasable backed by inc-ref and dec-ref the recovered commits with
      */
@@ -695,6 +719,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
             final VirtualBatchedCompoundCommit virtualBcc;
             final boolean commitAfterRelocationStarted;
             final Optional<IndexShardRoutingTable> shardRoutingTable = shardRoutingFinder.apply(shardId);
+            maybeSleepAfterCommitRoutingSnapshot(shardId, generation, shardRoutingTable);
             // reads the timestamp field value range outside the commit state synchronized block (because this does blocking IO)
             var timestampFieldValueRange = readTimestampFieldValueRange(commitState, reference);
             synchronized (commitState) {
@@ -2408,6 +2433,14 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                     + state;
 
             lastNewCommitNotificationSentTimestamp = threadPool.relativeTimeInMillis();
+            final var currentRoutingSnapshot = shardRoutingFinder.apply(shardId);
+            logger.info(
+                "{} sending CC commit notification for generation [{}]. Snapshot recipients: {}. Current recipients: {}",
+                shardId,
+                lastCompoundCommit.generation(),
+                shardRoutingTable.assignedUnpromotableShards(),
+                currentRoutingSnapshot.map(IndexShardRoutingTable::assignedUnpromotableShards).orElse(List.of())
+            );
             statelessCommitNotificationPublisher.sendNewCommitNotification(
                 shardRoutingTable,
                 lastCompoundCommit,
@@ -3715,6 +3748,19 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 compoundCommitGeneration,
                 nodeId,
                 l.map(registrationResponse -> {
+                    if (Boolean.getBoolean("es.stateless.debug.log_recovery_commit_registration")) {
+                        logger.info(
+                            "{} registering search node [{}] requested BCC [{}], commit [{}], returning BCC [{}], commit [{}]",
+                            shardId,
+                            nodeId,
+                            batchedCompoundGeneration,
+                            compoundCommitGeneration,
+                            registrationResponse.getLatestUploadedBatchedCompoundCommitTermAndGen(),
+                            registrationResponse.getCompoundCommit() == null
+                                ? PrimaryTermAndGeneration.ZERO
+                                : registrationResponse.getCompoundCommit().primaryTermAndGeneration()
+                        );
+                    }
                     if (Assertions.ENABLED) {
                         assert registrationResponse.getCompoundCommit() != null;
                         var cc = registrationResponse.getCompoundCommit().primaryTermAndGeneration();


### PR DESCRIPTION
See: https://github.com/elastic/elasticsearch/issues/150492#issuecomment-5611224118 for full repro and explanation.

**Problem**

`testRefreshesAreBlockedUntilBlockIsRemoved` can get stuck if an indexing shard creates its last commit while a search shard is still recovering. 
Commit-notification recipients are determined from the routing table when the commit is created. If the search shard after that routing snapshot, but before the new commit is pending upload and becomes visible to recovery, it can both recover from an older commit and miss the notification for the new commit, leaving an earlier refresh or bulk request blocked until a later commit notification arrives.

**Fix**

After all search shards are assigned, index ten documents per index with an immediate refresh. This is intended to generate later commit notifications after recovery has completed, allowing shards that missed an earlier notification to catch up and unblock the pending requests.

**Note**

This appears to be a genuine, low-risk production bug. The affected search shard should catch up on a later commit notification, so the state is eventually consistent. A proper fix likely needs more careful coordination between search-shard recovery and commit creation. Simply reading the routing table again immediately before sending the notification would narrow the window, but would not fully eliminate the race.

I filed a GitHub issue for the production concern: https://github.com/elastic/elasticsearch/issues/159479 and kept this PR focused solely on stabilizing the test for now. Curious on reviewers' thoughts though.

---

Closes: https://github.com/elastic/elasticsearch/issues/150492

Running test on VM with load: [builds](https://gradle-enterprise.elastic.co/scans/tests?search.publicHostnames=inespot-ci-test&search.startTimeMax=1789617599999&search.startTimeMin=1789358400000&search.timeZoneId=America%2FNew_York&tests.container=org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT&tests.test=testRefreshesAreBlockedUntilBlockIsRemoved), 1200 runs without failures so far