### PR TITLE
[9.5] Fix regression introduced by #148249

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/SearchBasedChangesSnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/SearchBasedChangesSnapshotTests.java
@@ -414,13 +414,16 @@ public abstract class SearchBasedChangesSnapshotTests extends EngineTestCase {
                     pullOperations(engine);
                 }
                 assertConsistentHistoryBetweenTranslogAndLuceneIndex(engine);
+                assertThat(
+                    engine.config().getMapperService().isUseColumnarId(),
+                    equalTo(leader.config().getMapperService().isUseColumnarId())
+                );
                 // have to verify without source since we are randomly testing without _source
-                boolean columnarId = engine.engineConfig.getMapperService().isUseColumnarId();
-                List<DocIdSeqNoAndSource> docsWithoutSourceOnFollower = EngineTestUtils.getDocIds(engine, true, columnarId)
+                List<DocIdSeqNoAndSource> docsWithoutSourceOnFollower = EngineTestUtils.getDocIds(engine, true)
                     .stream()
                     .map(d -> new DocIdSeqNoAndSource(d.id(), null, d.seqNo(), d.primaryTerm(), d.version()))
                     .toList();
-                List<DocIdSeqNoAndSource> docsWithoutSourceOnLeader = EngineTestUtils.getDocIds(engine, true, columnarId)
+                List<DocIdSeqNoAndSource> docsWithoutSourceOnLeader = EngineTestUtils.getDocIds(leader, true)
                     .stream()
                     .map(d -> new DocIdSeqNoAndSource(d.id(), null, d.seqNo(), d.primaryTerm(), d.version()))
                     .toList();

--- a/test/framework/src/main/java/org/elasticsearch/index/EngineTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/EngineTestUtils.java
@@ -20,6 +20,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.engine.DocIdSeqNoAndSource;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
@@ -45,10 +46,12 @@ public final class EngineTestUtils {
      *
      * For integration tests, use the {@link org.elasticsearch.test.ESIntegTestCase#getDocIdAndSeqNos(IndexShard)} method.
      */
-    public static List<DocIdSeqNoAndSource> getDocIds(Engine engine, boolean refresh, boolean columnarId) throws IOException {
+    public static List<DocIdSeqNoAndSource> getDocIds(Engine engine, boolean refresh) throws IOException {
         if (refresh) {
             engine.refresh("test_get_doc_ids");
         }
+        final MapperService mapperService = engine.getEngineConfig().getMapperService();
+        final boolean columnarId = mapperService != null && mapperService.isUseColumnarId();
         try (Engine.Searcher searcher = engine.acquireSearcher("test_get_doc_ids", Engine.SearcherScope.INTERNAL)) {
             List<DocIdSeqNoAndSource> docs = new ArrayList<>();
             for (LeafReaderContext leafContext : searcher.getIndexReader().leaves()) {

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1246,7 +1246,7 @@ public abstract class EngineTestCase extends ESTestCase {
      * Gets a collection of tuples of docId, sequence number, and primary term of all live documents in the provided engine.
      */
     protected List<DocIdSeqNoAndSource> getDocIds(Engine engine, boolean refresh) throws IOException {
-        return EngineTestUtils.getDocIds(engine, refresh, false);
+        return EngineTestUtils.getDocIds(engine, refresh);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -1122,7 +1122,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
     }
 
     protected List<DocIdSeqNoAndSource> getDocIdAndSeqNos(final IndexShard shard, final boolean refresh) throws IOException {
-        return shard.withEngineException(engine -> EngineTestUtils.getDocIds(engine, refresh, false));
+        return shard.withEngineException(engine -> EngineTestUtils.getDocIds(engine, refresh));
     }
 
     protected void assertDocCount(IndexShard shard, int docCount) throws IOException {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -404,7 +404,7 @@ public class FollowingEngineTests extends ESTestCase {
             EngineTestCase.waitForOpsToComplete(follower, leader.getProcessedLocalCheckpoint());
             assertThat(follower.getMaxSeqNoOfUpdatesOrDeletes(), equalTo(-1L));
             assertThat(getNumVersionLookups(follower), equalTo(0L));
-            assertThat(getDocIds(follower, true, false), equalTo(getDocIds(leader, true, false)));
+            assertThat(getDocIds(follower, true), equalTo(getDocIds(leader, true)));
 
             // Do not apply optimization for deletes or updates
             long versionLookUps = 0;
@@ -420,11 +420,11 @@ public class FollowingEngineTests extends ESTestCase {
             EngineTestCase.waitForOpsToComplete(follower, leader.getProcessedLocalCheckpoint());
             assertThat(getNumVersionLookups(follower), greaterThanOrEqualTo(versionLookUps));
             assertThat(follower.getMaxSeqNoOfUpdatesOrDeletes(), equalTo(leader.getMaxSeqNoOfUpdatesOrDeletes()));
-            assertThat(getDocIds(follower, true, false), equalTo(getDocIds(leader, true, false)));
+            assertThat(getDocIds(follower, true), equalTo(getDocIds(leader, true)));
             // Apply optimization for documents that do not exist
             long moreDocs = between(1, 100);
             versionLookUps = getNumVersionLookups(follower);
-            Set<String> docIds = getDocIds(follower, true, false).stream().map(doc -> doc.id()).collect(Collectors.toSet());
+            Set<String> docIds = getDocIds(follower, true).stream().map(doc -> doc.id()).collect(Collectors.toSet());
             for (int i = 0; i < moreDocs; i++) {
                 String docId = randomValueOtherThanMany(docIds::contains, () -> Integer.toString(between(1, 1000)));
                 docIds.add(docId);
@@ -433,7 +433,7 @@ public class FollowingEngineTests extends ESTestCase {
             EngineTestCase.waitForOpsToComplete(follower, leader.getProcessedLocalCheckpoint());
             assertThat(follower.getMaxSeqNoOfUpdatesOrDeletes(), equalTo(leader.getMaxSeqNoOfUpdatesOrDeletes()));
             assertThat(getNumVersionLookups(follower), equalTo(versionLookUps));
-            assertThat(getDocIds(follower, true, false), equalTo(getDocIds(leader, true, false)));
+            assertThat(getDocIds(follower, true), equalTo(getDocIds(leader, true)));
         });
     }
 
@@ -502,7 +502,7 @@ public class FollowingEngineTests extends ESTestCase {
         runFollowTest((leader, follower) -> {
             EngineTestCase.concurrentlyApplyOps(ops, leader);
             EngineTestCase.waitForOpsToComplete(follower, leader.getProcessedLocalCheckpoint());
-            assertThat(getDocIds(follower, true, false), equalTo(getDocIds(leader, true, false)));
+            assertThat(getDocIds(follower, true), equalTo(getDocIds(leader, true)));
 
             leader.delete(deleteForPrimary("id"));
             EngineTestCase.waitForOpsToComplete(follower, leader.getProcessedLocalCheckpoint());
@@ -627,7 +627,7 @@ public class FollowingEngineTests extends ESTestCase {
                     thread.join();
                 }
                 assertThat(follower.getMaxSeqNoOfUpdatesOrDeletes(), greaterThanOrEqualTo(leader.getMaxSeqNoOfUpdatesOrDeletes()));
-                assertThat(getDocIds(follower, true, false), equalTo(getDocIds(leader, true, false)));
+                assertThat(getDocIds(follower, true), equalTo(getDocIds(leader, true)));
                 EngineTestCase.assertConsistentHistoryBetweenTranslogAndLuceneIndex(follower);
                 EngineTestCase.assertAtMostOneLuceneDocumentPerSequenceNumber(follower);
             }
@@ -892,7 +892,7 @@ public class FollowingEngineTests extends ESTestCase {
                         assertThat(failure.getExistingPrimaryTerm().getAsLong(), equalTo(operationWithTerms.get(op.seqNo())));
                     }
                 }
-                for (DocIdSeqNoAndSource docId : getDocIds(followingEngine, true, false)) {
+                for (DocIdSeqNoAndSource docId : getDocIds(followingEngine, true)) {
                     assertThat(docId.primaryTerm(), equalTo(operationWithTerms.get(docId.seqNo())));
                 }
                 // Replica should accept duplicates
@@ -906,7 +906,7 @@ public class FollowingEngineTests extends ESTestCase {
                     Engine.Result result = applyOperation(followingEngine, op, newTerm, nonPrimary);
                     assertThat(result.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
                 }
-                for (DocIdSeqNoAndSource docId : getDocIds(followingEngine, true, false)) {
+                for (DocIdSeqNoAndSource docId : getDocIds(followingEngine, true)) {
                     assertThat(docId.primaryTerm(), equalTo(operationWithTerms.get(docId.seqNo())));
                 }
             }


### PR DESCRIPTION
Backport of #158840 for 9.5

#148249 added a `columnarId` boolean parameter to the method EngineTestUtils.getDocIds. While doing so it rewrote the

```java
List<DocIdSeqNoAndSource> docsWithoutSourceOnLeader = getDocIds(leader, true).stream()
```
into
```java
List<DocIdSeqNoAndSource> docsWithoutSourceOnLeader = EngineTestUtils.getDocIds(engine, true, columnarId)
```

but in that last one `engine` refers to the follower engine, not the leader's. So the assertion that compares the list of docs always compare two lists of the follower docs and not leader's versus follower's.

This change fixes the regression, and revert the getLiveDocs method so that the columnar mode is extracted from the engine configuration and not an external parameter.

Relates #148249
Relates #150408
