### PR TITLE
ESQL: Fail and repair dead golden version declarations

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -632,10 +632,26 @@ tasks.named("test").configure {
   if (System.getProperty("golden.overwrite") != null || project.hasProperty("golden.overwrite")) {
     systemProperty "golden.overwrite", "true"
   }
-  if (System.getProperty("golden.gc.strict") != null || project.hasProperty("golden.gc.strict")) {
-    systemProperty "golden.gc.strict", "true"
-  }
+}
 
+// Repairs golden tests whose version declarations the compatibility floor has passed: deletes their before_<version>
+// directories and removes the declarations from the test sources, then reformats. Run it on the PR that moved the floor.
+tasks.register('goldenGc', Test) {
+  description = 'Removes dead version declarations and directories from the ES|QL golden tests'
+  group = 'verification'
+  testClassesDirs = sourceSets.test.output.classesDirs
+  classpath = sourceSets.test.runtimeClasspath
+  systemProperty 'arrow.memory.debug.allocator', 'true'
+  systemProperty 'es.esql_remote_fetch_topn_feature_flag_enabled', 'false'
+  systemProperty 'golden.gc.fix', 'true'
+  // it edits its own inputs: never skip it, never restore it from the cache, never let two forks edit one source
+  outputs.upToDateWhen { false }
+  outputs.cacheIf { false }
+  maxParallelForks = 1
+  filter {
+    includeTestsMatching '*GoldenTests'
+  }
+  finalizedBy tasks.named('spotlessJavaApply')
 }
 
 /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenGc.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenGc.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.elasticsearch.core.IOUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Repairs golden version declarations the compatibility floor has passed. Once no compatible version is below a
+ * declaration, its {@code before_<name>} directory and its {@code expectationChangesAt}/{@code since} call describe
+ * planning nobody can run anymore. Under {@code -Dgolden.gc.fix} the runner calls this instead of failing, so the PR
+ * that moved the floor is repaired by one Gradle task rather than by hand.
+ */
+final class GoldenGc {
+
+    private GoldenGc() {}
+
+    /** What a repair pass did, so the runner can tell "already done" from "needs a human". */
+    enum Outcome {
+        REPAIRED,
+        ABSENT,
+        UNMATCHED
+    }
+
+    /** A call with its argument; a comment trailing it on the same line goes with it. */
+    private static final Pattern CALL = Pattern.compile(
+        "\\s*\\.(?:expectationChangesAt|since)\\(((?:[^()]|\\([^()]*\\))*)\\)(?:[ \\t]*//[^\\n]*)?"
+    );
+
+    static boolean fixMode() {
+        return System.getProperty("golden.gc.fix") != null;
+    }
+
+    /** Deletes every directory called {@code dirName} under {@code root}; none left is already clean. */
+    static void deleteDirectoriesNamed(Path root, String dirName) throws IOException {
+        if (Files.notExists(root)) {
+            return;
+        }
+        List<Path> dirs;
+        try (Stream<Path> walk = Files.walk(root)) {
+            dirs = walk.filter(p -> Files.isDirectory(p) && p.getFileName().toString().equals(dirName)).toList();
+        }
+        for (Path dir : dirs) {
+            IOUtils.rm(dir);
+        }
+    }
+
+    /**
+     * Removes every {@code .expectationChangesAt(...)} and {@code .since(...)} of {@code versionName} from {@code javaSource},
+     * whether written as a literal, through a {@code static final String} constant, or through a version constant whose
+     * name resembles the version's, and drops the string constant once nothing else in the file uses it. Returns whether
+     * the file changed, so a second pass is a no-op.
+     */
+    static boolean removeDeclarations(Path javaSource, String versionName) throws IOException {
+        String source = Files.readString(javaSource);
+        String repaired = removeDeclarations(source, versionName);
+        if (repaired.equals(source)) {
+            return false;
+        }
+        Files.writeString(javaSource, repaired);
+        return true;
+    }
+
+    static String removeDeclarations(String source, String versionName) {
+        String literal = '"' + versionName + '"';
+        List<String> constants = constantsHolding(source, literal);
+        StringBuilder repaired = new StringBuilder();
+        Matcher call = CALL.matcher(source);
+        int copied = 0;
+        while (call.find()) {
+            if (names(call.group(1), versionName, literal, constants)) {
+                repaired.append(source, copied, call.start());
+                copied = call.end();
+            }
+        }
+        repaired.append(source, copied, source.length());
+        String result = repaired.toString();
+        for (String constant : constants) {
+            Pattern declaration = Pattern.compile(
+                "^[ \\t]*(?:private|protected|public)?[ \\t]*static[ \\t]+final[ \\t]+String[ \\t]+"
+                    + Pattern.quote(constant)
+                    + "[ \\t]*=[ \\t]*"
+                    + Pattern.quote(literal)
+                    + "[ \\t]*;[^\\n]*\\n",
+                Pattern.MULTILINE
+            );
+            String withoutDeclaration = declaration.matcher(result).replaceFirst("");
+            if (Pattern.compile("\\b" + Pattern.quote(constant) + "\\b").matcher(withoutDeclaration).find() == false) {
+                result = withoutDeclaration;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Whether any declaration in {@code source} looks like it is about {@code versionName} under a looser reading than
+     * {@link #removeDeclarations} uses. True after a repair changed nothing means a shape the rewrite refused, not an
+     * already-repaired file.
+     */
+    static boolean mentions(String source, String versionName) {
+        String name = normalize(versionName);
+        Matcher call = CALL.matcher(source);
+        while (call.find()) {
+            String token = lastSegment(call.group(1));
+            if (token.length() >= 6 && (token.contains(name) || name.contains(token))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A literal or string constant matches exactly. A version constant matches by name: {@code Sum.ESQL_SUM_LONG_OVERFLOW_FIX},
+     * {@code DimensionValues.DIMENSION_VALUES_VERSION} and {@code MvSingleValueOrNull.MV_SINGLE_VALUE_OR_NULL_TRANSPORT_VERSION}
+     * all name their version, give or take a prefix and a {@code _VERSION} suffix. {@code TS_COLLAPSE_V2} does not name
+     * {@code ts_collapse}.
+     */
+    private static boolean names(String argument, String versionName, String literal, List<String> constants) {
+        String trimmed = argument.strip();
+        if (trimmed.equals(literal) || constants.contains(trimmed)) {
+            return true;
+        }
+        String token = lastSegment(trimmed);
+        for (String suffix : new String[] { "transportversion", "version" }) {
+            if (token.endsWith(suffix)) {
+                token = token.substring(0, token.length() - suffix.length());
+                break;
+            }
+        }
+        String name = normalize(versionName);
+        return token.length() >= 6 && (name.equals(token) || name.endsWith(token) || token.endsWith(name));
+    }
+
+    private static String lastSegment(String argument) {
+        String trimmed = argument.strip();
+        return normalize(trimmed.substring(trimmed.lastIndexOf('.') + 1));
+    }
+
+    private static String normalize(String identifier) {
+        return identifier.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+    }
+
+    private static List<String> constantsHolding(String source, String literal) {
+        Matcher m = Pattern.compile("static[ \\t]+final[ \\t]+String[ \\t]+(\\w+)[ \\t]*=[ \\t]*" + Pattern.quote(literal) + "[ \\t]*;")
+            .matcher(source);
+        List<String> constants = new ArrayList<>();
+        while (m.find()) {
+            constants.add(m.group(1));
+        }
+        return constants;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenGcTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenGcTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/** The source rewrites {@code -Dgolden.gc.fix} performs, on the shapes the golden suites actually use. */
+public class GoldenGcTests extends ESTestCase {
+
+    public void testRemovesChainedCallsAndUnusedConstant() {
+        String source = """
+            public class FooGoldenTests extends GoldenTestCase {
+                private static final String DIMENSION_VALUES = "dimension_values";
+                private static final String PACK_DIMS_AGG = "pack_dims_agg";
+
+                public void testOne() {
+                    builder("FROM a").expectationChangesAt(DIMENSION_VALUES)
+                        .expectationChangesAt(PACK_DIMS_AGG)
+                        .run();
+                }
+
+                public void testTwo() {
+                    builder("FROM b")
+                        .expectationChangesAt(DIMENSION_VALUES) // the plan changes shape here
+                        .run();
+                }
+            }
+            """;
+        String expected = """
+            public class FooGoldenTests extends GoldenTestCase {
+                private static final String PACK_DIMS_AGG = "pack_dims_agg";
+
+                public void testOne() {
+                    builder("FROM a")
+                        .expectationChangesAt(PACK_DIMS_AGG)
+                        .run();
+                }
+
+                public void testTwo() {
+                    builder("FROM b")
+                        .run();
+                }
+            }
+            """;
+        assertThat(GoldenGc.removeDeclarations(source, "dimension_values"), equalTo(expected));
+    }
+
+    public void testKeepsConstantStillReferencedElsewhere() {
+        String source = """
+            private static final String DIMENSION_VALUES = "dimension_values";
+            void test() {
+                builder("FROM a").since(DIMENSION_VALUES).run();
+                assumeTrue(DIMENSION_VALUES, true);
+            }
+            """;
+        String expected = """
+            private static final String DIMENSION_VALUES = "dimension_values";
+            void test() {
+                builder("FROM a").run();
+                assumeTrue(DIMENSION_VALUES, true);
+            }
+            """;
+        assertThat(GoldenGc.removeDeclarations(source, "dimension_values"), equalTo(expected));
+    }
+
+    public void testRemovesLiteralFormAndLeavesOtherVersionsAlone() {
+        String source = """
+            builder("FROM a").since("dimension_values").expectationChangesAt("pack_dims_agg").run();
+            """;
+        String expected = """
+            builder("FROM a").expectationChangesAt("pack_dims_agg").run();
+            """;
+        assertThat(GoldenGc.removeDeclarations(source, "dimension_values"), equalTo(expected));
+    }
+
+    public void testSecondPassChangesNothing() throws IOException {
+        Path file = createTempFile();
+        Files.writeString(file, """
+            private static final String X = "x_version";
+            void test() { builder("FROM a").expectationChangesAt(X).run(); }
+            """);
+        assertTrue(GoldenGc.removeDeclarations(file, "x_version"));
+        assertFalse(GoldenGc.removeDeclarations(file, "x_version"));
+        assertThat(Files.readString(file), equalTo("void test() { builder(\"FROM a\").run(); }\n"));
+    }
+
+    public void testRemovesConstantFormSinceByVersionName() {
+        String source = """
+            public class FooGoldenTests extends GoldenTestCase {
+                public void testOne() {
+                    nullify(query).since(DimensionValues.DIMENSION_VALUES_VERSION);
+                    load(query).since(DimensionValues.DIMENSION_VALUES_VERSION);
+                }
+
+                public void testTwo() {
+                    builder("FROM b").since(Sum.ESQL_SUM_LONG_OVERFLOW_FIX).run();
+                }
+
+                public void testThree() {
+                    builder("FROM c").since(MvSingleValueOrNull.MV_SINGLE_VALUE_OR_NULL_TRANSPORT_VERSION).run();
+                }
+
+                public void testFour() {
+                    builder("FROM d").since(CompactMultiTypeEsField.CompactMultiTypeEsField).run();
+                }
+            }
+            """;
+        String afterDimensionValues = source.replace(".since(DimensionValues.DIMENSION_VALUES_VERSION)", "");
+        assertThat(GoldenGc.removeDeclarations(source, "dimension_values"), equalTo(afterDimensionValues));
+        assertThat(
+            GoldenGc.removeDeclarations(source, "esql_mv_single_value_or_null"),
+            equalTo(source.replace(".since(MvSingleValueOrNull.MV_SINGLE_VALUE_OR_NULL_TRANSPORT_VERSION)", ""))
+        );
+        assertThat(
+            GoldenGc.removeDeclarations(source, "compact_multi_type_es_field"),
+            equalTo(source.replace(".since(CompactMultiTypeEsField.CompactMultiTypeEsField)", ""))
+        );
+        assertThat(
+            GoldenGc.removeDeclarations(source, "esql_sum_long_overflow_fix").contains("ESQL_SUM_LONG_OVERFLOW_FIX"),
+            equalTo(false)
+        );
+    }
+
+    public void testLeavesLookalikeConstantAloneButReportsIt() {
+        String source = """
+            builder("FROM a").since(TimeSeriesCollapse.TS_COLLAPSE_V2).run();
+            """;
+        assertThat(GoldenGc.removeDeclarations(source, "ts_collapse"), equalTo(source));
+        assertTrue(GoldenGc.mentions(source, "ts_collapse"));
+        assertFalse(GoldenGc.mentions(source, "pack_dims_agg"));
+    }
+
+    public void testDeletesDirectoriesOfThatNameAcrossTheSuite() throws IOException {
+        Path root = createTempDir();
+        Path dead1 = root.resolve("testFoo").resolve("before_x_version");
+        Path dead2 = root.resolve("testBar").resolve("nested").resolve("before_x_version");
+        Path alive = root.resolve("testFoo").resolve("before_y_version");
+        for (Path dir : List.of(dead1, dead2, alive)) {
+            Files.createDirectories(dir);
+            Files.writeString(dir.resolve("analysis.expected"), "plan");
+        }
+        GoldenGc.deleteDirectoriesNamed(root, "before_x_version");
+        assertFalse(Files.exists(dead1));
+        assertFalse(Files.exists(dead2));
+        assertTrue(Files.exists(alive.resolve("analysis.expected")));
+        GoldenGc.deleteDirectoriesNamed(root, "before_x_version");
+        GoldenGc.deleteDirectoriesNamed(root.resolve("missing"), "before_x_version");
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
@@ -139,6 +139,8 @@ public abstract class GoldenTestCase extends ESTestCase {
     }
 
     private final Path baseFile;
+    /** The sources of this test class and its abstract parents, which {@code -Dgolden.gc.fix} edits to drop dead declarations. */
+    private final List<Path> sourceFiles;
     private final String goldenMode;
 
     public GoldenTestCase() {
@@ -154,6 +156,13 @@ public abstract class GoldenTestCase extends ESTestCase {
             String path = PathUtils.get(getClass().getResource(".").toURI()).toAbsolutePath().normalize().toString();
             var inSrc = path.replace('\\', '/').replaceFirst("build/classes/java/test", "src/test/resources");
             baseFile = PathUtils.get(Strings.format("%s/golden_tests/%s/", inSrc, getClass().getSimpleName()));
+            List<Path> sources = new ArrayList<>();
+            for (Class<?> c = getClass(); c != GoldenTestCase.class; c = c.getSuperclass()) {
+                var classDir = PathUtils.get(c.getResource(".").toURI()).toAbsolutePath().normalize().toString();
+                var inJava = classDir.replace('\\', '/').replaceFirst("build/classes/java/test", "src/test/java");
+                sources.add(PathUtils.get(inJava, c.getSimpleName() + ".java"));
+            }
+            sourceFiles = List.copyOf(sources);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
@@ -203,6 +212,7 @@ public abstract class GoldenTestCase extends ESTestCase {
         private TransportVersion transportVersion;
         private boolean explicitTransportVersion;
         private TransportVersion since;
+        private String sinceName;
         private final List<Label> labels = new ArrayList<>();
         private Function<LogicalOptimizerContext, LogicalPlanOptimizer> optimizerFactory;
         private AliasFilter aliasFilter;
@@ -291,6 +301,7 @@ public abstract class GoldenTestCase extends ESTestCase {
          * the feature under test. Distinct from {@link #expectationChangesAt}, which splits coverage instead of removing it.
          */
         public TestBuilder since(String transportVersionName) {
+            sinceName = transportVersionName;
             return since(resolve(transportVersionName));
         }
 
@@ -372,6 +383,10 @@ public abstract class GoldenTestCase extends ESTestCase {
             if (since != null && labels.isEmpty() == false && labels.getFirst().version().id() <= since.id()) {
                 throw new IllegalArgumentException(Strings.format("label [%s] must be above since [%s]", labels.getFirst().name(), since));
             }
+            if (since != null && COMPATIBLE_VERSIONS.stream().allMatch(version -> version.supports(since))) {
+                reportDeadSince(testName);
+                since = null;
+            }
             List<VersionRange> ranges = explicitTransportVersion
                 ? List.of(new VersionRange(null, transportVersion, List.of(transportVersion)))
                 : liveRanges(testName);
@@ -429,18 +444,68 @@ public abstract class GoldenTestCase extends ESTestCase {
 
         private void reportDeadRange(String testName, VersionRange range, String nextLabel) {
             String message = Strings.format(
-                "test [%s]: golden range [%s] is dead — every version that can be sampled is past [%s]. "
-                    + "Remove expectationChangesAt(\"%s\") and delete the [%s] directory. See GoldenTestsReadme.MD.",
+                "test [%s]: golden range [%s] is dead — every version that can be sampled is past [%s] (compatibility floor [%s]). "
+                    + "Remove expectationChangesAt(\"%s\") and delete the [%s] directory, or run [%s] to do it. See GoldenTestsReadme.MD.",
                 testName,
                 range.dir(),
                 nextLabel,
+                TransportVersion.minimumCompatible(),
                 nextLabel,
-                range.dir()
+                range.dir(),
+                GC_TASK
             );
-            if (System.getProperty("golden.gc.strict") != null) {
+            if (GoldenGc.fixMode() == false) {
                 fail(message);
-            } else {
-                logger.warn(message);
+            }
+            try {
+                repair(nextLabel, message);
+                // the label is dead for every test in this class, muted and skipped ones included
+                GoldenGc.deleteDirectoriesNamed(baseFile, range.dir());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        /**
+         * Removes {@code versionName}'s declarations from the class's sources. Nothing changing is normal for the second mode of
+         * the same test; nothing changing while a declaration still resembles the name is a shape the rewrite refused, which
+         * only a human can settle.
+         */
+        private void repair(String versionName, String message) throws IOException {
+            for (Path source : sourceFiles) {
+                if (Files.exists(source) && GoldenGc.removeDeclarations(source, versionName)) {
+                    logger.info("repaired: {}", message);
+                    return;
+                }
+            }
+            for (Path source : sourceFiles) {
+                if (Files.exists(source) && GoldenGc.mentions(Files.readString(source), versionName)) {
+                    fail(message + " The repair could not rewrite the declaration in " + source + "; remove it by hand.");
+                }
+            }
+        }
+
+        /** A {@code since} at or below the compatibility floor no longer removes any coverage. */
+        private void reportDeadSince(String testName) {
+            String message = Strings.format(
+                "test [%s]: since [%s] is dead — it is at or below the compatibility floor [%s], so it drops no coverage. "
+                    + "Remove it, or run [%s] to do it. See GoldenTestsReadme.MD.",
+                testName,
+                since,
+                TransportVersion.minimumCompatible(),
+                GC_TASK
+            );
+            if (GoldenGc.fixMode() == false) {
+                fail(message);
+            }
+            String name = sinceName != null ? sinceName : since.name();
+            if (name == null) {
+                fail(message + " The version has no name to search for; remove the declaration by hand.");
+            }
+            try {
+                repair(name, message);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
         }
 
@@ -619,6 +684,8 @@ public abstract class GoldenTestCase extends ESTestCase {
         .stream()
         .filter(TransportVersion::isCompatible)
         .toList();
+
+    private static final String GC_TASK = "./gradlew :x-pack:plugin:esql:goldenGc";
 
     private static boolean overwriteMode() {
         return System.getProperty("golden.overwrite") != null;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestsReadme.MD
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestsReadme.MD
@@ -144,10 +144,14 @@ range, at a random released version inside it. The two names mute independently:
   own starting version, so the old shape comes back and `{current}` stays red.
 - `{historical}` flaky on an unlabeled test: you found an undeclared fork; the failure diff shows
   both shapes. Declare it (label or `since`) and regenerate.
-- Warning about a dead range: the compatibility floor (advances at major releases) passed a label.
-  Harmless, but clean up as the message says — delete the `before_<label>` directory and remove
-  the declaration; nothing else moves. `-Dgolden.gc.strict` escalates the warning to a failure,
-  for scheduled cleanup sweeps.
+- Dead range or dead `since`: the compatibility floor (advances at major releases) passed the
+  declared version, so it no longer splits or removes any coverage. The test fails on the PR that
+  moved the floor. Run `./gradlew :x-pack:plugin:esql:goldenGc -Dtests.mutes.enabled=false` (so
+  muted golden tests are repaired too): it deletes the dead `before_<label>` directories across
+  each suite, removes the declarations and their now-unused constants from the test sources, and
+  reformats. Nothing else moves. A `since` through a version constant is matched by name
+  (`Sum.ESQL_SUM_LONG_OVERFLOW_FIX` names `esql_sum_long_overflow_fix`); one the task cannot
+  match fails with a message asking for a hand edit.
 - Error that a declaration no longer resolves: the transport version name was retired, meaning the
   code path it gated is gone. Remove the declaration; for a label, also delete its
   `before_<label>` directory (its files described planning that no longer exists).


### PR DESCRIPTION
Follow-up to the golden-test rollout under #150856.

A golden `expectationChangesAt` label or `since()` dies when the compatibility floor passes its version. The runner already ignores it, but the declaration stays in the test and its `before_<label>` directory stays in the tree. Both describe planning nobody can run anymore. Until now this was a warning nobody read. The scheduled strict sweep meant to escalate it was never built.

Dead declarations now fail the test. That happens on the one PR per major release that moves the floor, and the failure names the fix:

```
./gradlew :x-pack:plugin:esql:goldenGc -Dtests.mutes.enabled=false
```

The task runs the golden suites in repair mode. For each dead declaration it removes the `.expectationChangesAt(...)` or `.since(...)` call from the test source, drops the `static final String` constant that held the name once nothing else uses it, deletes every `before_<label>` directory of that name in the suite (muted siblings included), then runs spotless. A `since` through a version constant is matched by name, so `Sum.ESQL_SUM_LONG_OVERFLOW_FIX` is recognised as `esql_sum_long_overflow_fix`. A declaration the task cannot match fails with a message asking for a hand edit. A repair that finds nothing to rewrite fails too, unless this run already rewrote the class's source for the same version (the other mode of the test, or a sibling sharing the abstract parent). So a green run means the tree is clean.

<details>
<summary>Verification</summary>

- `GoldenGcTests`: the source rewrites on the shapes the suites use (chained calls inline and on their own line, trailing comments, literal names, string constants, the four constant-naming styles in the tree, a lookalike constant that must be left alone, a constant still referenced elsewhere, idempotency, suite-wide directory deletion).
- All 1686 golden tests pass under the new task with nothing to repair today: every referable version is above the current floor, and the tree is unchanged after the run.
- Rehearsal of a floor bump to 9524000 locally, which kills seven declared versions including a `since` declared in a helper method: default mode fails 302 tests, every message a dead declaration and none of another kind; `goldenGc` deletes 412 expectation files under six dead labels and edits 19 test sources with no repair failure; the default run on the repaired tree passes 1687 of 1688 golden tests, the one failure being `PromqlGoldenTests.testBinaryWithDifferentSelectors`, already muted on main for flakiness (#157827, #157912) and only visible because the rehearsal disabled mutes. Floor and repairs reverted afterwards; nothing of the rehearsal is in this PR.
- Second rehearsal after the review round, floor bumped to 9385000 with the stricter no-op check: `goldenGc` passes 1688 golden tests with 0 failures, deleting 205 expectation files and rewriting 13 sources, no false failure from the shared-parent or second-mode cases. Reverted afterwards.
- `checkstyleTest` and `spotlessJavaCheck` clean.

</details>

<details>
<summary>Known limits</summary>

- A `since` through a version constant whose name does not resemble the version's name is reported, not rewritten.
- A whole suite skipped by a class-level `assumeTrue` is not repaired; it is not run in default mode either, so nothing fails until the capability turns on.
- The task reformats the whole module, since spotless has no per-file mode here.

</details>

Relates #150856.

_Assisted by Claude._

