### PR TITLE
[9.5] [CI] Allow intake to auto-retry failing tests and pass if they are just flaky (#158206)

### DIFF
--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -59,6 +59,8 @@ steps:
           signal_reason: none
         - limit: 2
           signal_reason: agent_stop
+        - exit_status: "1"
+          limit: 1
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart2
     timeout_in_minutes: 300
@@ -84,6 +86,8 @@ steps:
           signal_reason: none
         - limit: 2
           signal_reason: agent_stop
+        - exit_status: "1"
+          limit: 1
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart3
     timeout_in_minutes: 300
@@ -109,6 +113,8 @@ steps:
           signal_reason: none
         - limit: 2
           signal_reason: agent_stop
+        - exit_status: "1"
+          limit: 1
   - label: part4
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart4
     timeout_in_minutes: 300
@@ -134,6 +140,8 @@ steps:
           signal_reason: none
         - limit: 2
           signal_reason: agent_stop
+        - exit_status: "1"
+          limit: 1
   - label: part5
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart5
     timeout_in_minutes: 300
@@ -159,6 +167,8 @@ steps:
           signal_reason: none
         - limit: 2
           signal_reason: agent_stop
+        - exit_status: "1"
+          limit: 1
   - label: part6
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart6
     timeout_in_minutes: 300
@@ -184,6 +194,8 @@ steps:
           signal_reason: none
         - limit: 2
           signal_reason: agent_stop
+        - exit_status: "1"
+          limit: 1
 
   - group: bwc-snapshots
     steps:
@@ -217,6 +229,8 @@ steps:
               signal_reason: none
             - limit: 2
               signal_reason: agent_stop
+            - exit_status: "1"
+              limit: 1
   - label: bc-upgrade
     command: ".buildkite/scripts/run-bc-upgrade-tests.sh"
   - group: lucene-compat


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[CI] Allow intake to auto-retry failing tests and pass if they are just flaky (#158206)](https://github.com/elastic/elasticsearch/pull/158206)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)