### PR TITLE
[Docs] Update applicability tags for Vector Database project type

### DIFF
--- a/docs/reference/elasticsearch/columnar/index.md
+++ b/docs/reference/elasticsearch/columnar/index.md
@@ -2,7 +2,11 @@
 navigation_title: Columnar
 applies_to:
   stack: preview 9.5
-  serverless: preview
+  serverless:
+    elasticsearch: preview
+    observability: preview
+    security: preview
+    vectordb: unavailable
 ---
 
 # Columnar index mode [columnar-index-mode]

--- a/docs/reference/elasticsearch/index-settings/index-modules.md
+++ b/docs/reference/elasticsearch/index-settings/index-modules.md
@@ -64,14 +64,14 @@ $$$index-mode-setting$$$ `index.mode` {applies_to}`serverless: all`
       1. This index uses the `standard` index mode
 
     The `index.mode` setting supports the following values:
-       - `null`:   Default value (same as `standard`).
-       -  `standard`:   Standard indexing with default settings.
-       -  `lookup`: Index that can be used for [LOOKUP JOIN](/reference/query-languages/esql/esql-lookup-join.md) in ES|QL. Limited to 1 shard.
-       - `time_series`:   *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md).
-       - `logsdb`: Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md).
+       - `null`:   Default value (same as `standard`). {applies_to}`vectordb: unavailable`
+       -  `standard`:   Standard indexing with default settings. {applies_to}`vectordb: unavailable`
+       -  `lookup`: Index that can be used for [LOOKUP JOIN](/reference/query-languages/esql/esql-lookup-join.md) in ES|QL. Limited to 1 shard. {applies_to}`vectordb: unavailable`
+       - `time_series`:   *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md). {applies_to}`vectordb: unavailable`
+       - `logsdb`: Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md). {applies_to}`vectordb: unavailable`
        - `vectordb_document` {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga`: Index mode optimized for vector search use cases. Applies settings and defaults tuned for indexing, merging, and searching dense vector data. For details, see [Index modes for vector search](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-index-modes).
-       - `columnar`: {applies_to}`stack: preview 9.5+`  {applies_to}`serverless: preview` Index mode that turns {{es}} into a full analytical and search columnar store. Fields are stored once as doc values with no inverted index or BKD tree by default. For more information, refer to [Columnar index mode](/reference/elasticsearch/columnar/index.md).
-       - `logsdb_columnar`: {applies_to}`stack: preview 9.5+`  {applies_to}`serverless: preview` Columnar index mode with logging-oriented defaults, including a default `@timestamp` mapping. For more information, refer to [Columnar index mode](/reference/elasticsearch/columnar/index.md).
+       - `columnar`: {applies_to}`stack: preview 9.5+` {applies_to}`elasticsearch: preview` {applies_to}`observability: preview` {applies_to}`security: preview` {applies_to}`vectordb: unavailable` Index mode that turns {{es}} into a full analytical and search columnar store. Fields are stored once as doc values with no inverted index or BKD tree by default. For more information, refer to [Columnar index mode](/reference/elasticsearch/columnar/index.md).
+       - `logsdb_columnar`: {applies_to}`stack: preview 9.5+` {applies_to}`elasticsearch: preview` {applies_to}`observability: preview` {applies_to}`security: preview` {applies_to}`vectordb: unavailable` Columnar index mode with logging-oriented defaults, including a default `@timestamp` mapping. For more information, refer to [Columnar index mode](/reference/elasticsearch/columnar/index.md).
 
 $$$routing-partition-size$$$ `index.routing_partition_size`
 :   The number of shards a custom routing value can go to. Defaults to 1 and can only be set at index creation time. This value must be less than `index.number_of_shards` unless the value is also 1. For more details about how this setting is used, refer to [](/reference/elasticsearch/mapping-reference/mapping-routing-field.md#routing-index-partition).

--- a/docs/reference/elasticsearch/index-settings/time-series.md
+++ b/docs/reference/elasticsearch/index-settings/time-series.md
@@ -4,7 +4,11 @@ mapped_pages:
 navigation_title: Time series
 applies_to:
   stack: all
-  serverless: all
+  serverless:
+    elasticsearch: all
+    observability: all
+    security: all
+    vectordb: unavailable
 ---
 
 # Time series index settings [tsds-index-settings]
@@ -16,27 +20,27 @@ Backing indices in a [time series data stream (TSDS)](docs-content://manage-data
 
 $$$index-mode$$$
 
-`index.mode` {applies_to}`serverless: all`
+`index.mode`
 :   (Static, string) Mode for the index. Valid values are [`time_series`](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md#time-series-mode) and `null` (no mode). Defaults to `null`.
 
 $$$index-time-series-start-time$$$
 
-`index.time_series.start_time` {applies_to}`serverless: all`
+`index.time_series.start_time`
 :   (Static, string) Earliest `@timestamp` value (inclusive) accepted by the index. Only indices with an `index.mode` of [`time_series`](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md#time-series-mode) support this setting. For more information, refer to [Time-bound indices](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md#time-bound-indices).
 
 $$$index-time-series-end-time$$$
 
-`index.time_series.end_time` {applies_to}`serverless: all`
+`index.time_series.end_time`
 :   (Dynamic, string) Latest `@timestamp` value (exclusive) accepted by the index. Only indices with an `index.mode` of `time_series` support this setting. For more information, refer to [Time-bound indices](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md#time-bound-indices).
 
 $$$index-time-series-temporality-field$$$
 
-`index.time_series.temporality_field` {applies_to}`stack: ga 9.5` {applies_to}`serverless: all`
+`index.time_series.temporality_field` {applies_to}`stack: ga 9.5`
 :   (Static, string) Defines the name of the field used to store metric temporality per document. Only indices with an `index.mode` of `time_series` support this setting. The field must be mapped as `keyword` and must have `time_series_dimension` set to `true`. Based on the value of this field in each document, PromQL or ES|QL `TS` queries interpret metric values differently: `delta` causes metrics to be interpreted with delta temporality semantics, and `cumulative` with cumulative temporality semantics. Any other value, including `null`, causes metrics to be interpreted with the default temporality for their metric type: cumulative for `counter`s and delta for `histogram`s.
 
 $$$index-look-ahead-time$$$
 
-`index.look_ahead_time` {applies_to}`serverless: all`
+`index.look_ahead_time`
 :   (Static, [time units](/reference/elasticsearch/rest-apis/api-conventions.md#time-units)) Interval used to calculate the `index.time_series.end_time` for a TSDS’s write index. Defaults to `30m` (30 minutes). Accepts `1m` (one minute) to `2h` (two hours). Only indices with an `index.mode` of `time_series` support this setting. For more information, refer to [Look-ahead time](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md#tsds-look-ahead-time). Additionally this setting can not be less than `time_series.poll_interval` cluster setting.
 
 ::::{note}
@@ -46,10 +50,10 @@ Increasing the `look_ahead_time` will also increase the amount of time {{ilm-cap
 
 $$$index-look-back-time$$$
 
-`index.look_back_time` {applies_to}`serverless: all`
+`index.look_back_time`
 :   (Static, [time units](/reference/elasticsearch/rest-apis/api-conventions.md#time-units)) Interval used to calculate the `index.time_series.start_time` for a TSDS’s first backing index when a tsdb data stream is created. Defaults to `2h` (2 hours). Accepts `1m` (one minute) to `7d` (seven days). Only indices with an `index.mode` of `time_series` support this setting. For more information, refer to [Look-back time](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md#tsds-look-back-time).
 
-$$$index-routing-path$$$ `index.routing_path` {applies_to}`serverless: all`
+$$$index-routing-path$$$ `index.routing_path`
 :   (Static, string or array of strings) Time series dimension fields used to route documents in a TSDS to index shards.
 Supports wildcards (`*`).
 Only indices with an `index.mode` of `time_series` support this setting.
@@ -67,7 +71,7 @@ For more information, refer to [Dimension-based routing](docs-content://manage-d
 
 $$$index-dimensions-tsid-strategy-enabled$$$
 
-`index.dimensions_tsid_strategy_enabled` {applies_to}`stack: ga 9.2` {applies_to}`serverless: all`
+`index.dimensions_tsid_strategy_enabled` {applies_to}`stack: ga 9.2`
 :   (Static, boolean) Controls if the `_tsid` can be created using the `index.dimensions` index setting.
 This is an internal setting that will be automatically populated and updated for eligible time series data streams and is not user-configurable.
 This strategy offers an improved ingestion performance that avoids processing dimensions multiple times for the purposes of shard routing and creating the `_tsid`.

--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -754,6 +754,12 @@ PUT my-vector-index
 }
 ```
 
+:::{tip}
+:applies_to: {"vectordb": "ga"}
+On [Elasticsearch Vector Database](docs-content://solutions/vector-database.md) projects, new indices use `vectordb_document` automatically. It is the only supported index mode. For details, refer to [when to use this project type](docs-content://solutions/vector-database.md#when-to-use-this-project-type).
+:::
+
+
 When `vectordb_document` mode is active, the following settings are applied automatically unless you explicitly configure them:
 
 `element_type` (dense_vector)

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -19,7 +19,7 @@ FROM <source_index>
 ## Parameters
 
 `<lookup_index>`
-:   The name of the lookup index. This must be a specific index name or alias. Wildcards and remote cluster prefixes are not supported. If the query source includes remote indices, the lookup index must exist on all involved clusters. Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting).
+:   The name of the lookup index. This must be a specific index name or alias. Wildcards and remote cluster prefixes are not supported. If the query source includes remote indices, the lookup index must exist on all involved clusters. Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting). {applies_to}`vectordb: unavailable`
 
     In cross-cluster or cross-project queries, you can prefix the index name with `_coordinator:` to run the lookup on the coordinating node of the local cluster or origin project instead of on each remote cluster or linked project. This allows `LOOKUP JOIN` to be used after pipeline-breaking commands such as `STATS`, `LIMIT`, `SORT`. {applies_to}`stack: preview 9.6+` {applies_to}`serverless: preview`
    

--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -40,7 +40,7 @@ Refer to [`LOOKUP JOIN`](/reference/query-languages/esql/commands/lookup-join.md
 The `LOOKUP JOIN` command adds fields from the lookup index as new columns to your results table based on matching values in the join field.
 
 The command requires two parameters:
-* The name of the lookup index (which must have the `lookup` [`index.mode setting`](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting))
+* The name of the lookup index (which must have the `lookup` [`index.mode setting`](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting)) {applies_to}`vectordb: unavailable`
 * The join condition. Can be one of the following:
    * A single field name
    * A comma-separated list of field names {applies_to}`stack: ga 9.2+`
@@ -213,7 +213,7 @@ Refer to the examples section of the [`LOOKUP JOIN`](/reference/query-languages/
 
 ### Index configuration
 
-Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting).
+Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting). {applies_to}`vectordb: unavailable`
 
 ### Data type compatibility
 


### PR DESCRIPTION
Part of https://github.com/elastic/docs-content-internal/issues/1780

This PR clarifies which `index.mode` values apply to Elasticsearch Vector Database Serverless projects.

* `index-modules.md` — Mark non-vector modes (standard, lookup, time_series, logsdb, columnar modes, etc.) as vectordb: unavailable; spell out ES/Obs/Sec preview for columnar modes.
* `columnar/index.md` and `time-series.md` — Page-level nested Serverless applicability with vectordb: unavailable.
* `dense-vector.md` — Tip for Vector Database: vectordb_document is applied automatically and is the only supported mode.
* LOOKUP JOIN docs — Flag the lookup index mode requirement as unavailable on Vector Database.


