### PR TITLE
[9.4] Enable extended doc_values flag in runtime-fields YAML tests

### DIFF
--- a/x-pack/qa/runtime-fields/core-with-mapped/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/test/mapped/CoreWithMappedRuntimeFieldsIT.java
+++ b/x-pack/qa/runtime-fields/core-with-mapped/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/test/mapped/CoreWithMappedRuntimeFieldsIT.java
@@ -33,6 +33,7 @@ public class CoreWithMappedRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "false")
         .build();

--- a/x-pack/qa/runtime-fields/core-with-search/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/test/search/CoreTestsWithSearchRuntimeFieldsIT.java
+++ b/x-pack/qa/runtime-fields/core-with-search/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/test/search/CoreTestsWithSearchRuntimeFieldsIT.java
@@ -43,6 +43,7 @@ public class CoreTestsWithSearchRuntimeFieldsIT extends ESClientYamlSuiteTestCas
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "false")
         .build();


### PR DESCRIPTION
## Summary
- Enable `FeatureFlag.EXTENDED_DOC_VALUES_PARAMS` on the runtime-fields YAML clusters (`CoreTestsWithSearchRuntimeFieldsIT` and `CoreWithMappedRuntimeFieldsIT`).
- Periodic `release-tests` uses a release distribution, so this flag is off unless the cluster spec lists it. The core YAML suite already enables it; these suites did not.
- That made `search/395_binary_doc_values_search` and `aggregations/terms_text_docvalues` fail deterministically with `Could not convert [doc_values] to boolean` / `unknown parameter [doc_values] on mapper [text_field]`.
- This happens only in the periodic 9.4 and there're 8 CI failures relate to this and they has stand out as timeout ( mis-labelled ) in the last week's CI build failure report.

This is 9.4-only. Main/9.5 already dropped configurable cardinality (#151689).