### PR TITLE
[9.5] Fix replica divergence on sequence numbers disabled indices (#158870)

### DIFF
--- a/docs/changelog/158870.yaml
+++ b/docs/changelog/158870.yaml
@@ -1,0 +1,6 @@
+area: CRUD
+issues:
+ - 150408
+pr: 158870
+summary: Fix replica divergence on sequence numbers disabled indices
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -386,15 +386,38 @@ final class PerThreadIDVersionAndSeqNoLookup {
     }
 
     /** Return null if id is not found. */
-    DocIdAndSeqNo lookupDocIdAndSeqNo(BytesRef id, LeafReaderContext context, boolean loadSeqNo) throws IOException {
+    DocIdAndSeqNo lookupDocIdAndSeqNo(BytesRef id, LeafReaderContext context, boolean allowMissingSeqNo) throws IOException {
         assert readerKey == null || context.reader().getCoreCacheHelper().getKey().equals(readerKey)
             : "context's reader is not the same as the reader class was initialized on.";
         final int docID = getDocID(id, context);
         if (docID != DocIdSetIterator.NO_MORE_DOCS) {
-            final long seqNo = loadSeqNo ? readNumericDocValues(context.reader(), SeqNoFieldMapper.NAME, docID) : UNASSIGNED_SEQ_NO;
+            final long seqNo = readSeqNo(context.reader(), docID, allowMissingSeqNo);
             return new DocIdAndSeqNo(docID, seqNo, context);
         } else {
             return null;
         }
+    }
+
+    /**
+     * Reads the {@code _seq_no} doc value for the given document.
+     *
+     * <p>On sequence-number-disabled indices, {@link org.elasticsearch.index.engine.PruningMergePolicy} removes the {@code _seq_no}
+     * doc value of a document once it is fully replicated (its seq_no falls below the retained range, i.e. {@code minRetainedSeqNo}).
+     * When {@code allowMissingSeqNo} is {@code true}, a missing doc value is tolerated and
+     * {@link org.elasticsearch.index.seqno.SequenceNumbers#UNASSIGNED_SEQ_NO} is returned:
+     * a pruned document is older than any operation that can still reach seq-no-based conflict resolution, so treating it as unassigned
+     * yields the correct {@code OP_NEWER} verdict. When {@code allowMissingSeqNo} is {@code false} (sequence numbers enabled, so
+     * {@code _seq_no} is never pruned) a missing doc value indicates corruption and fails.
+     */
+    private static long readSeqNo(LeafReader reader, int docId, boolean allowMissingSeqNo) throws IOException {
+        final NumericDocValues dv = reader.getNumericDocValues(SeqNoFieldMapper.NAME);
+        if (dv != null && dv.advanceExact(docId)) {
+            return dv.longValue();
+        }
+        if (allowMissingSeqNo) {
+            return UNASSIGNED_SEQ_NO;
+        }
+        assert false : "document [" + docId + "] does not have docValues for [" + SeqNoFieldMapper.NAME + "]";
+        throw new IllegalStateException("document [" + docId + "] does not have docValues for [" + SeqNoFieldMapper.NAME + "]");
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/VersionsAndSeqNoResolver.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/VersionsAndSeqNoResolver.java
@@ -351,15 +351,17 @@ public final class VersionsAndSeqNoResolver {
      * The result is either null or the live and latest version of the given uid.
      */
     public static DocIdAndSeqNo loadDocIdAndSeqNo(IndexReader reader, BytesRef term) throws IOException {
-        return loadDocIdAndSeqNo(reader, term, true);
+        return loadDocIdAndSeqNo(reader, term, false);
     }
 
     /**
      * Loads the internal docId and sequence number of the latest copy for a given uid from the provided reader.
-     * When {@code loadSeqNo} is false, {@code UNASSIGNED_SEQ_NO} is returned instead of reading the doc value.
+     * When {@code allowMissingSeqNo} is true, a {@code _seq_no} doc value that has been pruned (see
+     * {@link org.elasticsearch.index.engine.PruningMergePolicy}) is tolerated and {@code UNASSIGNED_SEQ_NO} is returned instead of
+     * failing. This is required on sequence-number-disabled indices, where the {@code _seq_no} of fully replicated documents is pruned.
      * The result is either null or the live and latest version of the given uid.
      */
-    public static DocIdAndSeqNo loadDocIdAndSeqNo(IndexReader reader, BytesRef term, boolean loadSeqNo) throws IOException {
+    public static DocIdAndSeqNo loadDocIdAndSeqNo(IndexReader reader, BytesRef term, boolean allowMissingSeqNo) throws IOException {
         final PerThreadIDVersionAndSeqNoLookup[] lookups = getLookupState(reader, false);
         final List<LeafReaderContext> leaves = reader.leaves();
         // iterate backwards to optimize for the frequently updated documents
@@ -367,7 +369,7 @@ public final class VersionsAndSeqNoResolver {
         for (int i = leaves.size() - 1; i >= 0; i--) {
             final LeafReaderContext leaf = leaves.get(i);
             final PerThreadIDVersionAndSeqNoLookup lookup = lookups[leaf.ord];
-            final DocIdAndSeqNo result = lookup.lookupDocIdAndSeqNo(term, leaf, loadSeqNo);
+            final DocIdAndSeqNo result = lookup.lookupDocIdAndSeqNo(term, leaf, allowMissingSeqNo);
             if (result != null) {
                 return result;
             }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1064,12 +1064,17 @@ public class InternalEngine extends Engine {
         } else {
             // load from index
             assert incrementIndexVersionLookup();
-            final boolean loadSeqNo = engineConfig.getIndexSettings().sequenceNumbersDisabled() == false;
+            // On sequence-number-disabled indices, PruningMergePolicy removes the _seq_no doc value of a document once it is fully
+            // replicated (its seq_no drops below minRetainedSeqNo). Allow missing seq no so a pruned _seq_no is read as UNASSIGNED_SEQ_NO
+            // rather than failing: a pruned document is older than any op that can still reach this path, so the op is correctly
+            // OP_NEWER. A retained _seq_no (a document that is not yet fully replicated) is still read and compared, so out-of-order
+            // stale writes are correctly rejected instead of overwriting a newer document.
+            final boolean allowMissingSeqNo = engineConfig.getIndexSettings().sequenceNumbersDisabled();
             try (Searcher searcher = acquireSearcher("load_seq_no", SearcherScope.INTERNAL)) {
                 final DocIdAndSeqNo docAndSeqNo = VersionsAndSeqNoResolver.loadDocIdAndSeqNo(
                     searcher.getIndexReader(),
                     op.uid(),
-                    loadSeqNo
+                    allowMissingSeqNo
                 );
                 if (docAndSeqNo == null) {
                     status = OpVsLuceneDocStatus.LUCENE_DOC_NOT_FOUND;

--- a/server/src/test/java/org/elasticsearch/index/engine/ColumnarLuceneSyntheticSourceChangesSnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ColumnarLuceneSyntheticSourceChangesSnapshotTests.java
@@ -24,10 +24,7 @@ public class ColumnarLuceneSyntheticSourceChangesSnapshotTests extends LuceneSyn
             .put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), SourceFieldMapper.Mode.COLUMNAR_STORED.name())
             .put(IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING.getKey(), true)
             .put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY.name())
-            // Workaround for https://github.com/elastic/elasticsearch/issues/150408: seq no pruning
-            // during merges drops _seq_no from soft-deleted docs, causing LuceneSyntheticSourceChangesSnapshot
-            // to miss DELETE tombstones and stale ops.
-            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), false)
+            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
             .build();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2056,6 +2056,54 @@ public class InternalEngineTests extends EngineTestCase {
         assertOpsOnReplica(ops, replicaEngine, true, logger);
     }
 
+    /**
+     * Reproduces the primary/replica divergence tracked in
+     * <a href="https://github.com/elastic/elasticsearch/issues/150408">#150408</a> on a plain (non-columnar) index, showing the bug
+     * depends only on {@link IndexSettings#sequenceNumbersDisabled()} and not on the columnar index mode.
+     *
+     * <p>Two replica writes for the same document arrive out of order (higher seq_no first, then a stale lower seq_no write) with a
+     * refresh in between so the id is evicted from the version map and the conflict must be resolved against Lucene. The document with
+     * the highest seq_no must always win regardless of application order. When sequence numbers are disabled,
+     * {@code InternalEngine#compareOpToLuceneDocBasedOnSeqNo} resolves against Lucene with {@code loadSeqNo=false}, so
+     * {@code VersionsAndSeqNoResolver#loadDocIdAndSeqNo} returns {@code UNASSIGNED_SEQ_NO} and the stale op is wrongly considered
+     * newer, overwriting the live document.
+     */
+    public void testOutOfOrderReplicaWritesWithSequenceNumbersDisabledConverge() throws Exception {
+        IOUtils.close(engine, store);
+        final SeqNoFieldMapper.SeqNoIndexOptions previousSeqNoIndexOptions = seqNoIndexOptions;
+        try {
+            // Sequence numbers cannot be trimmed for points, so DISABLE_SEQUENCE_NUMBERS requires doc-values-only seq_no.
+            seqNoIndexOptions = SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY;
+            final Settings settings = Settings.builder()
+                .put(indexSettings())
+                .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
+                .build();
+            final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("index", settings);
+            assertTrue("this test requires sequence numbers to be disabled", indexSettings.sequenceNumbersDisabled());
+            // config() reads the shared mapperService field, so it must reflect the doc-values-only seq_no options above.
+            mapperService = createMapperService(settings, defaultMapping(), extraMappers());
+            store = createStore();
+            engine = createEngine(config(indexSettings, store, createTempDir(), newMergePolicy()));
+
+            // Model the primary having observed an update at seq_no 1 so the replica resolves the conflict against Lucene rather than
+            // taking the append-only optimization.
+            engine.advanceMaxSeqNoOfUpdatesOrDeletes(1L);
+            // The higher seq_no write arrives first and becomes the live document.
+            engine.index(replicaIndexForDoc(parseDocument(mapperService, "1", null), 2L, 1L, false));
+            // Refresh so the id is evicted from the version map, forcing the next op to resolve against Lucene.
+            engine.refresh("test");
+            // The stale write (lower seq_no) arrives late; it must not overwrite the higher seq_no document.
+            engine.index(replicaIndexForDoc(parseDocument(mapperService, "1", null), 1L, 0L, false));
+            engine.refresh("test");
+
+            final List<DocIdSeqNoAndSource> docs = getDocIds(engine, true);
+            assertThat(docs, hasSize(1));
+            assertThat("the document with the highest seq_no must remain live", docs.get(0).seqNo(), equalTo(1L));
+        } finally {
+            seqNoIndexOptions = previousSeqNoIndexOptions;
+        }
+    }
+
     public void testConcurrentOutOfOrderDocsOnReplica() throws IOException, InterruptedException {
         final List<Engine.Operation> opsDoc1 = generateSingleDocHistory(
             true,
@@ -5047,19 +5095,20 @@ public class InternalEngineTests extends EngineTestCase {
         }
     }
 
-    public void testLoadDocIdAndSeqNoWithLoadSeqNoFalse() throws IOException {
+    public void testLoadDocIdAndSeqNoLenient() throws IOException {
         indexDoc(engine, indexForDoc(createParsedDoc("1", null)));
         engine.refresh("test");
 
         try (Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL)) {
-            DocIdAndSeqNo withSeqNo = VersionsAndSeqNoResolver.loadDocIdAndSeqNo(searcher.getIndexReader(), Uid.encodeId("1"), true);
-            assertNotNull(withSeqNo);
-            assertThat(withSeqNo.seqNo, greaterThanOrEqualTo(0L));
+            // A retained (non-pruned) _seq_no doc value is read and returned regardless of leniency: strict and lenient loads agree.
+            DocIdAndSeqNo strict = VersionsAndSeqNoResolver.loadDocIdAndSeqNo(searcher.getIndexReader(), Uid.encodeId("1"), false);
+            assertNotNull(strict);
+            assertThat(strict.seqNo, greaterThanOrEqualTo(0L));
 
-            DocIdAndSeqNo withoutSeqNo = VersionsAndSeqNoResolver.loadDocIdAndSeqNo(searcher.getIndexReader(), Uid.encodeId("1"), false);
-            assertNotNull(withoutSeqNo);
-            assertThat(withoutSeqNo.seqNo, equalTo(UNASSIGNED_SEQ_NO));
-            assertThat(withoutSeqNo.docId, equalTo(withSeqNo.docId));
+            DocIdAndSeqNo lenient = VersionsAndSeqNoResolver.loadDocIdAndSeqNo(searcher.getIndexReader(), Uid.encodeId("1"), true);
+            assertNotNull(lenient);
+            assertThat(lenient.seqNo, equalTo(strict.seqNo));
+            assertThat(lenient.docId, equalTo(strict.docId));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.DocIdSeqNoAndSource;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.EngineTestCase;
@@ -703,6 +704,59 @@ public class IndexLevelReplicationTests extends ESIndexLevelReplicationTestCase 
             deleteOnReplica(deleteRequest, shards, replica);
             indexOnReplica(indexRequest, shards, replica);
             shards.assertAllEqual(0);
+        }
+    }
+
+    /**
+     * Reproduces the primary/replica divergence tracked in
+     * <a href="https://github.com/elastic/elasticsearch/issues/150408">#150408</a> at the replication-group level, exercising the real
+     * replication code path rather than the engine in isolation.
+     *
+     * <p>Two writes for the same document are applied in order on the primary (an update), so the higher seq_no wins there. They are then
+     * delivered <em>out of order</em> on the replica (higher seq_no first, then the stale lower seq_no) with a refresh in between so the id
+     * is evicted from the version map and the stale op must resolve against Lucene. On sequence-number-disabled indices the replica must
+     * still keep the highest seq_no document so that primary and replica converge. Before the fix the replica read a pruned/absent
+     * {@code _seq_no} as {@code UNASSIGNED_SEQ_NO}, treated the stale op as newer, and diverged from the primary.
+     */
+    public void testOutOfOrderReplicaWritesConvergeWithSequenceNumbersDisabled() throws Exception {
+        final Settings settings = Settings.builder()
+            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
+            .put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY.name())
+            .build();
+        // Pre-register field "f" in the mapping: the test framework uses a no-op mapping updater, so a document that triggers a dynamic
+        // mapping update on the primary would hang waiting for a master update that never happens.
+        final String mappings = """
+            { "_doc": { "properties": { "f": { "type": "keyword"} }}}""";
+        try (ReplicationGroup shards = new ReplicationGroup(buildIndexMetadata(1, settings, mappings))) {
+            shards.startAll();
+            final IndexShard primary = shards.getPrimary();
+            final IndexShard replica = shards.getReplicas().get(0);
+
+            // Two writes for the same id, applied in order on the primary: the second (higher seq_no) becomes the live document.
+            final BulkShardRequest staleWrite = indexOnPrimary(
+                new IndexRequest(index.getName()).id("1").source("{\"f\":\"stale\"}", XContentType.JSON),
+                primary
+            );
+            final BulkShardRequest freshWrite = indexOnPrimary(
+                new IndexRequest(index.getName()).id("1").source("{\"f\":\"fresh\"}", XContentType.JSON),
+                primary
+            );
+
+            // Deliver the writes out of order on the replica: the higher seq_no first ...
+            indexOnReplica(freshWrite, shards, replica);
+            // ... refresh so the id is evicted from the version map and the stale op must resolve against Lucene ...
+            replica.refresh("test");
+            // ... then the stale (lower seq_no) write, which must not overwrite the higher seq_no document.
+            indexOnReplica(staleWrite, shards, replica);
+
+            primary.refresh("test");
+            final List<DocIdSeqNoAndSource> primaryDocs = getDocIdAndSeqNos(primary);
+            assertThat(primaryDocs, hasSize(1));
+            assertThat(
+                "primary and replica must converge on the highest seq_no document",
+                getDocIdAndSeqNos(replica),
+                equalTo(primaryDocs)
+            );
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix replica divergence on sequence numbers disabled indices (#158870)