### PR TITLE
Allow security refresh interval updates

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/settings/UpdateSecuritySettingsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/settings/UpdateSecuritySettingsAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -53,6 +54,8 @@ public class UpdateSecuritySettingsAction {
             (it, ex) -> ex, // no additional validation
             IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS,
             (it, ex) -> ex, // no additional validation
+            IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(),
+            (it, ex) -> ex, // local-only: allow stretching .security refresh for API key grant tests
             DataTier.TIER_PREFERENCE,
             (it, ex) -> {
                 Set<String> allowedTiers = Set.of(DataTier.DATA_CONTENT, DataTier.DATA_HOT, DataTier.DATA_WARM, DataTier.DATA_COLD);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/settings/UpdateSecuritySettingsActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/settings/UpdateSecuritySettingsActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.security.action.settings;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
@@ -36,6 +37,8 @@ public class UpdateSecuritySettingsActionTests extends ESTestCase {
         () -> randomAlphaOfLength(5), // no additional validation
         IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS,
         () -> randomAlphaOfLength(5), // no additional validation
+        IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(),
+        () -> randomFrom("300s", "-1", "1s"),
         DataTier.TIER_PREFERENCE,
         () -> randomFrom(DataTier.DATA_CONTENT, DataTier.DATA_HOT, DataTier.DATA_WARM, DataTier.DATA_COLD)
     );


### PR DESCRIPTION
**Related: https://github.com/elastic/kibana/pull/290306**

## Summary

Local-only test hack: allow `index.refresh_interval` on `PUT /_security/settings` so `.security` refresh can be stretched when testing Kibana API key grants (`refresh=false`).

Not intended to merge. Opening as draft for a shareable diff, then closing.

```http
PUT /_security/settings
{
  "security": {
    "index.refresh_interval": "300s"
  }
}
```

## Test plan

- [ ] Run ES from this branch
- [ ] `PUT /_security/settings` with `index.refresh_interval: 300s` succeeds
- [ ] `GET /_security/settings` shows the new interval


Made with [Cursor](https://cursor.com)