### PR TITLE
Count bytes actually read in inference SizeLimitInputStream

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStream.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStream.java
@@ -58,7 +58,7 @@ public final class SizeLimitInputStream extends FilterInputStream {
         int bytesRead = super.read(b, off, len);
 
         if (bytesRead != -1) {
-            byteCounter.addAndGet(len);
+            byteCounter.addAndGet(bytesRead);
             checkMaximumLengthReached();
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStreamTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStreamTests.java
@@ -29,6 +29,15 @@ public class SizeLimitInputStreamTests extends ESTestCase {
         }
     }
 
+    public void testRead_WithBufferLargerThanData_WithoutThrowingException() throws IOException {
+        int size = randomIntBetween(1, 100);
+
+        try (var stream = createRandomLimitedStream(size, size)) {
+            assertThat(stream.read(new byte[size + randomIntBetween(1, 100)]), is(size));
+            assertThat(stream.read(new byte[size]), is(-1));
+        }
+    }
+
     public void testRead_OneByteAtATime_WithoutThrowingException() throws IOException {
         int size = randomIntBetween(1, 100);
 


### PR DESCRIPTION
While comparing the three copies of `SizeLimitInputStream` in the repo, I noticed that the inference one counts the wrong thing in `read(byte[], int, int)`: it adds `len` (the size the caller asked for) to the byte counter instead of `bytesRead` (what the underlying stream actually returned). The copy added in `modules/workload-identity` with #149767 already counts `bytesRead`.

This matters because `HttpResult.limitBody` reads provider responses through this stream with `Streams.copy`, which uses an 8 KiB buffer. Every short read, and on a socket most reads are short, gets counted as a full 8 KiB, so the counter can run well ahead of the real body size. A response comfortably under `xpack.inference.http.max_response_size` can then be rejected with `InputStreamTooLargeException`, depending on how the bytes happen to arrive. The smallest case is a single read with a buffer larger than the remaining data: a 75 byte body with a 75 byte limit fails on the first call.

The fix is the one-word change to `byteCounter.addAndGet(bytesRead)`. I added `testRead_WithBufferLargerThanData_WithoutThrowingException` to `SizeLimitInputStreamTests`, which reads the whole body with an oversized buffer and then expects EOF. Without the fix it fails with `Maximum limit of [75] bytes reached` (seed `27EA702A3AFE2E66`); with it, the suite passes over 20 iterations. I also ran `spotlessJavaCheck` for the inference plugin, `HttpClientTests` and `RetryingHttpSenderTests`, all green. I did not run the full `gradle check`.

AI tools used
