### PR TITLE
[9.5] [ML] Fix getFailedCategoryCount returning the dead category count (#158186)

### DIFF
--- a/docs/changelog/158186.yaml
+++ b/docs/changelog/158186.yaml
@@ -1,0 +1,5 @@
+pr: 158186
+summary: Fix `model.failed_category_count` in `_cat/ml/anomaly_detectors` reporting the dead category count
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/CategorizerStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/CategorizerStats.java
@@ -242,7 +242,7 @@ public class CategorizerStats implements ToXContentObject, Writeable {
     }
 
     public long getFailedCategoryCount() {
-        return deadCategoryCount;
+        return failedCategoryCount;
     }
 
     public CategorizationStatus getCategorizationStatus() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
@@ -442,7 +442,7 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
     }
 
     public long getFailedCategoryCount() {
-        return deadCategoryCount;
+        return failedCategoryCount;
     }
 
     public CategorizationStatus getCategorizationStatus() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/CategorizerStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/CategorizerStatsTests.java
@@ -26,6 +26,12 @@ public class CategorizerStatsTests extends AbstractXContentSerializingTestCase<C
         assertEquals(CategorizationStatus.OK, stats.getCategorizationStatus());
     }
 
+    public void testDistinctDeadAndFailedCategoryCountsShouldBeReportedIndependently() {
+        CategorizerStats stats = new CategorizerStats.Builder("foo").setDeadCategoryCount(7).setFailedCategoryCount(3).build();
+        assertEquals(7, stats.getDeadCategoryCount());
+        assertEquals(3, stats.getFailedCategoryCount());
+    }
+
     @Override
     protected CategorizerStats createTestInstance() {
         return createRandomized("foo");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStatsTests.java
@@ -41,6 +41,12 @@ public class ModelSizeStatsTests extends AbstractXContentSerializingTestCase<Mod
         assertEquals(CategorizationStatus.OK, stats.getCategorizationStatus());
     }
 
+    public void testDistinctDeadAndFailedCategoryCountsShouldBeReportedIndependently() {
+        ModelSizeStats stats = new ModelSizeStats.Builder("foo").setDeadCategoryCount(7).setFailedCategoryCount(3).build();
+        assertEquals(7, stats.getDeadCategoryCount());
+        assertEquals(3, stats.getFailedCategoryCount());
+    }
+
     public void testSetMemoryStatus_GivenNull() {
         ModelSizeStats.Builder stats = new ModelSizeStats.Builder("foo");
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ML] Fix getFailedCategoryCount returning the dead category count (#158186)