### PR TITLE
Document spill-to-disk on partitioning APIs

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/PartitionedHashTable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/PartitionedHashTable.java
@@ -16,6 +16,12 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
  * partition via {@link #splitPartition} and {@link #combinePartition} instead of all at once. A key always falls into the
  * same partition regardless of which table it came from, so partitions can be combined independently, concurrently and
  * released as soon as they have been combined.
+ * <p>
+ * The same partitioning can support spilling large aggregations to disk without sorting keys. Once the split partitions
+ * held in memory exceed the memory budget, they are written to disk partition by partition. The combine then loads the
+ * slices of one partition at a time and merges them via {@link #combinePartition}, so peak memory is bounded by the
+ * partitions being merged rather than by the whole aggregation. Spilled slices are append-only writes and sequential reads,
+ * and only the partitioned keys and their per-key state need serializing; the split and combine steps stay the same.
  */
 public interface PartitionedHashTable {
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperator.java
@@ -54,6 +54,15 @@ import java.util.concurrent.locks.ReentrantLock;
  * which causes unnecessary yields and reschedules. Increasing {@link #pagesPerWorker} mitigates
  * this at the cost of buffering more memory. The emit phase now can dump the entire partition
  * to the exchange instead checking the capacity for every emit.
+ *
+ * <p>The same partitioning can support spilling large aggregations to disk without sorting keys,
+ * reusing the two-phase flow above. In the first phase, once the registry exceeds the memory budget,
+ * split partitions are written to disk instead of being kept in memory. In the second phase, a worker
+ * claiming a partition loads its spilled slices, merges them with the in-memory ones, and emits as
+ * usual. Only the slices of the partitions being merged need to be in memory, so peak memory is
+ * bounded by those partitions rather than by the whole aggregation. Spilled slices are append-only
+ * writes and sequential reads, and only the partitioned keys and aggregation states need
+ * serializing; the split and combine steps stay the same.
  */
 public final class ParallelHashAggregationOperator implements Operator {
     public static final int PAGE_PER_WORKER = 10;


### PR DESCRIPTION
The partitioning APIs already support spilling large aggregations to disk without sorting keys. Add javadoc describing the approach so future readers and AI agents can find it.