### PR TITLE
ESQL: Run logical optimizer test suites at current + random transport version

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/InsertDefaultInnerTimeSeriesAggregateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/InsertDefaultInnerTimeSeriesAggregateTests.java
@@ -38,6 +38,10 @@ public class InsertDefaultInnerTimeSeriesAggregateTests extends AbstractLogicalP
 
     private final InsertDefaultInnerTimeSeriesAggregate rule = new InsertDefaultInnerTimeSeriesAggregate();
 
+    public InsertDefaultInnerTimeSeriesAggregateTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testSimpleImplicitOverTime() {
         assertStatsEqual("network.bytes_in", "last_over_time(network.bytes_in)");
         assertStatsEqual("sum(network.bytes_in)", "sum(last_over_time(network.bytes_in))");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLogicalPlanOptimizerTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.optimizer;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.metadata.DataSourceReference;
 import org.elasticsearch.cluster.metadata.Dataset;
@@ -15,10 +17,15 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.TestAnalyzer;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.datasources.DatasetRewriter;
@@ -26,35 +33,87 @@ import org.elasticsearch.xpack.esql.datasources.metadata.DataSource;
 import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValues;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.PackDimsAgg;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.IndexProperties;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.PackDims;
+import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
 import org.junit.BeforeClass;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.unboundLogicalOptimizerContext;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
+/**
+ * Every test in this hierarchy runs twice. {@code current} pins {@link TransportVersion#current()} on both the analyzer and
+ * the optimizer so a version-gated plan change is exercised in its own PR; {@code historical} draws one random compatible
+ * version per test instance. Analyzer and optimizer of one instance share that version, as a real coordinator's do, unless an
+ * analyzer needs a feature floor above it ({@link #minimumVersionAtLeast}) or a test optimizes with
+ * {@link #logicalOptimizerWithLatestVersion}. Before, the optimizer drew once per class and every analyzer drew on its own.
+ */
 public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
-    protected static LogicalOptimizerContext logicalOptimizerCtx;
-    protected static LogicalPlanOptimizer logicalOptimizer;
 
-    protected static LogicalPlanOptimizer logicalOptimizerWithLatestVersion;
+    /** The two runs of each test; {@link #toString()} is the parameter name shown in the test name. */
+    public enum VersionMode {
+        CURRENT(TransportVersion::current),
+        HISTORICAL(EsqlTestUtils::randomMinimumVersion);
+
+        private final Supplier<TransportVersion> version;
+
+        VersionMode(Supplier<TransportVersion> version) {
+            this.version = version;
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    /** Inherited by every subclass, which only needs a constructor passing the mode up. */
+    @ParametersFactory(argumentFormatting = "%1$s")
+    public static List<Object[]> params() {
+        return List.of(new Object[] { VersionMode.CURRENT }, new Object[] { VersionMode.HISTORICAL });
+    }
+
+    protected final VersionMode versionMode;
+    protected final TransportVersion minimumVersion;
+    protected final LogicalOptimizerContext logicalOptimizerCtx;
+    protected final LogicalPlanOptimizer logicalOptimizer;
+
+    protected final LogicalPlanOptimizer logicalOptimizerWithLatestVersion;
 
     protected static Map<String, EsField> mapping;
+
+    // Built in the constructor rather than @Before so subclass field initializers can already use the version.
+    protected AbstractLogicalPlanOptimizerTests(VersionMode versionMode) {
+        this.versionMode = versionMode;
+        minimumVersion = versionMode.version.get();
+        logicalOptimizerCtx = new LogicalOptimizerContext(EsqlTestUtils.TEST_CFG, FoldContext.small(), minimumVersion);
+        logicalOptimizer = new LogicalPlanOptimizer(logicalOptimizerCtx);
+        logicalOptimizerWithLatestVersion = new LogicalPlanOptimizer(
+            new LogicalOptimizerContext(logicalOptimizerCtx.configuration(), logicalOptimizerCtx.foldCtx(), TransportVersion.current())
+        );
+    }
 
     public static class TestSubstitutionOnlyOptimizer extends LogicalPlanOptimizer {
         // A static instance of this would break the EsqlNodeSubclassTests because its initialization requires a Random instance.
@@ -78,45 +137,70 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
     }
 
     @BeforeClass
-    public static void init() {
-        logicalOptimizerCtx = unboundLogicalOptimizerContext();
-        logicalOptimizer = new LogicalPlanOptimizer(logicalOptimizerCtx);
-        logicalOptimizerWithLatestVersion = new LogicalPlanOptimizer(
-            new LogicalOptimizerContext(logicalOptimizerCtx.configuration(), logicalOptimizerCtx.foldCtx(), TransportVersion.current())
-        );
+    public static void initMapping() {
         mapping = loadMapping("mapping-basic.json");
     }
 
-    protected static TestAnalyzer analyzerWithEnrichPolicies() {
-        return analyzer().addEnrichPolicy(MATCH_TYPE, "languages_idx", "id", "languages_idx", "mapping-languages.json")
+    public void testAnalyzerAndOptimizerShareModeVersion() {
+        assertThat(defaultAnalyzer().buildContext().minimumVersion(), equalTo(logicalOptimizerCtx.minimumVersion()));
+        assertTrue(metricsAnalyzer().buildContext().minimumVersion().supports(DimensionValues.DIMENSION_VALUES_VERSION));
+        if (versionMode == VersionMode.CURRENT) {
+            assertThat(logicalOptimizerCtx.minimumVersion(), equalTo(TransportVersion.current()));
+        }
+    }
+
+    /** An analyzer at this instance's version; shadows {@link EsqlTestUtils#analyzer()} so every helper below shares it. */
+    protected TestAnalyzer analyzer() {
+        return EsqlTestUtils.analyzer().minimumTransportVersion(minimumVersion);
+    }
+
+    /** This instance's version, or {@code floor} when it does not support it, for analyzers that need a feature the floor gates. */
+    protected TransportVersion minimumVersionAtLeast(TransportVersion floor) {
+        assert floor.supports(PackDimsAgg.PACK_DIMS_AGG_VERSION) == false
+            : "packsDimsInAggregate() assumes every floor predates pack_dims_agg";
+        return minimumVersion.supports(floor) ? minimumVersion : floor;
+    }
+
+    private static TestAnalyzer addEnrichPolicies(TestAnalyzer analyzer) {
+        return analyzer.addEnrichPolicy(MATCH_TYPE, "languages_idx", "id", "languages_idx", "mapping-languages.json")
             .addEnrichPolicy(Enrich.Mode.REMOTE, MATCH_TYPE, "languages_remote", "id", "languages_idx", "mapping-languages.json")
             .addEnrichPolicy(Enrich.Mode.COORDINATOR, MATCH_TYPE, "languages_coordinator", "id", "languages_idx", "mapping-languages.json");
     }
 
-    protected static TestAnalyzer defaultAnalyzer() {
+    protected TestAnalyzer analyzerWithEnrichPolicies() {
+        return addEnrichPolicies(analyzer());
+    }
+
+    protected TestAnalyzer defaultAnalyzer() {
         return analyzerWithEnrichPolicies().addEmployees("test").addEmployees().addLanguagesLookup().addTestLookup().addSpatialLookup();
     }
 
-    protected static TestAnalyzer airportsAnalyzer() {
+    protected TestAnalyzer airportsAnalyzer() {
         return analyzerWithEnrichPolicies().addAirports().addLanguagesLookup().addTestLookup().addSpatialLookup();
     }
 
-    protected static TestAnalyzer typesAnalyzer() {
+    protected TestAnalyzer typesAnalyzer() {
         return analyzerWithEnrichPolicies().addAnalysisTestsInferenceResolution().addIndex("types", "mapping-all-types.json");
     }
 
-    protected static TestAnalyzer extraAnalyzer() {
+    protected TestAnalyzer extraAnalyzer() {
         return analyzerWithEnrichPolicies().addIndex("extra", "mapping-extra.json");
     }
 
-    protected static TestAnalyzer metricsAnalyzer() {
-        return analyzerWithEnrichPolicies().addIndex("exp_histo_sample", "exp_histo_sample-mappings.json", IndexMode.TIME_SERIES)
-            .addIndex("tdigest_timeseries_index", "tdigest_timeseries_index-mappings.json", IndexMode.TIME_SERIES)
-            .addK8s()
-            .minimumTransportVersion(DimensionValues.DIMENSION_VALUES_VERSION);
+    protected TestAnalyzer metricsAnalyzer() {
+        return metricsAnalyzerAt(minimumVersionAtLeast(DimensionValues.DIMENSION_VALUES_VERSION));
     }
 
-    protected static TestAnalyzer multiIndexAnalyzer() {
+    /** Exact-version variant for callers outside this hierarchy, which have no mode to follow. */
+    public static TestAnalyzer metricsAnalyzerAt(TransportVersion version) {
+        return addEnrichPolicies(EsqlTestUtils.analyzer().minimumTransportVersion(version)).addIndex(
+            "exp_histo_sample",
+            "exp_histo_sample-mappings.json",
+            IndexMode.TIME_SERIES
+        ).addIndex("tdigest_timeseries_index", "tdigest_timeseries_index-mappings.json", IndexMode.TIME_SERIES).addK8s();
+    }
+
+    protected TestAnalyzer multiIndexAnalyzer() {
         var multiIndexMapping = loadMapping("mapping-basic.json");
         EsField partialTypeKeyword = new EsField("partial_type_keyword", KEYWORD, emptyMap(), true, EsField.TimeSeriesFieldType.NONE);
         multiIndexMapping.put(
@@ -133,7 +217,7 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
         return analyzerWithEnrichPolicies().addIndex(multiIndex);
     }
 
-    protected static TestAnalyzer unionIndexAnalyzer() {
+    protected TestAnalyzer unionIndexAnalyzer() {
         var typesToIndices_languages = new LinkedHashMap<String, Set<String>>();
         typesToIndices_languages.put("byte", Set.of("union_types_index"));
         typesToIndices_languages.put("integer", Set.of("union_types_index_incompatible"));
@@ -174,11 +258,11 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
             .addSpatialLookup();
     }
 
-    protected static TestAnalyzer sampleDataAnalyzer() {
+    protected TestAnalyzer sampleDataAnalyzer() {
         return analyzerWithEnrichPolicies().addSampleData();
     }
 
-    protected static TestAnalyzer subqueryAnalyzer() {
+    protected TestAnalyzer subqueryAnalyzer() {
         return analyzerWithEnrichPolicies().addEmployees("test")
             .addLanguages()
             .addSampleData()
@@ -193,7 +277,7 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
             .addSpatialLookup();
     }
 
-    protected static TestAnalyzer baseConversionAnalyzer() {
+    protected TestAnalyzer baseConversionAnalyzer() {
         return analyzerWithEnrichPolicies().addIndex("base_conversion", "mapping-base_conversion.json")
             .addLanguagesLookup()
             .addTestLookup()
@@ -243,6 +327,45 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
             TestIndexNameExpressionResolver.newInstance()
         );
         return optimize(analyzer().externalSourceResolution(resource, schema, FileList.UNRESOLVED).buildAnalyzer().analyze(rewritten));
+    }
+
+    /**
+     * From {@code pack_dims_agg} on, a {@link PackDimsAgg} inside the time-series aggregate packs its dimensions; before, a
+     * {@link PackDims} node above it does. The analyzer decides this at its own version, which equals the instance version
+     * for this purpose because every floor passed to {@link #minimumVersionAtLeast} predates {@code pack_dims_agg}.
+     */
+    protected boolean packsDimsInAggregate() {
+        return minimumVersion.supports(PackDimsAgg.PACK_DIMS_AGG_VERSION);
+    }
+
+    /** The time-series aggregate whose {@code dimCount} dimensions {@code plan} packs, in the shape this instance's version produces. */
+    protected TimeSeriesAggregate packedTimeSeriesAggregate(LogicalPlan plan, int dimCount) {
+        if (packsDimsInAggregate()) {
+            TimeSeriesAggregate aggregate = as(plan, TimeSeriesAggregate.class);
+            assertThat(packedDims(aggregate.aggregates()), hasSize(dimCount));
+            return aggregate;
+        }
+        PackDims pack = as(plan, PackDims.class);
+        TimeSeriesAggregate aggregate = as(pack.child(), TimeSeriesAggregate.class);
+        assertThat(pack.dims(), hasSize(dimCount));
+        // PackDims references the DIMENSIONVALUES aliases by id; names differ when the grouping is aliased (BY p = pod).
+        var dimensionValueIds = aggregate.aggregates()
+            .stream()
+            .filter(aggregation -> Alias.unwrap(aggregation) instanceof DimensionValues)
+            .map(NamedExpression::id)
+            .toList();
+        assertThat(pack.dims().stream().map(Attribute::id).toList(), equalTo(dimensionValueIds));
+        return aggregate;
+    }
+
+    /** The dimensions {@code aggregates} carry, whether one {@link DimensionValues} each or a single {@link PackDimsAgg}. */
+    protected static List<Expression> packedDims(List<? extends NamedExpression> aggregates) {
+        List<Expression> dims = new ArrayList<>();
+        for (NamedExpression aggregate : aggregates) {
+            aggregate.forEachDown(DimensionValues.class, values -> dims.add(values.field()));
+            aggregate.forEachDown(PackDimsAgg.class, packed -> dims.addAll(packed.dims()));
+        }
+        return dims;
     }
 
     protected LogicalPlan planAirports(String query) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/HoistOrderByBeforeInlineJoinOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/HoistOrderByBeforeInlineJoinOptimizerTests.java
@@ -48,6 +48,10 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class HoistOrderByBeforeInlineJoinOptimizerTests extends AbstractLogicalPlanOptimizerTests {
 
+    public HoistOrderByBeforeInlineJoinOptimizerTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     /*
      * Project[[emp_no{f}#12, avg{r}#6, languages{f}#15, gender{f}#14]]
      * \_TopN[[Order[emp_no{f}#12,ASC,LAST]],5[INTEGER],false]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.WindowFilter;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValues;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.FirstDocId;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
@@ -143,7 +144,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
 import static org.elasticsearch.xpack.esql.core.util.TestUtils.getFieldAttribute;
-import static org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests.metricsAnalyzer;
+import static org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests.metricsAnalyzerAt;
 import static org.elasticsearch.xpack.esql.plan.physical.AbstractPhysicalPlanSerializationTests.randomEstimatedRowSize;
 import static org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec.StatsType;
 import static org.hamcrest.Matchers.contains;
@@ -3095,7 +3096,11 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
 
     public void testTranslateMetricsGroupedByTwoDimension() {
         var query = "TS k8s | STATS sum(rate(network.total_bytes_in)) BY cluster, pod";
-        var plan = plannerOptimizerTimeSeries.plan(query, EsqlTestUtils.TEST_SEARCH_STATS, metricsAnalyzer().buildAnalyzer());
+        var plan = plannerOptimizerTimeSeries.plan(
+            query,
+            EsqlTestUtils.TEST_SEARCH_STATS,
+            metricsAnalyzerAt(DimensionValues.DIMENSION_VALUES_VERSION).buildAnalyzer()
+        );
         var project = as(plan, ProjectExec.class);
         var limit = as(project.child(), LimitExec.class);
         var unpack = as(limit.child(), UnpackDimsExec.class);
@@ -3129,7 +3134,11 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
      */
     public void testNonMultipleWindowInsertsPartialAggregate() {
         var query = "TS k8s | STATS sum(rate(network.total_bytes_in, 7 minute)) BY TBUCKET(5 minute)";
-        var plan = plannerOptimizerTimeSeries.plan(query, EsqlTestUtils.TEST_SEARCH_STATS, metricsAnalyzer().buildAnalyzer());
+        var plan = plannerOptimizerTimeSeries.plan(
+            query,
+            EsqlTestUtils.TEST_SEARCH_STATS,
+            metricsAnalyzerAt(DimensionValues.DIMENSION_VALUES_VERSION).buildAnalyzer()
+        );
         List<TimeSeriesAggregateExec> tsAggs = new ArrayList<>();
         plan.forEachDown(TimeSeriesAggregateExec.class, tsAggs::add);
         assertThat(tsAggs, hasSize(2));
@@ -3173,7 +3182,11 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
         var query = "TS k8s"
             + " | STATS sum(rate(network.total_bytes_in, 7 minute)), avg(rate(network.total_bytes_in, 12 minute))"
             + " BY TBUCKET(5 minute)";
-        var plan = plannerOptimizerTimeSeries.plan(query, EsqlTestUtils.TEST_SEARCH_STATS, metricsAnalyzer().buildAnalyzer());
+        var plan = plannerOptimizerTimeSeries.plan(
+            query,
+            EsqlTestUtils.TEST_SEARCH_STATS,
+            metricsAnalyzerAt(DimensionValues.DIMENSION_VALUES_VERSION).buildAnalyzer()
+        );
         List<TimeSeriesAggregateExec> tsAggs = new ArrayList<>();
         plan.forEachDown(TimeSeriesAggregateExec.class, tsAggs::add);
         assertThat(tsAggs, hasSize(2));
@@ -3214,7 +3227,11 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
         var query = "TS k8s"
             + " | STATS min(max_over_time(network.bytes_in, 2 minute)), avg(max_over_time(network.bytes_in, 7 minute))"
             + " BY TBUCKET(5 minute)";
-        var plan = plannerOptimizerTimeSeries.plan(query, EsqlTestUtils.TEST_SEARCH_STATS, metricsAnalyzer().buildAnalyzer());
+        var plan = plannerOptimizerTimeSeries.plan(
+            query,
+            EsqlTestUtils.TEST_SEARCH_STATS,
+            metricsAnalyzerAt(DimensionValues.DIMENSION_VALUES_VERSION).buildAnalyzer()
+        );
         List<TimeSeriesAggregateExec> tsAggs = new ArrayList<>();
         plan.forEachDown(TimeSeriesAggregateExec.class, tsAggs::add);
         assertThat(tsAggs, hasSize(2));
@@ -3246,7 +3263,11 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
      */
     public void testNonMultipleWindowWithFilteredAggregate() {
         var query = "TS k8s" + " | STATS sum(rate(network.total_bytes_in, 7 minute)) WHERE pod == \"one\"" + " BY TBUCKET(5 minute)";
-        var plan = plannerOptimizerTimeSeries.plan(query, EsqlTestUtils.TEST_SEARCH_STATS, metricsAnalyzer().buildAnalyzer());
+        var plan = plannerOptimizerTimeSeries.plan(
+            query,
+            EsqlTestUtils.TEST_SEARCH_STATS,
+            metricsAnalyzerAt(DimensionValues.DIMENSION_VALUES_VERSION).buildAnalyzer()
+        );
         List<TimeSeriesAggregateExec> tsAggs = new ArrayList<>();
         plan.forEachDown(TimeSeriesAggregateExec.class, tsAggs::add);
         assertThat(tsAggs, hasSize(2));
@@ -3279,7 +3300,11 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
      */
     public void testExactMultipleWindowPlansNoPartialAggregate() {
         var query = "TS k8s | STATS sum(rate(network.total_bytes_in, 10 minute)) BY TBUCKET(5 minute)";
-        var plan = plannerOptimizerTimeSeries.plan(query, EsqlTestUtils.TEST_SEARCH_STATS, metricsAnalyzer().buildAnalyzer());
+        var plan = plannerOptimizerTimeSeries.plan(
+            query,
+            EsqlTestUtils.TEST_SEARCH_STATS,
+            metricsAnalyzerAt(DimensionValues.DIMENSION_VALUES_VERSION).buildAnalyzer()
+        );
         List<TimeSeriesAggregateExec> tsAggs = new ArrayList<>();
         plan.forEachDown(TimeSeriesAggregateExec.class, tsAggs::add);
         assertThat(tsAggs, hasSize(2));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerInSubqueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerInSubqueryTests.java
@@ -14,7 +14,6 @@ import org.junit.Before;
 
 import java.util.List;
 
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
 import static org.hamcrest.Matchers.containsString;
 
@@ -27,6 +26,10 @@ import static org.hamcrest.Matchers.containsString;
  * These queries work if an explicit {@code Limit} is specified inside the IN subquery.
  */
 public class LogicalPlanOptimizerInSubqueryTests extends AbstractLogicalPlanOptimizerTests {
+
+    public LogicalPlanOptimizerInSubqueryTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     @Before
     public void checkInSubquerySupport() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -53,7 +53,6 @@ import org.elasticsearch.xpack.esql.expression.function.WindowFilter;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.DeltaOnlyHistogramMergeOverTime;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValues;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.HistogramMerge;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.HistogramMergeOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
@@ -141,7 +140,6 @@ import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
-import org.elasticsearch.xpack.esql.plan.logical.PackDims;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegisteredDomain;
 import org.elasticsearch.xpack.esql.plan.logical.Row;
@@ -186,7 +184,6 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.ONE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.THREE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TWO;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.asLimit;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.containsIgnoringIds;
@@ -237,7 +234,12 @@ import static org.hamcrest.Matchers.startsWith;
 
 //@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests {
+
     private static final LiteralsOnTheRight LITERALS_ON_THE_RIGHT = new LiteralsOnTheRight();
+
+    public LogicalPlanOptimizerTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     public void testEvalWithScoreImplicitLimit() {
         var plan = plan("""
@@ -5024,7 +5026,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
                     s_null = count(null)
                     by w = emp_no % 2
             | keep s, s_expr, s_null, w
-            """, new TestSubstitutionOnlyOptimizer());
+            """, new TestSubstitutionOnlyOptimizer(logicalOptimizerCtx));
 
         var limit = as(plan, Limit.class);
         var topProject = as(limit.child(), Project.class);
@@ -5096,7 +5098,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
                     s_null = sum(null)
                     by w = emp_no % 2
             | keep s, s_expr, s_null, w
-            """, new TestSubstitutionOnlyOptimizer());
+            """, new TestSubstitutionOnlyOptimizer(logicalOptimizerCtx));
 
         var limit = as(plan, Limit.class);
         var topProject = as(limit.child(), Project.class);
@@ -5201,7 +5203,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             );
             String query = LoggerMessageFormat.format(null, queryWithoutValues, "[1,2]", "314.0/100", "null");
 
-            var plan = plan(query, new TestSubstitutionOnlyOptimizer());
+            var plan = plan(query, new TestSubstitutionOnlyOptimizer(logicalOptimizerCtx));
 
             var limit = as(plan, Limit.class);
             var topProject = as(limit.child(), Project.class);
@@ -5249,7 +5251,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             );
             String query = LoggerMessageFormat.format(null, queryWithoutValues, "[1,2]", "314.0/100", "null");
 
-            var plan = plan(query, new TestSubstitutionOnlyOptimizer());
+            var plan = plan(query, new TestSubstitutionOnlyOptimizer(logicalOptimizerCtx));
 
             var limit = as(plan, Limit.class);
             var topProject = as(limit.child(), Project.class);
@@ -5959,7 +5961,10 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     public static boolean releaseBuildForInlineStats(@Nullable String query) {
         if (EsqlCapabilities.Cap.INLINE_STATS.isEnabled() == false) {
             if (query != null) {
-                analyzer().addEmployees("test").error(query, ParsingException.class, containsString("mismatched input 'INLINE' expecting"));
+                // Parse error only; the transport version plays no part.
+                EsqlTestUtils.analyzer()
+                    .addEmployees("test")
+                    .error(query, ParsingException.class, containsString("mismatched input 'INLINE' expecting"));
             }
             return true;
         }
@@ -6557,7 +6562,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertSemanticMatching((BinaryComparison) ignoreIds(bc), (EsqlBinaryComparison) ignoreIds(extractPlannedBinaryComparison(exp)));
     }
 
-    private static void assertSemanticMatching(Expression fieldAttributeExp, Expression unresolvedAttributeExp) {
+    private void assertSemanticMatching(Expression fieldAttributeExp, Expression unresolvedAttributeExp) {
         Expression unresolvedUpdated = unresolvedAttributeExp.transformUp(
             LITERALS_ON_THE_RIGHT.expressionToken(),
             be -> LITERALS_ON_THE_RIGHT.rule(be, logicalOptimizerCtx)
@@ -7471,9 +7476,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         Aggregate aggsByCluster = as(unpack.child(), Aggregate.class);
         assertThat(aggsByCluster, not(instanceOf(TimeSeriesAggregate.class)));
         assertThat(aggsByCluster.aggregates(), hasSize(2));
-        PackDims pack = as(aggsByCluster.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(1));
-        TimeSeriesAggregate aggsByTsid = as(pack.child(), TimeSeriesAggregate.class);
+        TimeSeriesAggregate aggsByTsid = packedTimeSeriesAggregate(aggsByCluster.child(), 1);
         assertThat(aggsByTsid.aggregates(), hasSize(2)); // _tsid is dropped
         assertNull(aggsByTsid.timeBucket());
         EsRelation relation = as(aggsByTsid.child(), EsRelation.class);
@@ -7485,8 +7488,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
         Rate rate = as(Alias.unwrap(aggsByTsid.aggregates().get(0)), Rate.class);
         assertThat(Expressions.attribute(rate.field()).name(), equalTo("network.total_bytes_in"));
-        DimensionValues values = as(Alias.unwrap(aggsByTsid.aggregates().get(1)), DimensionValues.class);
-        assertThat(Expressions.attribute(values.field()).name(), equalTo("cluster"));
+        assertThat(Expressions.names(packedDims(aggsByTsid.aggregates())), contains("cluster"));
     }
 
     public void testTranslateMetricsGroupedByTwoDimension() {
@@ -7507,10 +7509,9 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         Aggregate finalAggs = as(eval.child(), Aggregate.class);
         assertThat(finalAggs, not(instanceOf(TimeSeriesAggregate.class)));
         assertThat(finalAggs.aggregates(), hasSize(3)); // sum, count, packed grouping
-        PackDims pack = as(finalAggs.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(2));
-        TimeSeriesAggregate aggsByTsid = as(pack.child(), TimeSeriesAggregate.class);
-        assertThat(aggsByTsid.aggregates(), hasSize(3)); // _tsid is dropped
+        TimeSeriesAggregate aggsByTsid = packedTimeSeriesAggregate(finalAggs.child(), 2);
+        assertThat(aggsByTsid.aggregates(), hasSize(packsDimsInAggregate() ? 2 : 3)); // _tsid is dropped; rate, then packed dims or two
+                                                                                      // values
         assertNull(aggsByTsid.timeBucket());
         EsRelation relation = as(aggsByTsid.child(), EsRelation.class);
         assertThat(relation.indexMode(), equalTo(IndexMode.TIME_SERIES));
@@ -7524,13 +7525,9 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(Expressions.attribute(count.field()).id(), equalTo(aggsByTsid.aggregates().get(0).id()));
         assertThat(finalAggs.groupings(), hasSize(1)); // the two dimensions are packed into one grouping key
 
-        assertThat(aggsByTsid.aggregates(), hasSize(3)); // rates, values(cluster), values(pod)
         Rate rate = as(Alias.unwrap(aggsByTsid.aggregates().get(0)), Rate.class);
         assertThat(Expressions.attribute(rate.field()).name(), equalTo("network.total_bytes_in"));
-        DimensionValues values1 = as(Alias.unwrap(aggsByTsid.aggregates().get(1)), DimensionValues.class);
-        assertThat(Expressions.attribute(values1.field()).name(), equalTo("cluster"));
-        DimensionValues values2 = as(Alias.unwrap(aggsByTsid.aggregates().get(2)), DimensionValues.class);
-        assertThat(Expressions.attribute(values2.field()).name(), equalTo("pod"));
+        assertThat(Expressions.names(packedDims(aggsByTsid.aggregates())), contains("cluster", "pod"));
     }
 
     public void testTranslateMetricsGroupedByTimeBucket() {
@@ -7579,9 +7576,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         Div div = as(Alias.unwrap(eval.fields().get(0)), Div.class);
         Aggregate finalAgg = as(eval.child(), Aggregate.class);
         assertThat(finalAgg, not(instanceOf(TimeSeriesAggregate.class)));
-        PackDims pack = as(finalAgg.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(2));
-        TimeSeriesAggregate aggsByTsid = as(pack.child(), TimeSeriesAggregate.class);
+        TimeSeriesAggregate aggsByTsid = packedTimeSeriesAggregate(finalAgg.child(), 2);
         assertNotNull(aggsByTsid.timeBucket());
         assertThat(aggsByTsid.timeBucket().buckets().fold(FoldContext.small()), equalTo(Duration.ofMinutes(5)));
         Eval bucket = as(aggsByTsid.child(), Eval.class);
@@ -7597,11 +7592,10 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(Expressions.attribute(count.field()).id(), equalTo(aggsByTsid.aggregates().get(0).id()));
         assertThat(finalAgg.groupings(), hasSize(2)); // bucket + packed grouping
 
-        assertThat(aggsByTsid.aggregates(), hasSize(4)); // rate, values(pod), values(cluster), bucket
+        assertThat(aggsByTsid.aggregates(), hasSize(packsDimsInAggregate() ? 3 : 4)); // rate, packed dims or two values, bucket
         Rate rate = as(Alias.unwrap(aggsByTsid.aggregates().get(0)), Rate.class);
         assertThat(Expressions.attribute(rate.field()).name(), equalTo("network.total_bytes_in"));
-        DimensionValues podValues = as(Alias.unwrap(aggsByTsid.aggregates().get(1)), DimensionValues.class);
-        assertThat(Expressions.attribute(podValues.field()).name(), equalTo("pod"));
+        assertThat(Expressions.names(packedDims(aggsByTsid.aggregates())), contains("pod", "cluster"));
     }
 
     public void testTranslateSumOfTwoRates() {
@@ -7622,9 +7616,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         Add sum = as(Alias.unwrap(eval.fields().get(0)), Add.class);
         assertThat(Expressions.name(sum.left()), equalTo("RATE_$1"));
         assertThat(Expressions.name(sum.right()), equalTo("RATE_$2"));
-        PackDims pack = as(eval.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(2));
-        TimeSeriesAggregate aggsByTsid = as(pack.child(), TimeSeriesAggregate.class);
+        TimeSeriesAggregate aggsByTsid = packedTimeSeriesAggregate(eval.child(), 2);
         assertThat(Expressions.name(aggsByTsid.aggregates().get(0)), equalTo("RATE_$1"));
         assertThat(Expressions.name(aggsByTsid.aggregates().get(1)), equalTo("RATE_$2"));
     }
@@ -7647,9 +7639,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         Div div = as(Alias.unwrap(eval.fields().get(0)), Div.class);
         Aggregate finalAgg = as(eval.child(), Aggregate.class);
         assertThat(finalAgg, not(instanceOf(TimeSeriesAggregate.class)));
-        PackDims pack = as(finalAgg.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(1));
-        TimeSeriesAggregate aggsByTsid = as(pack.child(), TimeSeriesAggregate.class);
+        TimeSeriesAggregate aggsByTsid = packedTimeSeriesAggregate(finalAgg.child(), 1);
         assertNotNull(aggsByTsid.timeBucket());
         assertThat(aggsByTsid.timeBucket().buckets().fold(FoldContext.small()), equalTo(Duration.ofMinutes(5)));
         Eval bucket = as(aggsByTsid.child(), Eval.class);
@@ -7702,9 +7692,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         Round round = as(Alias.unwrap(evalRound.fields().get(0)), Round.class);
         Mul mul = as(round.field(), Mul.class);
 
-        PackDims pack = as(evalRound.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(1));
-        TimeSeriesAggregate aggsByTsid = as(pack.child(), TimeSeriesAggregate.class);
+        TimeSeriesAggregate aggsByTsid = packedTimeSeriesAggregate(evalRound.child(), 1);
         assertThat(aggsByTsid.aggregates(), hasSize(3)); // rate, cluster, bucket
         assertThat(aggsByTsid.groupings(), hasSize(2));
         assertNotNull(aggsByTsid.timeBucket());
@@ -7731,8 +7719,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(mul.right().fold(FoldContext.small()), equalTo(1.05));
         Rate rate = as(Alias.unwrap(aggsByTsid.aggregates().get(0)), Rate.class);
         assertThat(Expressions.attribute(rate.field()).name(), equalTo("network.total_bytes_in"));
-        DimensionValues values = as(Alias.unwrap(aggsByTsid.aggregates().get(1)), DimensionValues.class);
-        assertThat(Expressions.attribute(values.field()).name(), equalTo("cluster"));
+        assertThat(Expressions.names(packedDims(aggsByTsid.aggregates())), contains("cluster"));
     }
 
     public void testTranslateMaxOverTime() {
@@ -9681,9 +9668,9 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
     private LogicalPlanOptimizer getCustomRulesLogicalPlanOptimizer(
         List<RuleExecutor.Batch<LogicalPlan>> batches,
-        TransportVersion minimumVersion
+        TransportVersion version
     ) {
-        LogicalOptimizerContext context = new LogicalOptimizerContext(EsqlTestUtils.TEST_CFG, FoldContext.small(), minimumVersion);
+        LogicalOptimizerContext context = new LogicalOptimizerContext(EsqlTestUtils.TEST_CFG, FoldContext.small(), version);
         LogicalPlanOptimizer customOptimizer = new LogicalPlanOptimizer(context) {
             @Override
             protected List<Batch<LogicalPlan>> batches() {
@@ -11313,16 +11300,12 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(aggregate.aggregates(), hasSize(3));
         as(Alias.unwrap(aggregate.aggregates().get(0)), Max.class);
 
-        // PackDims[[p], packed_$1]
-        var pack = as(aggregate.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(1));
-
-        // TimeSeriesAggregate[[_tsid, bucket], [MAX(..) AS MAXOVERTIME_$1, DIMENSIONVALUES(pod) AS p, bucket]]
-        var timeSeriesAggregate = as(pack.child(), TimeSeriesAggregate.class);
+        // PackDims[[p], packed_$1] before pack_dims_agg; from then on PACKDIMSAGG(pod) sits inside the aggregate below
+        // TimeSeriesAggregate[[_tsid, bucket], [MAX(..) AS MAXOVERTIME_$1, DIMENSIONVALUES(pod) AS p or PACKDIMSAGG(pod), bucket]]
+        var timeSeriesAggregate = packedTimeSeriesAggregate(aggregate.child(), 1);
         assertThat(timeSeriesAggregate.groupings(), hasSize(2));
         assertThat(timeSeriesAggregate.aggregates(), hasSize(3));
-        var dimensionValues = as(Alias.unwrap(timeSeriesAggregate.aggregates().get(1)), DimensionValues.class);
-        assertThat(Expressions.attribute(dimensionValues.field()).name(), equalTo("pod"));
+        assertThat(Expressions.names(packedDims(timeSeriesAggregate.aggregates())), contains("pod"));
 
         // Eval[[BUCKET(@timestamp, PT1M) AS bucket(@timestamp, 1 minute)]]
         var eval3 = as(timeSeriesAggregate.child(), Eval.class);
@@ -11668,7 +11651,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     }
 
     public void testTsWildcardStatsWithOptionalIndex() {
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
+        var testAnalyzer = analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
         var plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("TS * | STATS count(events_received)"));
         Limit limit = as(plan, Limit.class);
         Aggregate finalAggs = as(limit.child(), Aggregate.class);
@@ -11686,19 +11669,19 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             Map.of(),
             Map.of()
         );
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex(IndexResolution.valid(mixedIndex));
+        var testAnalyzer = analyzer().addIndex(IndexResolution.valid(mixedIndex));
         var plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("TS * | STATS count(events_received)"));
         assertNotNull(plan);
     }
 
     public void testTsWildcardWithRateAggregate() {
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
+        var testAnalyzer = analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
         var plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("TS * | STATS max(rate(network.total_bytes_in))"));
         assertNotNull(plan);
     }
 
     public void testTsWildcardWithRateAndGrouping() {
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
+        var testAnalyzer = analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
         var plan = logicalOptimizerWithLatestVersion.optimize(
             testAnalyzer.query("TS * | STATS max(rate(network.total_bytes_in)) BY cluster")
         );
@@ -11706,13 +11689,13 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     }
 
     public void testPromqlWithoutExplicitIndex() {
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex(DEFAULT_PROMQL_INDEX_PATTERN, "k8s-mappings.json", IndexMode.TIME_SERIES);
+        var testAnalyzer = analyzer().addIndex(DEFAULT_PROMQL_INDEX_PATTERN, "k8s-mappings.json", IndexMode.TIME_SERIES);
         var plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("PROMQL step=5m avg(rate(network.total_bytes_in[5m]))"));
         assertNotNull(plan);
     }
 
     public void testPromqlWithoutExplicitIndexAndGrouping() {
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex(DEFAULT_PROMQL_INDEX_PATTERN, "k8s-mappings.json", IndexMode.TIME_SERIES);
+        var testAnalyzer = analyzer().addIndex(DEFAULT_PROMQL_INDEX_PATTERN, "k8s-mappings.json", IndexMode.TIME_SERIES);
         var plan = logicalOptimizerWithLatestVersion.optimize(
             testAnalyzer.query("PROMQL step=5m avg(rate(network.total_bytes_in[5m])) by (cluster)")
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 
 import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.singleValue;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.INLINE_STATS;
@@ -45,6 +44,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTests {
+
+    public OptimizerVerificationTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     /**
      * A cast to keyword (`::keyword`) produces a foldable string pattern. {@code 12::keyword} folds to the

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/AbstractPromqlPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/AbstractPromqlPlanOptimizerTests.java
@@ -32,13 +32,17 @@ import static org.hamcrest.Matchers.not;
 // @TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug tests")
 public abstract class AbstractPromqlPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests {
 
-    protected static TestAnalyzer tsAnalyzer() {
+    protected AbstractPromqlPlanOptimizerTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
+    protected TestAnalyzer tsAnalyzer() {
         return analyzerWithEnrichPolicies().addK8s()
             .addK8sDateNanos()
             .addOtelMetrics()
             .addEmptyIndex()
             .unmappedResolution(UnmappedResolution.NULLIFY)
-            .minimumTransportVersion(TimeSeriesCollapse.TS_COLLAPSE);
+            .minimumTransportVersion(minimumVersionAtLeast(TimeSeriesCollapse.TS_COLLAPSE));
     }
 
     protected LogicalPlan planPromql(String query) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlEsqlCommandTests.java
@@ -38,6 +38,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -47,6 +48,10 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
+
+    public PromqlEsqlCommandTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     public void testPromqlTrailingSpaces() {
         planPromql("PROMQL index=k8s step=1h (max(network.bytes_in)) ");
@@ -136,14 +141,18 @@ public class PromqlEsqlCommandTests extends AbstractPromqlPlanOptimizerTests {
         var aggregate = as(outerEval.child(), Aggregate.class);
         assertThat(aggregate.groupings(), hasSize(2));
 
-        var pack = as(aggregate.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(1));
-        assertThat(Expressions.name(pack.dims().getFirst()), equalTo("pod"));
-
-        var innerProject = as(pack.child(), Project.class);
-        var evalMiddle = as(innerProject.child(), Eval.class);
+        Eval evalMiddle;
+        if (packsDimsInAggregate()) {
+            evalMiddle = as(aggregate.child(), Eval.class); // no PackDims, so no Project feeding it either
+        } else {
+            var pack = as(aggregate.child(), PackDims.class);
+            assertThat(Expressions.names(pack.dims()), contains("pod"));
+            var innerProject = as(pack.child(), Project.class);
+            evalMiddle = as(innerProject.child(), Eval.class);
+        }
 
         var tsAggregate = as(evalMiddle.child(), TimeSeriesAggregate.class);
+        assertThat(Expressions.names(packedDims(tsAggregate.aggregates())), contains("pod"));
         assertThat(tsAggregate.groupings(), hasSize(2));
 
         // verify bucket duration plus reuse

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlFakeResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlFakeResolverTests.java
@@ -22,6 +22,10 @@ public class PromqlFakeResolverTests extends AbstractLogicalPlanOptimizerTests {
 
     private final PromqlFakeResolver resolver = new PromqlFakeResolver();
 
+    public PromqlFakeResolverTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testSimpleQuery() {
         var attributes = extractAttributes("PROMQL step=1m foo");
         assertThat(gauges(attributes), contains("foo"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlHistogramQuantileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlHistogramQuantileTests.java
@@ -43,6 +43,10 @@ import static org.hamcrest.Matchers.not;
 
 public class PromqlHistogramQuantileTests extends AbstractPromqlPlanOptimizerTests {
 
+    public PromqlHistogramQuantileTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testHistogramQuantileWithoutLeAfterAggregationResolves() {
         LogicalPlan plan = planHistogramPromql(
             "PROMQL index=prom_hist step=1m result=(histogram_quantile(0.9, sum by (job) (request_duration_seconds_bucket)))"

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanBinaryOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanBinaryOperatorTests.java
@@ -54,6 +54,10 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class PromqlPlanBinaryOperatorTests extends AbstractPromqlPlanOptimizerTests {
 
+    public PromqlPlanBinaryOperatorTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testConstantFoldingArithmeticOperators() {
         var plan = planPromql("PROMQL index=k8s step=5m 1 + 1");
         var eval = plan.collect(Eval.class).getFirst();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanFunctionCallTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.PackDims;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.UnpackDims;
@@ -45,12 +44,17 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isCounter;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTests {
+
+    public PromqlPlanFunctionCallTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     public void testConstantResults() {
         assertConstantResult("ceil(vector(3.14159))", equalTo(4.0));
@@ -337,11 +341,8 @@ public class PromqlPlanFunctionCallTests extends AbstractPromqlPlanOptimizerTest
         assertThat(sumAgg.groupings(), hasSize(2));
         assertThat(sumAgg.aggregates().getFirst().collect(Sum.class), not(empty()));
 
-        var pack = as(sumAgg.child(), PackDims.class);
-        assertThat(pack.dims(), hasSize(1));
-        assertThat(Expressions.name(pack.dims().getFirst()), equalTo("cluster"));
-
-        var tsAgg = plan.collect(TimeSeriesAggregate.class).getFirst();
+        var tsAgg = packedTimeSeriesAggregate(sumAgg.child(), 1);
+        assertThat(Expressions.names(packedDims(tsAgg.aggregates())), contains("cluster"));
         assertThat(tsAgg.aggregates().getFirst().collect(LastOverTime.class), not(empty()));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValues;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.LastOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.PromqlHistogramQuantile;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
@@ -53,6 +52,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class PromqlPlanSelectorTests extends AbstractPromqlPlanOptimizerTests {
+
+    public PromqlPlanSelectorTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     /**
      * Regression guard for the promcheck "Unknown column [label]" failures: {@code sum by (<absent>) (metric)}
@@ -221,9 +224,7 @@ public class PromqlPlanSelectorTests extends AbstractPromqlPlanOptimizerTests {
         var plan = planPromql("PROMQL index=k8s step=1m network.bytes_in", false);
         var dimensions = plan.collect(TimeSeriesAggregate.class)
             .stream()
-            .flatMap(aggregate -> aggregate.aggregates().stream())
-            .flatMap(aggregate -> aggregate.collect(DimensionValues.class).stream())
-            .map(DimensionValues::field)
+            .flatMap(aggregate -> packedDims(aggregate.aggregates()).stream())
             .map(e -> e instanceof Attribute attribute ? attribute.name() : e.toString())
             .toList();
         assertThat(dimensions, equalTo(List.of(MetadataAttribute.TIMESERIES)));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSetOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSetOperatorTests.java
@@ -30,6 +30,10 @@ import static org.hamcrest.Matchers.hasSize;
  */
 public class PromqlPlanSetOperatorTests extends AbstractPromqlPlanOptimizerTests {
 
+    public PromqlPlanSetOperatorTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testSimpleUnionShape() {
         LogicalPlan plan = planPromql("PROMQL index=k8s step=1m network.bytes_in or network.cost", false);
         assertTrue(plan.resolved());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanTopKTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanTopKTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.expression.Order;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValues;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
@@ -32,6 +31,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class PromqlPlanTopKTests extends AbstractPromqlPlanOptimizerTests {
+
+    public PromqlPlanTopKTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     @Before
     public void assumeTopkEnabled() {
@@ -102,9 +105,7 @@ public class PromqlPlanTopKTests extends AbstractPromqlPlanOptimizerTests {
 
         var dimensions = plan.collect(TimeSeriesAggregate.class)
             .stream()
-            .flatMap(aggregate -> aggregate.aggregates().stream())
-            .flatMap(aggregate -> aggregate.collect(DimensionValues.class).stream())
-            .map(DimensionValues::field)
+            .flatMap(aggregate -> packedDims(aggregate.aggregates()).stream())
             .map(e -> e instanceof Attribute attribute ? attribute.name() : e.toString())
             .toList();
         assertThat(dimensions, equalTo(List.of(MetadataAttribute.TIMESERIES, "pod")));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanWithoutGroupingTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.SerializationTestUtils;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
-import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -23,7 +22,6 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.TimeSeriesMetadataAttribute;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValues;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizer;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
@@ -60,6 +58,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerTests {
+
+    public PromqlPlanWithoutGroupingTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     @Before
     public void assumePromqlWithoutGroupingEnabled() {
@@ -169,9 +171,7 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         LogicalPlan fragment = as(as(dataNodePlan, ExchangeSinkExec.class).child(), FragmentExec.class).fragment();
         var fragmentPackedTimeSeriesValues = fragment.collect(TimeSeriesAggregate.class)
             .stream()
-            .flatMap(aggregate -> aggregate.aggregates().stream())
-            .flatMap(aggregate -> aggregate.collect(DimensionValues.class).stream())
-            .map(DimensionValues::field)
+            .flatMap(aggregate -> packedDims(aggregate.aggregates()).stream())
             .filter(Attribute.class::isInstance)
             .map(Attribute.class::cast)
             .filter(attr -> MetadataAttribute.TIMESERIES.equals(attr.name()))
@@ -187,9 +187,7 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         LogicalPlan deserializedFragment = as(as(deserializedDataNodePlan, ExchangeSinkExec.class).child(), FragmentExec.class).fragment();
         var deserializedPackedTimeSeriesValues = deserializedFragment.collect(TimeSeriesAggregate.class)
             .stream()
-            .flatMap(aggregate -> aggregate.aggregates().stream())
-            .flatMap(aggregate -> aggregate.collect(DimensionValues.class).stream())
-            .map(DimensionValues::field)
+            .flatMap(aggregate -> packedDims(aggregate.aggregates()).stream())
             .filter(Attribute.class::isInstance)
             .map(Attribute.class::cast)
             .filter(attr -> MetadataAttribute.TIMESERIES.equals(attr.name()))
@@ -203,9 +201,7 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         LogicalPlan localizedFragment = localLogical.localOptimize(deserializedFragment);
         var localizedPackedTimeSeriesValues = localizedFragment.collect(TimeSeriesAggregate.class)
             .stream()
-            .flatMap(aggregate -> aggregate.aggregates().stream())
-            .flatMap(aggregate -> aggregate.collect(DimensionValues.class).stream())
-            .map(DimensionValues::field)
+            .flatMap(aggregate -> packedDims(aggregate.aggregates()).stream())
             .filter(Attribute.class::isInstance)
             .map(Attribute.class::cast)
             .filter(attr -> MetadataAttribute.TIMESERIES.equals(attr.name()))
@@ -218,9 +214,7 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
             org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec.class
         )
             .stream()
-            .flatMap(aggregate -> aggregate.aggregates().stream())
-            .flatMap(aggregate -> aggregate.collect(DimensionValues.class).stream())
-            .map(DimensionValues::field)
+            .flatMap(aggregate -> packedDims(aggregate.aggregates()).stream())
             .filter(Attribute.class::isInstance)
             .map(Attribute.class::cast)
             .filter(attr -> MetadataAttribute.TIMESERIES.equals(attr.name()))
@@ -280,13 +274,8 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         assertEquals(((TimeSeriesMetadataAttribute) tsmaList.getFirst()).excludedFields(), Set.of("pod"));
         TimeSeriesAggregate innerAggregate = analyzed.collect(TimeSeriesAggregate.class).getFirst();
         assertThat(
-            innerAggregate.aggregates()
-                .stream()
-                .filter(
-                    aggregate -> Alias.unwrap(aggregate) instanceof DimensionValues values
-                        && values.field() instanceof FieldAttribute field
-                        && field.name().equals("cluster")
-                )
+            packedDims(innerAggregate.aggregates()).stream()
+                .filter(dim -> dim instanceof FieldAttribute field && field.name().equals("cluster"))
                 .toList(),
             hasSize(1)
         );
@@ -418,13 +407,8 @@ public class PromqlPlanWithoutGroupingTests extends AbstractPromqlPlanOptimizerT
         );
         TimeSeriesAggregate innerAggregate = analyzed.collect(TimeSeriesAggregate.class).getFirst();
         assertThat(
-            innerAggregate.aggregates()
-                .stream()
-                .filter(
-                    aggregate -> Alias.unwrap(aggregate) instanceof DimensionValues values
-                        && values.field() instanceof FieldAttribute field
-                        && field.name().equals("cluster")
-                )
+            packedDims(innerAggregate.aggregates()).stream()
+                .filter(dim -> dim instanceof FieldAttribute field && field.name().equals("cluster"))
                 .toList(),
             hasSize(1)
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/FullTextFunctionLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/FullTextFunctionLogicalPlanOptimizerTests.java
@@ -23,6 +23,10 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 
 public class FullTextFunctionLogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests {
 
+    public FullTextFunctionLogicalPlanOptimizerTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testFullTextFunctionQueryArgFoldedFromConcat() {
         String functionName = randomFrom("match", "match_phrase");
         var plan = optimizedPlan(String.format(Locale.ROOT, """

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineLimitTopNTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineLimitTopNTests.java
@@ -25,6 +25,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class CombineLimitTopNTests extends AbstractLogicalPlanOptimizerTests {
 
+    public CombineLimitTopNTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testCombineLimitByTopNBySameGroupings() {
         var attr = getFieldAttribute("a");
         var groupings = List.<Expression>of(attr);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggsTests.java
@@ -42,6 +42,11 @@ import static org.hamcrest.Matchers.is;
 
 //@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class DeduplicateAggsTests extends AbstractLogicalPlanOptimizerTests {
+
+    public DeduplicateAggsTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public static <T extends AggregateFunction> void aggFieldName(Expression exp, Class<T> aggType, String fieldName) {
         var alias = as(exp, Alias.class);
         var af = as(alias.child(), aggType);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HeterogeneousFromOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HeterogeneousFromOptimizerTests.java
@@ -59,11 +59,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getFieldAttribute;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.unboundLogicalOptimizerContext;
 import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests.relation;
@@ -80,6 +78,10 @@ import static org.hamcrest.Matchers.not;
  * (rather than the subquery-shape where children are {@code Project > Eval? > Subquery}).
  */
 public class HeterogeneousFromOptimizerTests extends AbstractLogicalPlanOptimizerTests {
+
+    public HeterogeneousFromOptimizerTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     /**
      * {@link PushDownFilterAndLimitIntoUnionAll} must push a filter predicate into both branches
@@ -115,7 +117,7 @@ public class HeterogeneousFromOptimizerTests extends AbstractLogicalPlanOptimize
         GreaterThan condition = new GreaterThan(EMPTY, unionEmpNo, new Literal(EMPTY, 1, INTEGER), null);
         Filter filter = new Filter(EMPTY, unionAll, condition);
 
-        LogicalPlan result = new PushDownFilterAndLimitIntoUnionAll().apply(filter, unboundLogicalOptimizerContext());
+        LogicalPlan result = new PushDownFilterAndLimitIntoUnionAll().apply(filter, logicalOptimizerCtx);
 
         UnionAll resultUnionAll = as(result, UnionAll.class);
         assertThat(resultUnionAll.children(), hasSize(2));
@@ -143,7 +145,7 @@ public class HeterogeneousFromOptimizerTests extends AbstractLogicalPlanOptimize
         UnionAll unionAll = new UnionAll(EMPTY, List.of(esRelation, extRelation), List.of(unionEmpNo));
         Limit limit = new Limit(EMPTY, new Literal(EMPTY, 10, INTEGER), unionAll);
 
-        LogicalPlan result = new PushDownAndCombineLimits().apply(limit, unboundLogicalOptimizerContext());
+        LogicalPlan result = new PushDownAndCombineLimits().apply(limit, logicalOptimizerCtx);
 
         // Limit must remain on top — it must not be pushed into each branch
         Limit resultLimit = as(result, Limit.class);
@@ -234,7 +236,7 @@ public class HeterogeneousFromOptimizerTests extends AbstractLogicalPlanOptimize
         OrderBy orderBy = new OrderBy(EMPTY, unionAll, List.of(order));
         Limit limit = new Limit(EMPTY, new Literal(EMPTY, 10, INTEGER), orderBy);
 
-        LogicalPlan result = new PushDownLimitAndOrderByIntoMergePlan().apply(limit, unboundLogicalOptimizerContext());
+        LogicalPlan result = new PushDownLimitAndOrderByIntoMergePlan().apply(limit, logicalOptimizerCtx);
 
         // Outer structure: Limit → OrderBy → UnionAll remains intact
         Limit resultLimit = as(result, Limit.class);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimitTests.java
@@ -24,6 +24,10 @@ import static org.hamcrest.Matchers.not;
 
 public class HoistRemoteEnrichLimitTests extends AbstractLogicalPlanOptimizerTests {
 
+    public HoistRemoteEnrichLimitTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     /**
      * <pre>
      * Limit[10[INTEGER],true,false]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 
 import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -26,6 +25,10 @@ import static org.hamcrest.Matchers.startsWith;
 
 // @TestLogging(reason = "debug", value = "org.elasticsearch.xpack.esql.optimizer:TRACE")
 public class HoistRemoteEnrichTopNTests extends AbstractLogicalPlanOptimizerTests {
+
+    public HoistRemoteEnrichTopNTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     /**
      * <pre>

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
@@ -83,6 +83,10 @@ import static org.hamcrest.Matchers.is;
 
 public class PruneColumnsTests extends AbstractLogicalPlanOptimizerTests {
 
+    public PruneColumnsTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testPruneUnusedEval() {
         var plan = plan("""
               from test

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneEmptyMergeBranchesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneEmptyMergeBranchesTests.java
@@ -34,6 +34,10 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class PruneEmptyMergeBranchesTests extends AbstractLogicalPlanOptimizerTests {
 
+    public PruneEmptyMergeBranchesTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     /**
      * {@snippet lang="text":
      * Limit[10[INTEGER],false,false]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneLiteralsInLimitByTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneLiteralsInLimitByTests.java
@@ -24,6 +24,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class PruneLiteralsInLimitByTests extends AbstractLogicalPlanOptimizerTests {
 
+    public PruneLiteralsInLimitByTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     @BeforeClass
     public static void checkLimitByCapability() {}
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
@@ -31,8 +31,13 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOptimizerTests {
+
     private static final String DATASET_NAME = "ext_ds";
     private static final String S3_RESOURCE = "s3://bucket/data.parquet";
+
+    public PruneRedundantAggregateGroupingsTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     public void testPrunesEvalConstantGrouping() {
         var plan = plan("""

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
@@ -87,7 +87,6 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOf;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOrEqualOf;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.lessThanOf;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.randomLiteral;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.randomMinimumVersion;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.rlike;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.wildcardLike;
@@ -103,7 +102,11 @@ import static org.mockito.Mockito.mock;
 //@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class PushDownAndCombineFiltersTests extends AbstractLogicalPlanOptimizerTests {
 
-    private final LogicalOptimizerContext optimizerContext = new LogicalOptimizerContext(null, FoldContext.small(), randomMinimumVersion());
+    private final LogicalOptimizerContext optimizerContext = new LogicalOptimizerContext(null, FoldContext.small(), minimumVersion);
+
+    public PushDownAndCombineFiltersTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     public void testCombineFilters() {
         EsRelation relation = relation();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitsTests.java
@@ -45,7 +45,6 @@ import java.util.function.BiFunction;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getFieldAttribute;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.randomLiteral;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.unboundLogicalOptimizerContext;
 import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
@@ -56,6 +55,10 @@ import static org.hamcrest.Matchers.instanceOf;
 
 // @TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class PushDownAndCombineLimitsTests extends AbstractLogicalPlanOptimizerTests {
+
+    public PushDownAndCombineLimitsTests(VersionMode versionMode) {
+        super(versionMode);
+    }
 
     private static class PushDownLimitTestCase<PlanType extends LogicalPlan> {
         private final Class<PlanType> clazz;
@@ -268,7 +271,7 @@ public class PushDownAndCombineLimitsTests extends AbstractLogicalPlanOptimizerT
     }
 
     private LogicalPlan optimizePlan(LogicalPlan plan) {
-        return new PushDownAndCombineLimits().apply(plan, unboundLogicalOptimizerContext());
+        return new PushDownAndCombineLimits().apply(plan, logicalOptimizerCtx);
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownFilterAndLimitIntoUnionAllTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownFilterAndLimitIntoUnionAllTests.java
@@ -70,6 +70,10 @@ import static org.hamcrest.Matchers.instanceOf;
 //@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class PushDownFilterAndLimitIntoUnionAllTests extends AbstractLogicalPlanOptimizerTests {
 
+    public PushDownFilterAndLimitIntoUnionAllTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     @Before
     public void checkSubqueryInFromCommandSupport() {
         assumeTrue("Requires subquery in FROM command support", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.isEnabled());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownIntoForkTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownIntoForkTests.java
@@ -38,6 +38,10 @@ import static org.hamcrest.Matchers.is;
 // @TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class PushDownIntoForkTests extends AbstractLogicalPlanOptimizerTests {
 
+    public PushDownIntoForkTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     /**
      * {@snippet lang="text":
      * TopN[[Order[emp_no{r}#18,ASC,LAST]],10[INTEGER],false]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownJoinPastProjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownJoinPastProjectTests.java
@@ -33,6 +33,10 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class PushDownJoinPastProjectTests extends AbstractLogicalPlanOptimizerTests {
 
+    public PushDownJoinPastProjectTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     // Expects
     //
     // Project[[languages{f}#16, emp_no{f}#13, languages{f}#16 AS language_code#6, language_name{f}#27]]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAliasingEvalWithProjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAliasingEvalWithProjectTests.java
@@ -27,6 +27,11 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.of;
 import static org.hamcrest.Matchers.startsWith;
 
 public class ReplaceAliasingEvalWithProjectTests extends AbstractLogicalPlanOptimizerTests {
+
+    public ReplaceAliasingEvalWithProjectTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     /**
      * {@snippet lang="text":
      * Project[[emp_no{f}#18, salary{f}#23, emp_no{f}#18 AS emp_no2#7, salary2{r}#10, emp_no{f}#18 AS emp_no3#13, salary3{r}#16]]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregateTests.java
@@ -48,6 +48,10 @@ public class ReplaceSparklineAggregateTests extends AbstractLogicalPlanOptimizer
 
     private static final String SPARKLINE_EXPR = "sparkline(count(*), hire_date, 10, \"2024-01-01\", \"2024-12-31\")";
 
+    public ReplaceSparklineAggregateTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     @Before
     public void checkCapability() {
         assumeTrue(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEvalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEvalTests.java
@@ -47,6 +47,10 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class ReplaceStatsFilteredOrNullAggWithEvalTests extends AbstractLogicalPlanOptimizerTests {
 
+    public ReplaceStatsFilteredOrNullAggWithEvalTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     /**
      * {@snippet lang="text":
      * Limit[1000[INTEGER]]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/RewriteSumOfExpressionPlusConstantTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/RewriteSumOfExpressionPlusConstantTests.java
@@ -21,6 +21,10 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
  */
 public class RewriteSumOfExpressionPlusConstantTests extends AbstractLogicalPlanOptimizerTests {
 
+    public RewriteSumOfExpressionPlusConstantTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testDuplicateAliasNotRewritten() {
         var plan = plan("""
             from test

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
@@ -24,6 +24,10 @@ import static org.hamcrest.Matchers.is;
 
 public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimizerTests {
 
+    public TimeSeriesBareAggregationsTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     protected LogicalPlan planK8s(String query) {
         return logicalOptimizer.optimize(analyzerWithEnrichPolicies().addK8s().query(query));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesWithoutTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesWithoutTests.java
@@ -36,6 +36,10 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class TranslateTimeSeriesWithoutTests extends AbstractLogicalPlanOptimizerTests {
 
+    public TranslateTimeSeriesWithoutTests(VersionMode versionMode) {
+        super(versionMode);
+    }
+
     public void testLoweringReplacesGroupingAndOutputReferences() {
         FieldAttribute cluster = new FieldAttribute(
             Source.EMPTY,


### PR DESCRIPTION
Item 4 of #150856, third tranche, after #155900 (physical optimizer) and #157068 (analyzer suites).

The logical optimizer suites built their optimizer once per class at a random transport version, and every analyzer helper drew its own random version. A version-gated plan change was only exercised when a draw happened to land above the gate. Now every test in `AbstractLogicalPlanOptimizerTests` and its 35 subclasses runs twice: `{current}` pins `TransportVersion.current()` on analyzer and optimizer, `{historical}` keeps one random compatible version per test. A version-gated change fails in its own PR.

The two exact analyzer pins in the hierarchy (`dimension_values` in `metricsAnalyzer()`, `ts_collapse` in the PromQL `tsAnalyzer()`) became floors. That exposed 15 tests that only ever saw the plan shape from before `pack_dims_agg`. They now assert the shape their version produces.

A sentinel test in the base checks that analyzer and optimizer carry the mode's version, so a helper that drops the pin fails everywhere.

<details>
<summary>Verification</summary>

- 36 classes: 1121 `{current}` + 1121 `{historical}`, 0 failures.
- 10 iterations of the adapted tests and all PromQL suites: 0 failures.
- Removing the analyzer pin makes the sentinel fail in both modes.
- `PromqlGoldenTests.testBinaryWithDifferentSelectors` fails under `-Dtests.iters` because its mute pattern lacks a wildcard. Pre-existing, muted on main.

</details>

<details>
<summary>Left as is</summary>

- `planMetrics()` still optimizes at `current()`; dropping `logicalOptimizerWithLatestVersion` is the cleanup after this rollout.
- `AnalyzerExternalTests` stays out, as in #157068.
- `LocalPhysicalPlanOptimizerTests` keeps its exact `dimension_values` pin via `metricsAnalyzerAt`.

</details>

Relates #150856.

_Assisted by Claude._
