### PR TITLE
Narrow five columnar dataset exclusions to per-test skips

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -161,6 +161,7 @@ c:long  | x:double  | y:double
 
 values
 required_capability: agg_values_spatial
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports
 | WHERE scalerank == 9
@@ -174,6 +175,7 @@ locations:keyword
 
 valuesGrouped
 required_capability: agg_values_spatial
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports
 | WHERE scalerank == 9
@@ -207,6 +209,7 @@ Z                    | POINT (60.900708564915 29.4752941956573)
 
 valuesGroupedByOrdinals
 required_capability: agg_values_spatial
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports
 | WHERE scalerank == 9
@@ -1789,6 +1792,7 @@ BRE      | Bremen                  | POINT(8.7858617703132 53.052287104156)   | 
 
 airportsSortDistanceFromCopenhagenTrainStationDetailsAndNonPushableEval
 required_capability: st_distance
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports
 | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")), position = location::keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
@@ -63,6 +63,7 @@ ISL|Iceland|BBOX(-24.538400, -13.499446, 66.536100, 63.390000)
 
 simpleLoadPointsAsShapes
 required_capability: spatial_shapes
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports
 | WHERE abbrev == "CPH" OR abbrev == "VLC"
@@ -93,6 +94,7 @@ CPH             |  Københavns Kommune  |  POINT(12.5683 55.6761)  |  Copenhagen
 
 pointIntersectsLiteralPolygon
 required_capability: st_intersects
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports
 | EVAL location = TO_GEOSHAPE(location)
@@ -119,6 +121,7 @@ SYX            | Sanya Phoenix Int'l  | 天涯区       | Sanya        | POINT(1
 
 pointIntersectsLiteralPolygonReversed
 required_capability: st_intersects
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports
 | EVAL location = TO_GEOSHAPE(location)
@@ -706,6 +709,7 @@ ISL|Iceland|BBOX(-2731602.192501422, -1502751.454502109, 1.0025136653899286E7, 9
 
 simpleLoadCartesianPointsAsShapes
 required_capability: spatial_shapes
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports_web
 | WHERE abbrev == "CPH" OR abbrev == "VLC"
@@ -723,6 +727,7 @@ abbrev:keyword | name:text    | scalerank:integer | type:keyword | location:cart
 
 cartesianPointIntersectsPolygon
 required_capability: st_intersects
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports_web
 | EVAL location = TO_CARTESIANSHAPE(location)

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sample.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sample.csv-spec
@@ -173,6 +173,7 @@ true
 
 sample cartesian_point
 required_capability: agg_sample
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports_web | SORT abbrev | LIMIT 3 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample::string)
 ;
@@ -206,6 +207,7 @@ sample:date_nanos
 
 sample geo_point
 required_capability: agg_sample
+skip_columnar: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals
 
 FROM airports | SORT abbrev | LIMIT 2 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample::string)
 ;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -116,23 +116,22 @@ public class CsvColumnarIT extends CsvIT {
      * fails on column types. The only failures were the {@code unmapped_fields="load"} family
      * described below, which now carry per-test {@code skip_columnar:} directives instead, so
      * these datasets are no longer excluded.
+     *
+     * <p>A second round removed {@code airports}, {@code airports_web}, {@code airports_not_indexed},
+     * {@code employees_incompatible} and {@code conv_from_keyword}. Their stated reasons were real but
+     * far narrower than a whole dataset: running them recovered 394 tests and failed only 11, all of
+     * them the geo_point precision difference, which now carries per-test directives. Prefer measuring
+     * the blast radius over trusting the reason: an entry that excludes hundreds of tests to silence a
+     * handful is worth re-checking, and a reason describing a result difference should be verified not
+     * to be an index-creation failure (the {@code doc_values:false} airports variants above were
+     * mislabelled that way).
      */
     private static final Set<String> COLUMNAR_INCOMPATIBLE_DATASETS = Set.of(
-        // index:false / doc_values:false are no-ops in strict columnar mode — every field gets
-        // doc values and is searchable — so query results differ by design from a standard index
-        // that honours those settings.
-        "airports_not_indexed",
+        // geo_point with doc_values:false cannot be rebuilt from doc values, so index creation
+        // fails with "field [location] cannot reconstruct _source from doc values". Note this is
+        // a creation failure, not the by-design result difference that index:false produces.
         "airports_no_doc_values",
         "airports_not_indexed_nor_doc_values",
-        // geo_point fields are stored at different precision in columnar mode: to_string() returns
-        // slightly different coordinates (e.g. "POINT (116.072 5.975)" vs "POINT (116.073 5.975)").
-        // See CrossIndexModeGenerativeRestRunner.EXCLUDED_DATASETS.
-        "airports",
-        "airports_web",
-        // Mapping designed to be type-incompatible with the standard employees dataset; its CSV
-        // data contains deliberate duplicates in boolean MV fields (e.g. [false,true,true]).
-        // SortedSetDocValues deduplicates those in standard mode while columnar may preserve them.
-        "employees_incompatible",
         // Contains a plain txt:text field with no doc_values; fails index creation in columnar
         // mode because text without doc_values cannot be reconstructed from doc values.
         "text_state_mapped",
@@ -142,10 +141,6 @@ public class CsvColumnarIT extends CsvIT {
         // cartesian_shape field with doc_values:false cannot be reconstructed from doc values
         // in columnar mode: "field [shape] cannot reconstruct _source from doc values".
         "cartesian_multipolygons_no_doc_values",
-        // index.mapping.index_disabled_by_default=true disables the inverted index for fields
-        // without an explicit "index: true", so full-text (:) queries return different results
-        // between standard and columnar modes.
-        "conv_from_keyword",
         // Mappings that disable or exclude _source are rejected by columnar mode:
         // "Failed to parse mapping: _source can not be disabled in index using [columnar] index mode".
         // These datasets test _source-disabled / _source-excluded query behavior, which does not
@@ -154,12 +149,13 @@ public class CsvColumnarIT extends CsvIT {
         "partial_mapping_mv_no_source_sample_data",
         "partial_mapping_excluded_source_sample_data",
         // LOAD_ALL / LOAD from source loads unmapped fields directly from the stored _source.
-        // In columnar mode, _source is synthetic (reconstructed from doc values), so unmapped
-        // fields — fields that exist in the stored document but have no mapping entry — are not
-        // available. All unmapped-load-all tests and the unmapped-load tests that load fields
-        // absent from the mapping therefore produce 0-column / 0-row results in columnar mode.
+        // In columnar mode _source is synthetic, so fields absent from the mapping are gone. Nearly
+        // every test reaching these two datasets exercises exactly that, so a per-test directive
+        // would mean ~230 of them; the dataset-level exclusion stays.
         "partial_mapping_sample_data",
         "partial_mapping_mv_sample_data",
+        // Has no explicit mapping at all, so every field is unmapped and the same reasoning applies.
+        "no_mapping_sample_data",
         // Same reason, for the LOAD_ALL fixtures: all of these are dynamic:false and deliberately leave
         // everything but the mapped keys in _source / _ignored_source, which strict columnar drops at
         // ingest. synthetic_source_partial_mapping reuses mapping-partial_mapping_sample_data.json.
@@ -180,12 +176,6 @@ public class CsvColumnarIT extends CsvIT {
         "unmapped_source_excludes",
         "unmapped_source_includes",
         "unmapped_source_subobjects_false",
-        // no_mapping_sample_data has no explicit mapping; all its fields are unmapped. When
-        // combined with other indices in a multi-index query and LOAD is used to load the
-        // unmapped fields, columnar mode returns null for them (synthetic _source cannot
-        // reconstruct fields that have no mapping entry). Excluding this dataset removes all
-        // type-conflict tests that depend on unmapped-field loading from this source.
-        "no_mapping_sample_data",
         // Keyword fields with a normalizer (e.g. test_lowercase) store only the normalised form
         // in doc values, losing the original value. Columnar mode therefore cannot reconstruct
         // the original _source for these fields and rejects index creation with

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -159,6 +159,11 @@ public class CsvColumnarIT extends CsvIT {
         // Same reason, for the LOAD_ALL fixtures: all of these are dynamic:false and deliberately leave
         // everything but the mapped keys in _source / _ignored_source, which strict columnar drops at
         // ingest. synthetic_source_partial_mapping reuses mapping-partial_mapping_sample_data.json.
+        // Measured: un-excluding all seven adds 37 tests, of which 36 fail and 1 is already skipped,
+        // so not one test is recovered. The failures are the reason itself — the unmapped column is
+        // absent from the result rather than merely wrong. Unlike the airports entries above, the
+        // blast radius here is exactly the genuine-failure set, so dataset level is the right
+        // granularity. No need to re-measure.
         "unmapped_multi_stored_foo",
         "unmapped_multi_stored_bar",
         "unmapped_multi_synthetic",


### PR DESCRIPTION
CsvColumnarIT excluded 25 datasets outright. Five of them were excluded for reasons that were real but far narrower than a whole dataset, so they dropped 394 tests to silence 11.

Un-exclude airports, airports_web, airports_not_indexed, employees_incompatible and conv_from_keyword. Only 11 tests fail, all of them the geo_point precision difference already named in the original comment: columnar rebuilds point coordinates from quantized doc values, so rendered coordinates differ from the _source values in the last decimals. Those carry skip_columnar directives instead.

Two entries were also mislabelled. airports_no_doc_values and airports_not_indexed_nor_doc_values were filed under "index:false is a no-op in columnar", a result difference, but doc_values:false on a geo_point fails index creation outright, which cascades across the shared dataset loading rather than failing one test. They stay excluded with a corrected comment.

The unmapped_fields="load" datasets stay excluded: nearly every test reaching them exercises the loading path that strict columnar drops at ingest, so per-test directives would mean roughly 230 of them.

383 tests now execute that previously did not.

The second commit resolves the other standing assumption in that list. The seven LOAD_ALL fixtures were excluded on the assumption that they fail for the documented unmapped reason, but that was never run. It holds exactly: un-excluding all seven adds 37 tests, of which 36 fail and 1 is already skipped, so not one test is recovered, and the failures are the reason itself rather than a value difference (the unmapped column is absent from the result). Blast radius equals the genuine-failure set, so dataset level is the right granularity there. The measurement is recorded in the comment so it is not repeated.