### PR TITLE
Add missing roles to authorization field

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/xcontent/XContentUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/xcontent/XContentUtils.java
@@ -83,7 +83,14 @@ public class XContentUtils {
      * - If the permissions are based on a user's roles at the time the config was created then the list of these
      *   roles is added.
      * - If the permissions come from an API key then the ID and name of the API key are added.
-     * - If the permissions come from a service account then the name of the service account is added.
+     * - If the permissions come from a service account then the name of the service account is added, along with its
+     *   assigned roles if it is user-managed rather than built-in.
+     * - If the permissions come from a cloud API key or a cloud service account then its ID and assigned roles are
+     *   added under a key naming the kind.
+     * - If the permissions come from a cross cluster access subject then the querying cluster's API key is added
+     *   together with the remote subject's own authorization, rendered by these same rules.
+     * Any subject whose roles are capped by the cloud identity provider also reports the names of the capping roles,
+     * because the assigned roles alone would overstate its permissions.
      * @param builder The {@link XContentBuilder} that the extra fields will be added to.
      * @param headers Security headers that were stored to determine which permissions a background service
      *                will run as. If <code>null</code> or no authentication key entry is present then no
@@ -124,9 +131,20 @@ public class XContentUtils {
 
     private static void addSubjectInfo(XContentBuilder builder, Subject subject) throws IOException {
         switch (subject.getType()) {
-            case USER -> builder.array(User.Fields.ROLES.getPreferredName(), subject.getUser().roles());
+            case USER -> {
+                builder.array(User.Fields.ROLES.getPreferredName(), subject.getUser().roles());
+                addCloudLimitedByRoles(builder, subject);
+            }
             case API_KEY -> addApiKeyInfo(builder, subject);
-            case SERVICE_ACCOUNT -> builder.field("service_account", subject.getUser().principal());
+            case SERVICE_ACCOUNT -> {
+                builder.field("service_account", subject.getUser().principal());
+                // A built-in account's privileges are fixed by its definition and resolved from the principal alone, so the
+                // principal is the whole authorization. A user-managed account is instead authorized from the role names
+                // snapshotted onto its user, which the principal does not reveal, so they have to be reported alongside it.
+                if (subject.isUserManagedServiceAccount()) {
+                    builder.array(User.Fields.ROLES.getPreferredName(), subject.getUser().roles());
+                }
+            }
             case CROSS_CLUSTER_ACCESS -> {
                 builder.startObject("cross_cluster_access");
                 {
@@ -149,14 +167,27 @@ public class XContentUtils {
                 }
                 builder.field("internal", metadata.get(AuthenticationField.API_KEY_INTERNAL_KEY));
                 builder.array(User.Fields.ROLES.getPreferredName(), subject.getUser().roles());
+                addCloudLimitedByRoles(builder, subject);
                 builder.endObject();
             }
             case CLOUD_SERVICE_ACCOUNT -> {
                 builder.startObject("cloud_service_account");
                 builder.field("id", subject.getUser().principal());
                 builder.array(User.Fields.ROLES.getPreferredName(), subject.getUser().roles());
+                addCloudLimitedByRoles(builder, subject);
                 builder.endObject();
             }
+        }
+    }
+
+    /**
+     * Reports the cloud identity provider's cap on a subject's assigned roles, when it has one. Authorization ANDs the
+     * cap with the assigned roles, so listing only the latter would overstate what the background service can do.
+     */
+    private static void addCloudLimitedByRoles(XContentBuilder builder, Subject subject) throws IOException {
+        final List<String> limitedByRoleNames = subject.getCloudLimitedByRoleNames();
+        if (limitedByRoleNames != null) {
+            builder.array(User.Fields.LIMITED_BY_ROLES.getPreferredName(), limitedByRoleNames.toArray(String[]::new));
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/xcontent/XContentUtilsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/xcontent/XContentUtilsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.security.xcontent;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -20,6 +21,7 @@ import org.elasticsearch.xpack.core.security.user.User;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -88,6 +90,74 @@ public class XContentUtilsTests extends ESTestCase {
         assertThat(json, equalTo("{\"authorization\":{\"service_account\":\"" + account + "\"}}"));
     }
 
+    /**
+     * A built-in account's privileges follow from its principal, but a user-managed account's follow from the role
+     * names snapshotted onto it, so the principal alone would not say what the background service may do.
+     */
+    public void testAddAuthorizationInfoWithUserManagedServiceAccount() throws IOException {
+        final String account = "apps/" + randomAlphaOfLengthBetween(3, 8);
+        final String[] roles = randomArray(1, 3, String[]::new, () -> "role_" + randomAlphaOfLengthBetween(3, 8));
+        final Authentication authentication = AuthenticationTestHelper.builder().userManagedServiceAccount(account, roles).build();
+        final String json = generateJson(Map.of(AuthenticationField.AUTHENTICATION_KEY, authentication.encode()));
+        assertThat(json, equalTo("{\"authorization\":{\"service_account\":\"" + account + "\",\"roles\":" + jsonStringArray(roles) + "}}"));
+    }
+
+    public void testAddAuthorizationInfoWithCloudServiceAccount() throws IOException {
+        final String serviceAccountId = randomAlphanumericOfLength(20);
+        final List<String> limitedByRoleNames = randomBoolean() ? null : AuthenticationTestHelper.randomCloudLimitedByRoleNames();
+        final Authentication authentication = AuthenticationTestHelper.randomCloudServiceAccountAuthentication(
+            serviceAccountId,
+            limitedByRoleNames
+        );
+        final String json = generateJson(Map.of(AuthenticationField.AUTHENTICATION_KEY, authentication.encode()));
+        assertThat(
+            json,
+            equalTo(
+                "{\"authorization\":{\"cloud_service_account\":{\"id\":\""
+                    + serviceAccountId
+                    + "\",\"roles\":"
+                    + jsonStringArray(authentication.getEffectiveSubject().getUser().roles())
+                    + expectedLimitedByRoles(limitedByRoleNames)
+                    + "}}}"
+            )
+        );
+    }
+
+    /**
+     * Authorization ANDs the cloud identity provider's cap with the subject's assigned roles, so reporting only the
+     * latter would overstate the permissions a background service runs with. The cap can be attached to a cloud user
+     * token, which authenticates through an ordinary realm and so presents as a plain user subject.
+     */
+    public void testAddAuthorizationInfoWithCloudUserLimitedByRoles() throws IOException {
+        final List<String> limitedByRoleNames = AuthenticationTestHelper.randomCloudLimitedByRoleNames();
+        final Authentication authentication = AuthenticationTestHelper.randomCloudUserAuthentication(limitedByRoleNames);
+        final String json = generateJson(Map.of(AuthenticationField.AUTHENTICATION_KEY, authentication.encode()));
+        assertThat(
+            json,
+            equalTo(
+                "{\"authorization\":{\"roles\":"
+                    + jsonStringArray(authentication.getEffectiveSubject().getUser().roles())
+                    + expectedLimitedByRoles(limitedByRoleNames)
+                    + "}}"
+            )
+        );
+    }
+
+    public void testAddAuthorizationInfoWithCloudApiKeyLimitedByRoles() throws IOException {
+        final List<String> limitedByRoleNames = AuthenticationTestHelper.randomCloudLimitedByRoleNames();
+        final User user = AuthenticationTestHelper.randomCloudApiKeyUser();
+        final Authentication authentication = AuthenticationTestHelper.randomCloudApiKeyAuthentication(
+            user,
+            user.principal(),
+            limitedByRoleNames
+        );
+        final String json = generateJson(Map.of(AuthenticationField.AUTHENTICATION_KEY, authentication.encode()));
+        assertThat(
+            json,
+            containsString("\"roles\":" + jsonStringArray(user.roles()) + ",\"limited_by_roles\":" + jsonStringArray(limitedByRoleNames))
+        );
+    }
+
     public void testAddAuthorizationInfoWithCrossClusterAccess() throws IOException {
         final Authentication authentication = AuthenticationTestHelper.builder().crossClusterAccess().build();
         final var apiKeyName = (String) authentication.getAuthenticatingSubject().getMetadata().get(API_KEY_NAME_KEY);
@@ -130,6 +200,18 @@ public class XContentUtilsTests extends ESTestCase {
     public void testAddAuthorizationInfoWithCorruptData() throws IOException {
         String json = generateJson(Map.of(AuthenticationField.AUTHENTICATION_KEY, "corrupt"));
         assertThat(json, equalTo("{}"));
+    }
+
+    private static String jsonStringArray(String... values) {
+        return Arrays.stream(values).collect(Collectors.joining("\",\"", "[\"", "\"]"));
+    }
+
+    private static String jsonStringArray(List<String> values) {
+        return jsonStringArray(values.toArray(String[]::new));
+    }
+
+    private static String expectedLimitedByRoles(@Nullable List<String> limitedByRoleNames) {
+        return limitedByRoleNames == null ? "" : ",\"limited_by_roles\":" + jsonStringArray(limitedByRoleNames);
     }
 
     private String generateJson(Map<String, String> headers) throws IOException {

--- a/x-pack/plugin/transform/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_authorization.yml
+++ b/x-pack/plugin/transform/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_authorization.yml
@@ -1,0 +1,109 @@
+setup:
+  - skip:
+      features: headers
+
+  - requires:
+      capabilities:
+        - method: PUT
+          path: /_security/service/{namespace}/{service}
+          capabilities: [user_managed_service_accounts]
+      test_runner_features: capabilities
+      reason: "User-managed service accounts are unavailable in multi-project clusters"
+
+  - do:
+      indices.create:
+        index: airline-data
+        body:
+          mappings:
+            properties:
+              time:
+                type: date
+              airline:
+                type: keyword
+              responsetime:
+                type: float
+
+  - do:
+      security.put_role:
+        name: "transform_worker"
+        body: >
+          {
+            "cluster": ["manage_transform"],
+            "indices": [
+              {
+                "names": ["airline-data", "airline-data-by-airline"],
+                "privileges": ["read", "view_index_metadata", "create_index", "index"]
+              }
+            ]
+          }
+
+  - do:
+      security.put_user_managed_service_account:
+        namespace: apps
+        service: transform_worker
+        body: >
+          {
+            "roles": ["transform_worker"],
+            "enabled": true
+          }
+
+---
+teardown:
+  - do:
+      transform.delete_transform:
+        transform_id: "service-account-transform"
+        ignore: 404
+
+  - do:
+      security.delete_service_token:
+        namespace: apps
+        service: transform_worker
+        name: transform-token
+        ignore: 404
+
+  - do:
+      security.delete_user_managed_service_account:
+        namespace: apps
+        service: transform_worker
+        force: true
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "transform_worker"
+        ignore: 404
+
+---
+"Test get transform authorization for a user-managed service account":
+  # The stash is cleared between the setup section and here, so the token has to be minted in
+  # the section that uses it.
+  - do:
+      security.create_service_token:
+        namespace: apps
+        service: transform_worker
+        name: transform-token
+  - set: { "token.value": transform_service_token }
+
+  - do:
+      headers:
+        Authorization: Bearer ${transform_service_token}
+      transform.put_transform:
+        transform_id: "service-account-transform"
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "dest": { "index": "airline-data-by-airline" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }
+
+  # The principal alone does not say what a user-managed account may do, so the roles it was
+  # created with have to travel with it. A built-in account emits the principal on its own.
+  - do:
+      transform.get_transform:
+        transform_id: "service-account-transform"
+  - match: { transforms.0.authorization.service_account: "apps/transform_worker" }
+  - match: { transforms.0.authorization.roles: ["transform_worker"] }
+  - is_false: transforms.0.authorization.api_key


### PR DESCRIPTION
The `authorization` field on transform, datafeed, and data frame analytics GET responses reports the identity a background job runs as, decoded from the security headers stored at creation. Two recently added subject kinds were reported incompletely.

A user-managed service account rendered as a bare principal. That is right for a built-in account, whose privileges are a fixed role descriptor resolved from the principal, but a user-managed account is authorized from the role names snapshotted onto its user, so the principal alone does not say what the job may do. Emit those names as a sibling `roles` array, leaving the built-in shape untouched.

Cloud subjects reported their assigned roles without the cloud identity provider's cap. Authorization ANDs the two, so the assigned names alone overstate the job's permissions. A plain user, a cloud API key, and a cloud service account can all carry a cap, so emit `limited_by_roles` for all three.
