### PR TITLE
Make default-distro feature-metadata input cache-relocatable

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -223,8 +223,17 @@ public class RestTestBasePlugin implements Plugin<Project> {
                         providerFactory.provider(() -> defaultDistro.getExtracted().getSingleFile().getPath())
                     );
 
-                    // If we are using the default distribution we need to register all module feature metadata
-                    task.getInputs().files(defaultDistroFeatureMetadataConfig).withPathSensitivity(PathSensitivity.NONE);
+                    // If we are using the default distribution we need to register all module feature metadata.
+                    // The metadata is a single deterministic JSON file emitted by the cacheable
+                    // ClusterFeaturesMetadataTask, so the file name is a stable key and the content can be
+                    // compared via classpath normalization rather than byte-for-byte. This avoids pinning
+                    // the test cache key to absolute paths (PathSensitivity.NONE, the historical setting)
+                    // and lets :javaRestTest tasks that depend on a stable default distribution hit the
+                    // remote build cache across checkouts and across feature-set-only changes.
+                    task.getInputs()
+                        .files(defaultDistroFeatureMetadataConfig)
+                        .withPropertyName("defaultDistroFeatureMetadata")
+                        .withNormalizer(ClasspathNormalizer.class);
                     nonInputSystemProperties.systemProperty(TESTS_FEATURES_METADATA_PATH, defaultDistroFeatureMetadataConfig::getAsPath);
 
                     return null;

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/test/rest/RestTestBasePluginSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/test/rest/RestTestBasePluginSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public License
+ * v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test.rest
+
+import org.elasticsearch.gradle.fixtures.AbstractProjectBuilderPluginSpec
+import spock.lang.TempDir
+
+import org.gradle.api.Project
+import org.gradle.api.internal.TaskInputsInternal
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.internal.fingerprint.DirectorySensitivity
+import org.gradle.internal.fingerprint.FileNormalizer
+import org.gradle.internal.fingerprint.LineEndingSensitivity
+import org.gradle.internal.properties.InputBehavior
+import org.gradle.internal.properties.InputFilePropertyType
+import org.gradle.internal.properties.PropertyValue
+import org.gradle.internal.properties.PropertyVisitor
+
+/**
+ * Unit coverage for the cache-relocatable input wiring in {@link RestTestBasePlugin} for tasks that
+ * opt into {@code usesDefaultDistribution(...)}.
+ * <p>
+ * When a test task opts in, the plugin registers the default distribution's cluster-features metadata
+ * config as a task input. Historically this used {@code PathSensitivity.NONE} (anonymous, byte-level
+ * sensitivity) which pinned the build cache key to absolute paths and to every byte of the metadata
+ * file. The fix names the input ({@code defaultDistroFeatureMetadata}) and applies classpath
+ * normalization so the cache key is stable across checkouts and across feature-set-only changes,
+ * letting tasks like {@code :x-pack:plugin:sql:qa:server:security:with-ssl:javaRestTest} that
+ * genuinely need the default distribution still hit the remote build cache.
+ */
+class RestTestBasePluginSpec extends AbstractProjectBuilderPluginSpec {
+
+    @Override
+    Class<InternalJavaRestTestPlugin> getPluginClassUnderTest() {
+        return InternalJavaRestTestPlugin
+    }
+
+    @TempDir
+    File workspace
+
+    Project rootProject
+
+    def setup() {
+        writeMinimalElasticsearchRepoLayout(workspace)
+        // The Test task in InternalJavaRestTestPlugin triggers MutedTestsBuildService, which reads
+        // <settingsDir>/muted-tests.yml. Provide an empty stub so the service can instantiate in
+        // isolation without the full repository layout.
+        new File(workspace, "muted-tests.yml").text = "tests: []\n"
+
+        rootProject = buildProject("elasticsearch", null, workspace)
+        // RestTestBasePlugin's usesDefaultDistribution closure also touches the BWC versions loader
+        // and DistributionDownloadPlugin; the minimal layout is sufficient because we don't trigger
+        // BWC resolution here (only call usesDefaultDistribution on a single javaRestTest task).
+
+        rootProject.pluginManager.apply(JavaPlugin)
+        // InternalJavaRestTestPlugin applies RestTestBasePlugin and registers the javaRestTest task
+        // (along with javaRestTestClasses, javaRestTestJar, etc.). We use it instead of applying
+        // RestTestBasePlugin directly because the task under test is the javaRestTest task itself.
+        applyPluginUnderTest(rootProject)
+    }
+
+    def "javaRestTest feature-metadata input is named and normalized for cache relocatability"() {
+        given:
+        // Opt the javaRestTest into usesDefaultDistribution, which is what triggers the input wiring.
+        rootProject.tasks.named("javaRestTest").configure { task ->
+            task.usesDefaultDistribution("test requires default distribution")
+        }
+
+        when:
+        def task = rootProject.tasks.getByName("javaRestTest")
+        def inputs = inputFileProperties(task)
+
+        then:
+        // Classpath normalization: the metadata file's name is stable, and classpath normalization
+        // ignores manifest timestamps / line endings, so two checkouts (or two feature-set-only
+        // changes) with the same logical file fingerprint will share a cache key.
+        inputs["defaultDistroFeatureMetadata"]?.normalizer == "RUNTIME_CLASSPATH"
+        inputs["defaultDistroFeatureMetadata"]?.optional == false
+
+        and:
+        // The input must not be registered under the legacy anonymous binding that used
+        // PathSensitivity.NONE — a regression there would re-pin the cache key to absolute paths.
+        !inputs.containsKey(null)
+    }
+
+    /**
+     * Collects the registered input file properties of a task as {@code name -> [normalizer, optional]}.
+     * The normalizer is reported by its {@link org.gradle.internal.execution.model.InputNormalizer} enum
+     * constant name (e.g. {@code RUNTIME_CLASSPATH}).
+     */
+    private static Map<String, Map> inputFileProperties(def task) {
+        Map<String, Map> collected = [:]
+        ((TaskInputsInternal) task.inputs).visitRegisteredProperties(new PropertyVisitor() {
+            @Override
+            void visitInputFileProperty(
+                String propertyName,
+                boolean optional,
+                InputBehavior behavior,
+                DirectorySensitivity directorySensitivity,
+                LineEndingSensitivity lineEndingSensitivity,
+                FileNormalizer normalizer,
+                PropertyValue value,
+                InputFilePropertyType filePropertyType
+            ) {
+                collected[propertyName] = [normalizer: ((Enum) normalizer).name(), optional: optional]
+            }
+        })
+        return collected
+    }
+}


### PR DESCRIPTION
## Problem

`build-tools-internal/.../RestTestBasePlugin.java` line 227 registered the cluster-features metadata config as a task input on every javaRestTest that opts into `usesDefaultDistribution(...)`:

```java
task.getInputs().files(defaultDistroFeatureMetadataConfig).withPathSensitivity(PathSensitivity.NONE);
```

Two compounding issues:

1. **Anonymous input** — no `withPropertyName(...)`, so Gradle defaults to `ABSOLUTE_PATH` normalization. The cache key is pinned to the checkout directory, which differs across CI agents. A cache entry stored by one agent can never be looked up by the next.
2. **`PathSensitivity.NONE`** — every byte of every file in the config is fingerprinted. The metadata file is content-stable, but the surrounding input closure can shift (manifest timestamps in transitively-loaded jars, line-ending normalization on re-checkout).

Result: every javaRestTest that calls `usesDefaultDistribution(...)` was guaranteed a cache miss on every run, regardless of whether its actual code or dependencies changed.

### Concrete impact

- `:x-pack:plugin:sql:qa:server:security:with-ssl:javaRestTest` — 0% cache hits on `main` over 14d (3,085 / 3,085 executed)
- `:x-pack:plugin:sql:qa:server:security:without-ssl:javaRestTest` — 0% / 252
- `:qa:remote-clusters:javaRestTest` — 0% / 249
- `:x-pack:plugin:eql:qa:correctness:javaRestTest` — 0% / 1,551
- `:qa:stateful:test:external-modules:test-esql-heap-attack:javaRestTest` — 0% / 1,393
- `:qa:stateful:x-pack:plugin:logsdb:javaRestTest` — 0% / 1,386
- `:qa:stateful:modules:data-streams:javaRestTest` — 0% / 1,384
- `:qa:stateful:x-pack:plugin:fleet:javaRestTest` — 0% / 1,377

All 8 high-volume zero-cache-hit javaRestTest tasks use `usesDefaultDistribution(...)`. The flag is called by **75** javaRestTest projects across the tree.

## Fix

The metadata is a single deterministic JSON file emitted by the cacheable `ClusterFeaturesMetadataTask` (which is itself a `@CacheableTask` whose classpath is already classpath-normalized). Naming the input and using `ClasspathNormalizer` lets the cache key tolerate non-substantive byte changes while still being invalidated by content changes to the metadata:

```java
task.getInputs()
    .files(defaultDistroFeatureMetadataConfig)
    .withPropertyName("defaultDistroFeatureMetadata")
    .withNormalizer(ClasspathNormalizer.class);
```

This follows the same pattern as #158823 — the `:server:test` input-cache-relocatable fix that landed 2026-09-09.

## Scope / caveat

This removes one *unconditional* cache buster, but the default Elasticsearch distribution itself still rebuilds from scratch on every commit on `main` (`:distribution:assemble` shows 0% cache hits across 525 runs over 14d). So the 8 zero-cache-hit tasks above probably won't immediately move above zero on `main` — but this fix is a prerequisite, and on stable branches (`8.19` already shows 1.5% hits for the SQL Security tests), the rate should climb. A follow-up to make the default distribution itself cacheable would unlock the rest.

## Testing

New `RestTestBasePluginSpec` unit test locks in:
- Input is named `defaultDistroFeatureMetadata`
- Input is normalized via `RUNTIME_CLASSPATH` (the classpath-normalizer enum constant)
- Input is not registered under a null/anonymous binding

Verified locally:
```
./gradlew :build-tools-internal:spotlessApply   # clean
./gradlew :build-tools-internal:test \
    --tests "org.elasticsearch.gradle.internal.test.rest.RestTestBasePluginSpec"
# → BUILD SUCCESSFUL, 1 test, 0 failures
```