### PR TITLE
[9.4] [ML] Mark orphan STOPPING routes STOPPED during node shutdown (#158820)

### DIFF
--- a/docs/changelog/158820.yaml
+++ b/docs/changelog/158820.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: [158818]
+pr: 158820
+summary: STOPPING trained model routes with no local deployment process no longer block ML node shutdown during node drain
+type: bug

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -409,10 +409,11 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                     }
                 }
 
-                /*
-                 * Check if this is a shutting down node and if we can gracefully shut down the native process after draining its queues
-                 */
-                if (shouldGracefullyShutdownDeployment(trainedModelAssignment, shuttingDownNodes, currentNode)) {
+                // STOPPING with no local task means nothing to drain; waiting for other STARTED routes would leave plugin shutdown
+                // IN_PROGRESS.
+                if (shouldMarkOrphanStoppingRouteStopped(trainedModelAssignment, shuttingDownNodes, currentNode)) {
+                    markOrphanStoppingRouteStopped(trainedModelAssignment.getDeploymentId(), currentNode);
+                } else if (shouldGracefullyShutdownDeployment(trainedModelAssignment, shuttingDownNodes, currentNode)) {
                     gracefullyStopDeployment(trainedModelAssignment.getDeploymentId(), currentNode);
                 }
             } else {
@@ -479,6 +480,37 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
             trainedModelAssignment.getTaskParams().getPerDeploymentMemoryBytes(),
             trainedModelAssignment.getTaskParams().getPerAllocationMemoryBytes()
         );
+    }
+
+    private void markOrphanStoppingRouteStopped(String deploymentId, String currentNode) {
+        assert deploymentIdToTask.containsKey(deploymentId) == false : "orphan STOPPING path requires no local deployment task";
+        logger.info(
+            () -> format(
+                "[%s] Marking orphan STOPPING route as STOPPED on shutting down node %s (no local deployment task)",
+                deploymentId,
+                currentNode
+            )
+        );
+        updateStoredState(
+            deploymentId,
+            RoutingInfoUpdate.updateStateAndReason(new RoutingStateAndReason(RoutingState.STOPPED, NODE_IS_SHUTTING_DOWN)),
+            ActionListener.wrap(
+                r -> logger.debug(() -> format("[%s] Orphan STOPPING route marked STOPPED on node %s", deploymentId, currentNode)),
+                e -> logger.warn(() -> format("[%s] Failed to mark orphan STOPPING route STOPPED on node %s", deploymentId, currentNode), e)
+            )
+        );
+    }
+
+    private boolean shouldMarkOrphanStoppingRouteStopped(
+        TrainedModelAssignment trainedModelAssignment,
+        Set<String> shuttingDownNodes,
+        String currentNode
+    ) {
+        RoutingInfo routingInfo = trainedModelAssignment.getNodeRoutingTable().get(currentNode);
+        return shuttingDownNodes.contains(currentNode)
+            && routingInfo != null
+            && routingInfo.getState() == RoutingState.STOPPING
+            && deploymentIdToTask.containsKey(trainedModelAssignment.getDeploymentId()) == false;
     }
 
     private boolean shouldGracefullyShutdownDeployment(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
@@ -500,11 +500,18 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
     }
 
-    public void testClusterChanged_WhenAssignmentIsRoutedToShuttingDownNodeButAlreadyRemoved_DoesNotCallStop() {
+    public void testClusterChangedWhenStoppingRouteHasNoLocalTaskOnShuttingDownNodeShouldMarkRouteStopped() {
         final TrainedModelAssignmentNodeService trainedModelAssignmentNodeService = createService();
         final DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId(NODE_ID).add(DiscoveryNodeUtils.create(NODE_ID, NODE_ID)).build();
         String modelOne = "model-1";
         String deploymentOne = "deployment-1";
+
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            ActionListener<AcknowledgedResponse> listener = (ActionListener) invocationOnMock.getArguments()[1];
+            listener.onResponse(AcknowledgedResponse.TRUE);
+            return null;
+        }).when(trainedModelAssignmentService).updateModelAssignmentState(any(), any());
 
         var taskParams = newParams(deploymentOne, modelOne);
 
@@ -533,11 +540,73 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
 
         trainedModelAssignmentNodeService.clusterChanged(event);
 
-        verify(deploymentManager, never()).stopAfterCompletingPendingWork(any(), any());
-        verify(trainedModelAssignmentService, never()).updateModelAssignmentState(
-            any(UpdateTrainedModelAssignmentRoutingInfoAction.Request.class),
-            any()
+        ArgumentCaptor<UpdateTrainedModelAssignmentRoutingInfoAction.Request> requestCapture = ArgumentCaptor.forClass(
+            UpdateTrainedModelAssignmentRoutingInfoAction.Request.class
         );
+        verify(deploymentManager, never()).stopAfterCompletingPendingWork(any(), any());
+        verify(trainedModelAssignmentService, times(1)).updateModelAssignmentState(requestCapture.capture(), any());
+        UpdateTrainedModelAssignmentRoutingInfoAction.Request request = requestCapture.getValue();
+        assertThat(request.getNodeId(), equalTo(NODE_ID));
+        assertThat(request.getDeploymentId(), equalTo(deploymentOne));
+        assertThat(request.getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STOPPED));
+        verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
+    }
+
+    public void testClusterChangedWhenStoppingRouteHasNoLocalTaskAndOtherNodeStartingShouldMarkRouteStopped() {
+        final TrainedModelAssignmentNodeService trainedModelAssignmentNodeService = createService();
+        String node2 = "test-node-2";
+        final DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .localNodeId(NODE_ID)
+            .add(DiscoveryNodeUtils.create(NODE_ID, NODE_ID))
+            .add(DiscoveryNodeUtils.create(node2, node2))
+            .build();
+        String modelOne = "model-1";
+        String deploymentOne = "deployment-1";
+
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            ActionListener<AcknowledgedResponse> listener = (ActionListener) invocationOnMock.getArguments()[1];
+            listener.onResponse(AcknowledgedResponse.TRUE);
+            return null;
+        }).when(trainedModelAssignmentService).updateModelAssignmentState(any(), any());
+
+        var taskParams = newParams(deploymentOne, modelOne);
+
+        ClusterChangedEvent event = new ClusterChangedEvent(
+            "testClusterChanged",
+            ClusterState.builder(new ClusterName("testClusterChanged"))
+                .nodes(nodes)
+                .metadata(
+                    Metadata.builder()
+                        .putCustom(
+                            TrainedModelAssignmentMetadata.NAME,
+                            TrainedModelAssignmentMetadata.Builder.empty()
+                                .addNewAssignment(
+                                    deploymentOne,
+                                    TrainedModelAssignment.Builder.empty(taskParams, null)
+                                        .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STOPPING, ""))
+                                        .addRoutingEntry(node2, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
+                                )
+                                .build()
+                        )
+                        .putCustom(NodesShutdownMetadata.TYPE, shutdownMetadata(NODE_ID))
+                        .build()
+                )
+                .build(),
+            ClusterState.EMPTY_STATE
+        );
+
+        trainedModelAssignmentNodeService.clusterChanged(event);
+
+        ArgumentCaptor<UpdateTrainedModelAssignmentRoutingInfoAction.Request> requestCapture = ArgumentCaptor.forClass(
+            UpdateTrainedModelAssignmentRoutingInfoAction.Request.class
+        );
+        verify(deploymentManager, never()).stopAfterCompletingPendingWork(any(), any());
+        verify(trainedModelAssignmentService, times(1)).updateModelAssignmentState(requestCapture.capture(), any());
+        UpdateTrainedModelAssignmentRoutingInfoAction.Request request = requestCapture.getValue();
+        assertThat(request.getNodeId(), equalTo(NODE_ID));
+        assertThat(request.getDeploymentId(), equalTo(deploymentOne));
+        assertThat(request.getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STOPPED));
         verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
     }
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [ML] Mark orphan STOPPING routes STOPPED during node shutdown (#158820)