### PR TITLE
[9.4] Fix DFA rolling-upgrade mixed-cluster setup 404 (#158688)

### DIFF
--- a/x-pack/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -1,19 +1,10 @@
 setup:
   # Rolling upgrades can leave analytics tasks in a failed state when nodes restart
   # mid-run. Force-stop clears failed tasks so subsequent tests can start/stop cleanly.
+  # Use a wildcard because allow_no_match does not suppress a missing exact ID.
   - do:
       ml.stop_data_frame_analytics:
-        id: "old_cluster_outlier_detection_job"
-        force: true
-        allow_no_match: true
-  - do:
-      ml.stop_data_frame_analytics:
-        id: "old_cluster_regression_job"
-        force: true
-        allow_no_match: true
-  - do:
-      ml.stop_data_frame_analytics:
-        id: "old_cluster_classification_job"
+        id: "old_cluster_*"
         force: true
         allow_no_match: true
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix DFA rolling-upgrade mixed-cluster setup 404 (#158688)