### PR TITLE
Prune the stored _id without a recovery source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/ElasticsearchCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/ElasticsearchCodec.java
@@ -88,7 +88,7 @@ public abstract class ElasticsearchCodec extends FilterCodec {
         // into a subclass means reworking how PerFieldMapperCodec is built, so it is left for a follow-up.
         this.fieldInfosFormat = new ElasticsearchFieldInfosFormat(new ValidatingFieldInfosFormat(delegate.fieldInfosFormat(), syntheticId));
         // TSDBStoredFieldsFormat adds a reader for synthetic ids, and only for segments whose _id says it has one; writes go
-        // straight to the format underneath. Segments without a synthetic id are unaffected either way.
+        // straight to the format underneath.
         this.storedFieldsFormat = new TSDBStoredFieldsFormat(
             new ElasticsearchStoredFieldsFormat(storedFieldsMode, legacyMode, delegate.storedFieldsFormat())
         );

--- a/server/src/main/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormat.java
@@ -43,16 +43,11 @@ public class TSDBStoredFieldsFormat extends StoredFieldsFormat {
 
     @Override
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
-        if (hasSyntheticId(fn)) {
+        if (SyntheticIdField.hasSyntheticId(fn)) {
             return new TSDBStoredFieldsReader(directory, si, fn, context);
         }
         // Lucene selects its stored fields merge strategy by testing the reader against Lucene90CompressingStoredFieldsReader.
         return delegate.fieldsReader(directory, si, fn, context);
-    }
-
-    private static boolean hasSyntheticId(FieldInfos fn) {
-        var fieldInfo = fn.fieldInfo(IdFieldMapper.NAME);
-        return fieldInfo != null && SyntheticIdField.hasSyntheticIdAttributes(fieldInfo.attributes());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormat.java
@@ -43,7 +43,16 @@ public class TSDBStoredFieldsFormat extends StoredFieldsFormat {
 
     @Override
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
-        return new TSDBStoredFieldsReader(directory, si, fn, context);
+        if (hasSyntheticId(fn)) {
+            return new TSDBStoredFieldsReader(directory, si, fn, context);
+        }
+        // Lucene selects its stored fields merge strategy by testing the reader against Lucene90CompressingStoredFieldsReader.
+        return delegate.fieldsReader(directory, si, fn, context);
+    }
+
+    private static boolean hasSyntheticId(FieldInfos fn) {
+        var fieldInfo = fn.fieldInfo(IdFieldMapper.NAME);
+        return fieldInfo != null && SyntheticIdField.hasSyntheticIdAttributes(fieldInfo.attributes());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ValidatingFieldInfosFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ValidatingFieldInfosFormat.java
@@ -50,12 +50,6 @@ public final class ValidatingFieldInfosFormat extends FieldInfosFormat {
         this.requireSyntheticIdOnWrite = requireSyntheticIdOnWrite;
     }
 
-    /** Whether {@code fieldInfos} says the segment has a synthetic id, which is what makes the rest of the check apply. */
-    private static boolean hasSyntheticId(FieldInfos fieldInfos) {
-        var idFieldInfo = fieldInfos.fieldInfo(SYNTHETIC_ID);
-        return idFieldInfo != null && SyntheticIdField.hasSyntheticIdAttributes(idFieldInfo.attributes());
-    }
-
     private void ensureSyntheticIdFields(FieldInfos fieldInfos) {
         List<String> missingFields = null;
         for (String fieldName : REQUIRED_FIELDS) {
@@ -121,7 +115,7 @@ public final class ValidatingFieldInfosFormat extends FieldInfosFormat {
     @Override
     public FieldInfos read(Directory directory, SegmentInfo segmentInfo, String segmentSuffix, IOContext iocontext) throws IOException {
         final var fieldInfos = delegate.read(directory, segmentInfo, segmentSuffix, iocontext);
-        if (hasSyntheticId(fieldInfos)) {
+        if (SyntheticIdField.hasSyntheticId(fieldInfos)) {
             ensureSyntheticIdFields(fieldInfos);
         }
         return fieldInfos;

--- a/server/src/main/java/org/elasticsearch/index/engine/PruningMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/PruningMergePolicy.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.codec.FilterDocValuesProducer;
 import org.elasticsearch.index.codec.storedfields.TSDBStoredFieldsFormat;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
+import org.elasticsearch.index.mapper.SyntheticIdField;
 import org.elasticsearch.search.internal.FilterStoredFieldVisitor;
 
 import java.io.IOException;
@@ -87,9 +88,10 @@ public final class PruningMergePolicy extends OneMergeWrappingMergePolicy {
         final boolean hasSeqNo = pruneSeqNo && seqNoDocValues != null && seqNoDocValues.nextDoc() != DocIdSetIterator.NO_MORE_DOCS;
         if (hasRecoverySource == false && hasSeqNo == false) {
             if (useSyntheticId) {
+                // The _id is synthesized rather than stored, so only the reader materializing it has to go.
                 return unwrapSyntheticIdStoredFieldsReader(reader);
             }
-            return reader;  // early terminate - nothing to do here
+            return reader; // early terminate - nothing to do here
         }
         IndexSearcher s = new IndexSearcher(reader);
         s.setQueryCache(null);
@@ -162,18 +164,23 @@ public final class PruningMergePolicy extends OneMergeWrappingMergePolicy {
         @Override
         public StoredFieldsReader getFieldsReader() {
             StoredFieldsReader fieldsReader = super.getFieldsReader();
-            // Track whether we successfully unwrapped the TSDBStoredFieldsReader. If the reader is hidden behind
-            // an intermediate wrapper (e.g., MismatchedStoredFieldsReader in tests), we cannot unwrap and must use
-            // PruningStoredFieldsReader to filter out the synthetic _id during merges.
-            boolean unwrappedSyntheticId = false;
-            if (useSyntheticId && fieldsReader instanceof TSDBStoredFieldsFormat.TSDBStoredFieldsReader tsdbReader) {
+            // The codec wraps the reader only for a segment that has a synthetic id. Unwrap it where it is there, and fall back
+            // to filtering the _id out where an intermediate wrapper hides it.
+            boolean materializesSyntheticId = useSyntheticId && SyntheticIdField.hasSyntheticId(getFieldInfos());
+            if (materializesSyntheticId && fieldsReader instanceof TSDBStoredFieldsFormat.TSDBStoredFieldsReader tsdbReader) {
                 fieldsReader = tsdbReader.getStoredFieldsReader();
-                unwrappedSyntheticId = true;
+                materializesSyntheticId = false;
             }
-            if (pruneStoredFieldName == null && pruneIdField == false && (useSyntheticId == false || unwrappedSyntheticId)) {
+            if (pruneStoredFieldName == null && pruneIdField == false && materializesSyntheticId == false) {
                 return fieldsReader;
             }
-            return new PruningStoredFieldsReader(fieldsReader, recoverySourceToKeep, pruneStoredFieldName, pruneIdField, useSyntheticId);
+            return new PruningStoredFieldsReader(
+                fieldsReader,
+                recoverySourceToKeep,
+                pruneStoredFieldName,
+                pruneIdField,
+                materializesSyntheticId
+            );
         }
 
         @Override
@@ -359,6 +366,9 @@ public final class PruningMergePolicy extends OneMergeWrappingMergePolicy {
                 StoredFieldsReader fieldsReader = super.getFieldsReader();
                 if (fieldsReader instanceof TSDBStoredFieldsFormat.TSDBStoredFieldsReader tsdbReader) {
                     return tsdbReader.getStoredFieldsReader();
+                }
+                if (SyntheticIdField.hasSyntheticId(getFieldInfos()) == false) {
+                    return fieldsReader; // nothing to skip
                 }
                 // The TSDBStoredFieldsReader is hidden behind an intermediate wrapper: bulk merging is already impossible in this case so
                 // we fall back to skipping _id via a visitor filter.

--- a/server/src/main/java/org/elasticsearch/index/engine/PruningMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/PruningMergePolicy.java
@@ -91,6 +91,18 @@ public final class PruningMergePolicy extends OneMergeWrappingMergePolicy {
                 // The _id is synthesized rather than stored, so only the reader materializing it has to go.
                 return unwrapSyntheticIdStoredFieldsReader(reader);
             }
+            if (pruneIdField) {
+                // A time series _id is recomputed from the _tsid and @timestamp, so a merge drops the stored one.
+                return new PruningFilterCodecReader(
+                    pruneStoredFieldName,
+                    pruneNumericDVFieldName,
+                    pruneIdField,
+                    pruneSeqNo,
+                    reader,
+                    null,
+                    useSyntheticId
+                );
+            }
             return reader; // early terminate - nothing to do here
         }
         IndexSearcher s = new IndexSearcher(reader);

--- a/server/src/main/java/org/elasticsearch/index/mapper/SyntheticIdField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SyntheticIdField.java
@@ -15,6 +15,7 @@ import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat;
@@ -85,6 +86,12 @@ public final class SyntheticIdField extends Field {
     public void setTokenStream(TokenStream tokenStream) {
         assert false : "this should never be called";
         throw new UnsupportedOperationException();
+    }
+
+    /** Whether {@code fieldInfos} says the segment holds a synthetic id, which is what the formats keyed on it check for. */
+    public static boolean hasSyntheticId(FieldInfos fieldInfos) {
+        var fieldInfo = fieldInfos.fieldInfo(NAME);
+        return fieldInfo != null && hasSyntheticIdAttributes(fieldInfo.attributes());
     }
 
     public static boolean hasSyntheticIdAttributes(Map<String, String> attributes) {

--- a/server/src/test/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormatTests.java
@@ -13,7 +13,13 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingStoredFieldsReader;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.BaseStoredFieldsFormatTestCase;
@@ -25,6 +31,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormatTests.runTestWithRandomDocs;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class TSDBStoredFieldsFormatTests extends BaseStoredFieldsFormatTestCase {
 
@@ -66,6 +73,23 @@ public class TSDBStoredFieldsFormatTests extends BaseStoredFieldsFormatTestCase 
                 }
             }
         });
+    }
+
+    /**
+     * A segment without a synthetic id keeps the reader type Lucene tests for when it selects a stored fields merge strategy.
+     */
+    public void testSegmentWithoutSyntheticIdIsBulkMergeable() throws Exception {
+        try (var directory = newDirectory(); var writer = new IndexWriter(directory, newIndexWriterConfig().setCodec(getCodec()))) {
+            var document = new Document();
+            document.add(new StringField(IdFieldMapper.NAME, "1", Field.Store.YES));
+            writer.addDocument(document);
+            // Read through the writer: reopening from the directory resolves the codec by name via SPI.
+            try (var reader = DirectoryReader.open(writer)) {
+                var fieldsReader = ((CodecReader) reader.leaves().getFirst().reader()).getFieldsReader();
+                assertThat(fieldsReader, instanceOf(Lucene90CompressingStoredFieldsReader.class));
+                assertThat(fieldsReader.getMergeInstance(), instanceOf(Lucene90CompressingStoredFieldsReader.class));
+            }
+        }
     }
 
     public void testSegmentsWithoutASyntheticIdReader() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingStoredFieldsReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -646,9 +647,8 @@ public class PruningMergePolicyTests extends ESTestCase {
                         );
                         var forcedMerges = mp.findForcedDeletesMerges(Lucene.readSegmentInfos(reader.getIndexCommit()), newMergeContext());
                         var wrappedForMerge = forcedMerges.merges.get(0).wrapForMerge(codecReader);
-                        // Should Lucene90CompressingStoredFieldsReader or newer
-                        assertThat(wrappedForMerge.getFieldsReader(), not(instanceOf(TSDBStoredFieldsFormat.TSDBStoredFieldsReader.class)));
-                        assertThat(wrappedForMerge.getFieldsReader(), not(instanceOf(TSDBSyntheticIdStoredFieldsReader.class)));
+                        // The reader Lucene tests for when it picks a stored fields merge strategy
+                        assertThat(wrappedForMerge.getFieldsReader(), instanceOf(Lucene90CompressingStoredFieldsReader.class));
                     }
 
                 }
@@ -704,8 +704,7 @@ public class PruningMergePolicyTests extends ESTestCase {
                 );
                 var forcedMerges = mp.findForcedDeletesMerges(Lucene.readSegmentInfos(reader.getIndexCommit()), newMergeContext());
                 var wrappedForMerge = forcedMerges.merges.get(0).wrapForMerge(codecReader);
-                assertThat(wrappedForMerge.getFieldsReader(), not(instanceOf(TSDBStoredFieldsFormat.TSDBStoredFieldsReader.class)));
-                assertThat(wrappedForMerge.getFieldsReader(), not(instanceOf(TSDBSyntheticIdStoredFieldsReader.class)));
+                assertThat(wrappedForMerge.getFieldsReader(), instanceOf(Lucene90CompressingStoredFieldsReader.class));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
@@ -87,6 +87,7 @@ import static org.elasticsearch.index.mapper.IdFieldMapper.syntheticIdField;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
@@ -175,8 +176,14 @@ public class PruningMergePolicyTests extends ESTestCase {
                                         segmentInfos,
                                         newMergeContext()
                                     );
-                                    // don't wrap if there is nothing to do
-                                    assertSame(codecReader, forcedMerges.merges.get(0).wrapForMerge(codecReader));
+                                    var wrappedForMerge = forcedMerges.merges.get(0).wrapForMerge(codecReader);
+                                    if (pruneIdField) {
+                                        // an index that prunes its _id does so on every merge
+                                        assertNotSame(codecReader, wrappedForMerge);
+                                    } else {
+                                        // don't wrap if there is nothing to do
+                                        assertSame(codecReader, wrappedForMerge);
+                                    }
                                 }
                             }
                         }
@@ -706,6 +713,75 @@ public class PruningMergePolicyTests extends ESTestCase {
                 var wrappedForMerge = forcedMerges.merges.get(0).wrapForMerge(codecReader);
                 assertThat(wrappedForMerge.getFieldsReader(), instanceOf(Lucene90CompressingStoredFieldsReader.class));
             }
+        }
+    }
+
+    /** A time series merge drops the stored {@code _id} even with no recovery source to prune it alongside. */
+    public void testPrunesStoredIdWithoutRecoverySource() throws IOException {
+        try (var dir = indexWithStoredId(true)) {
+            assertThat(storedFieldNames(dir), not(hasItem(IdFieldMapper.NAME)));
+            // and on every merge after that
+            assertThat(isWrappedForMerge(dir, true), equalTo(true));
+        }
+        // a non-tsdb index keeps its _id and is never wrapped
+        try (var dir = indexWithStoredId(false)) {
+            assertThat(storedFieldNames(dir), hasItem(IdFieldMapper.NAME));
+            assertThat(isWrappedForMerge(dir, false), equalTo(false));
+        }
+    }
+
+    private static PruningMergePolicy noRecoverySourcePolicy(boolean tsdb) {
+        return new PruningMergePolicy(
+            SourceFieldMapper.RECOVERY_SOURCE_NAME,
+            SourceFieldMapper.RECOVERY_SOURCE_NAME,
+            tsdb,
+            false,
+            () -> Queries.ALL_DOCS_INSTANCE,
+            newLogMergePolicy(),
+            false
+        );
+    }
+
+    /** Indexes documents with a stored _id and no recovery source, then force merges them into one segment. */
+    private static Directory indexWithStoredId(boolean tsdb) throws IOException {
+        var dir = newDirectory();
+        dir.setCheckIndexOnClose(false);
+        var iwc = new IndexWriterConfig(null).setMergePolicy(noRecoverySourcePolicy(tsdb));
+        try (var writer = new IndexWriter(dir, iwc)) {
+            for (int i = 0; i < 20; i++) {
+                var doc = new Document();
+                doc.add(new StringField(IdFieldMapper.NAME, "id-" + i, Field.Store.YES));
+                doc.add(new StoredField("source", "hello world " + i));
+                writer.addDocument(doc);
+                if (i % 5 == 4) {
+                    writer.flush();
+                }
+            }
+            writer.forceMerge(1);
+            writer.commit();
+        }
+        return dir;
+    }
+
+    private static Set<String> storedFieldNames(Directory dir) throws IOException {
+        try (var reader = DirectoryReader.open(dir)) {
+            var names = new HashSet<String>();
+            for (var field : reader.storedFields().document(0).getFields()) {
+                names.add(field.name());
+            }
+            return names;
+        }
+    }
+
+    /** Whether a further merge of {@code dir}'s single segment would wrap the reader. */
+    private static boolean isWrappedForMerge(Directory dir, boolean tsdb) throws IOException {
+        try (var reader = DirectoryReader.open(dir)) {
+            var codecReader = (CodecReader) reader.leaves().getFirst().reader();
+            var merges = noRecoverySourcePolicy(tsdb).findForcedDeletesMerges(
+                Lucene.readSegmentInfos(reader.getIndexCommit()),
+                newMergeContext()
+            );
+            return merges.merges.get(0).wrapForMerge(codecReader) != codecReader;
         }
     }
 


### PR DESCRIPTION
A time series `_id` is recomputed from the `_tsid` and `@timestamp`, so a merge drops the stored one.
That pruning only runs inside `PruningFilterCodecReader`, which `wrapReader` builds only when there
is a recovery source or a sequence number to prune. An index that keeps no recovery source returns
early instead, and so never prunes its `_id`.

This prunes it on its own when the early return is taken, so those indices stop storing an `_id`
they can recompute.

Nothing records that an earlier merge already dropped it, so a time series index prunes on every
merge and gives up the stored fields bulk merge paths to do it. An index that does not prune ids
reaches the merge untouched.

Based on #158955.
