### PR TITLE
Colocate simdjson benchmark with libs:simdjson

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     // us to invoke the JMH uberjar as usual.
     exclude group: 'net.sf.jopt-simple', module: 'jopt-simple'
   }
-  api(project(':libs:simdjson'))
   api(project(':libs:h3'))
   api(project(':modules:aggregations'))
   implementation project(':modules:mapper-extras');
@@ -131,7 +130,6 @@ tasks.named("compileJava").configure {
   // org.elasticsearch.plugins.internal is used in signatures classes used in benchmarks but we don't want to expose it publicly
   // adding an export to allow compilation with gradle. This does not solve a problem in intellij as it does not use compileJava task
   options.compilerArgs.addAll(["--add-exports", "org.elasticsearch.server/org.elasticsearch.plugins.internal=ALL-UNNAMED"])
-  options.compilerArgs.addAll(["--add-reads", "org.elasticsearch.simdjson=ALL-UNNAMED"])
 }
 
 tasks.register('copyExpression', Copy) {
@@ -156,9 +154,7 @@ tasks.named("run").configure {
   // Arrow's MemoryUtil reflects into java.nio.Buffer.address during static init; the parquet
   // format reader transitively triggers this via BlockFactory.arrowAllocator(). Mirrors the
   // flag already set on the test task above and on :x-pack:plugin:esql-datasource-parquet:test.
-  jvmArgs '--add-modules=jdk.incubator.vector'
   jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
-  jvmArgs '--add-opens=org.elasticsearch.server/org.elasticsearch.escf=ALL-UNNAMED'
   jvmArgs '--enable-native-access=ALL-UNNAMED'
   jvmArgs '-Dorg.apache.lucene.vectorization.upperJavaFeatureVersion=' + buildParams.getRuntimeJavaVersion().map { it.majorVersion }.get()
   // Without this the vectorization providers fall back to their scalar implementations, so a benchmark

--- a/libs/simdjson/README.md
+++ b/libs/simdjson/README.md
@@ -21,19 +21,22 @@ cache, direct walker) lives in the exported API and sibling `internal` packages.
 ```
 libs/simdjson/
 ├── src/                              # Java module (org.elasticsearch.simdjson)
-│   └── main/java/
-│       ├── module-info.java          #   Exports org.elasticsearch.simdjson only
-│       └── org/elasticsearch/simdjson/
-│           ├── SimdJsonParserPool.java   # Public entry point (thread-local document parsers)
-│           ├── JsonDocumentParser.java   # Single-document parser (stage 1 indexer + walker)
-│           ├── SimdJsonParser.java       # Stage 1 + per-document index windows
-│           ├── SimdJsonDirectWalker.java # Fused stage 2 / token walk
-│           ├── JsonDocumentHandler.java  # Callback API for field events
-│           └── internal/
-│               ├── StructuralIndexer.java    # Native stage 1 wrapper
-│               ├── SimdJsonLibrary.java      # FFM binding to libsimdjson
-│               ├── parsers/                  # Vendored from simdjson-java
-│               └── fieldnames/               # Per-batch field name cache
+│   ├── main/java/
+│   │   ├── module-info.java          #   Exports org.elasticsearch.simdjson only
+│   │   └── org/elasticsearch/simdjson/
+│   │       ├── SimdJsonParserPool.java   # Public entry point (thread-local document parsers)
+│   │       ├── JsonDocumentParser.java   # Single-document parser (stage 1 indexer + walker)
+│   │       ├── SimdJsonParser.java       # Stage 1 + per-document index windows
+│   │       ├── SimdJsonDirectWalker.java # Fused stage 2 / token walk
+│   │       ├── JsonDocumentHandler.java  # Callback API for field events
+│   │       └── internal/
+│   │           ├── StructuralIndexer.java    # Native stage 1 wrapper
+│   │           ├── SimdJsonLibrary.java      # FFM binding to libsimdjson
+│   │           ├── parsers/                  # Vendored from simdjson-java
+│   │           └── fieldnames/               # Per-batch field name cache
+│   └── benchmark/java/               # JMH benchmarks (gradlew :libs:simdjson:benchmark)
+│       └── org/elasticsearch/benchmark/xcontent/
+│           └── SimdJsonParserBenchmark.java  # simdjson vs Jackson through EscfEncoder
 ├── native/                           # Native C++ library (libsimdjson)
 │   ├── src/
 │   │   ├── es_simdjson.cpp           #   Elasticsearch stage 1 FFI surface
@@ -53,7 +56,6 @@ libs/simdjson/
     its thread's `JsonDocumentParser` once at construction
 - **`libs/native/libraries`** — downloads `org.elasticsearch:libsimdjson` native zips at
      build time.
-- **`benchmarks`** — `SimdJsonParserBenchmark` JMH harness
 
 ## Parsing pipeline
 

--- a/libs/simdjson/build.gradle
+++ b/libs/simdjson/build.gradle
@@ -8,12 +8,14 @@
  */
 
 import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask
+import org.elasticsearch.gradle.internal.test.TestUtil
 
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.foreign-library'
 apply plugin: 'elasticsearch.foreign-api'
 apply plugin: 'elasticsearch.native-library-build'
+apply plugin: 'elasticsearch.jmh'
 
 dependencies {
   api project(':libs:foreign-library')
@@ -24,6 +26,10 @@ dependencies {
   testImplementation(testFixtures(project(':libs:simdvec'))) {
     exclude group: 'org.elasticsearch', module: 'simdjson'
   }
+
+  // SimdJsonParserBenchmark measures simdjson through the EscfEncoder pipeline, so the benchmark
+  // source set needs :server for the escf, sourcebatch and bytes classes.
+  benchmarkImplementation project(':server')
 }
 
 tasks.named('compileJava').configure {
@@ -49,6 +55,14 @@ tasks.named('processForeignAnnotations').configure {
 tasks.named('javadoc').configure {
   options.addStringOption("-add-modules", "jdk.incubator.vector")
   options.addStringOption("-add-reads", "org.elasticsearch.simdjson=jdk.incubator.vector")
+}
+
+tasks.named('benchmark').configure {
+  dependsOn ':libs:native:native-libraries:extractLibs'
+  jvmArgs '--add-modules=jdk.incubator.vector', '--enable-native-access=ALL-UNNAMED'
+  // The benchmark bodies run in JMH's forked VMs; `es.nativelibs.path` needs to be passed as
+  // a system property so it get passed down to the fork.
+  systemProperty 'es.nativelibs.path', TestUtil.getTestLibraryPath(file('../native/libraries/build/platform/').toString())
 }
 
 tasks.withType(CheckForbiddenApisTask).configureEach {

--- a/libs/simdjson/src/benchmark/java/org/elasticsearch/benchmark/xcontent/SimdJsonParserBenchmark.java
+++ b/libs/simdjson/src/benchmark/java/org/elasticsearch/benchmark/xcontent/SimdJsonParserBenchmark.java
@@ -12,6 +12,7 @@ package org.elasticsearch.benchmark.xcontent;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.escf.EscfBatch;
 import org.elasticsearch.escf.EscfEncoder;
 import org.elasticsearch.simdjson.SimdJsonParserPool;
@@ -33,6 +34,7 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -78,17 +80,16 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p><strong>Running.</strong> Defaults cover two document shapes; {@code otel_nested} and other
  * parameters are available via {@code -p}.
  * <pre>{@code
- * cd benchmarks
  * # Single-threaded (default):
- * ../gradlew run --args "org.elasticsearch.benchmark.xcontent.SimdJsonParserBenchmark \
+ * ./gradlew :libs:simdjson:benchmark --args "SimdJsonParserBenchmark \
  *   -rf json -rff build/jmh-result.json" | tee /tmp/bench/simdjson_vs_jackson
  *
  * # Multi-threaded (8 threads):
- * ../gradlew run --args "org.elasticsearch.benchmark.xcontent.SimdJsonParserBenchmark \
+ * ./gradlew :libs:simdjson:benchmark --args "SimdJsonParserBenchmark \
  *   -t 8 -rf json -rff build/jmh-result.json" | tee /tmp/bench/simdjson_vs_jackson_mt
  *
  * # All shapes, single bulk size:
- * ../gradlew run --args "org.elasticsearch.benchmark.xcontent.SimdJsonParserBenchmark \
+ * ./gradlew :libs:simdjson:benchmark --args "SimdJsonParserBenchmark \
  *   -p shape=clickbench_flat,otel_nested,small_sparse -p docCount=1000"
  * }</pre>
  */
@@ -143,14 +144,22 @@ public class SimdJsonParserBenchmark {
             totalLen += raw.length;
         }
 
+        printSetupSummary(minLen, totalLen / docCount, maxLen);
+    }
+
+    @SuppressForbidden(
+        reason = "setup summary for the benchmark run; nativeStage1 tells the reader whether simdjson was actually exercised"
+    )
+    private void printSetupSummary(int minLen, long avgLen, int maxLen) {
         System.out.printf(
+            Locale.ROOT,
             "[setup] thread=%s shape=%s docCount=%d shardCount=%d docSize min=%d avg=%d max=%d nativeStage1=%s maxSimdDocBytes=%d%n",
             Thread.currentThread().getName(),
             shape,
             docCount,
             shardCount,
             minLen,
-            totalLen / docCount,
+            avgLen,
             maxLen,
             SimdJsonSupport.isSupported(),
             SimdJsonParserPool.getDefault().maxDocumentBytes()
@@ -207,54 +216,56 @@ public class SimdJsonParserBenchmark {
     }
 
     private static String generateClickBenchFlat(Random random) {
-        return """
-            {
-              "WatchID": %d, "JavaEnable": %d, "Title": "%s",
-              "GoodEvent": %d, "EventTime": %d, "EventDate": %d,
-              "CounterID": %d, "ClientIP": %d, "ClientIP6": "%s",
-              "RegionID": %d, "UserID": %d,
-              "CounterClass": %d, "OS": %d, "UserAgent": %d,
-              "URL": "https://example.com/%s", "Referer": "https://ref.example.com/%s",
-              "URLDomain": "example.com", "RefererDomain": "ref.example.com",
-              "Refresh": %d, "IsRobot": %d, "RefererCategories": %d,
-              "URLCategories": %d, "URLRegions": %d, "RefererRegions": %d,
-              "ResolutionWidth": %d, "ResolutionHeight": %d, "ResolutionDepth": %d,
-              "FlashMajor": %d, "FlashMinor": %d, "FlashMinor2": "%d",
-              "NetMajor": %d, "NetMinor": %d, "UserAgentMajor": %d,
-              "UserAgentMinor": %d, "CookieEnable": %d, "JavascriptEnable": %d,
-              "IsMobile": %d, "MobilePhone": %d, "MobilePhoneModel": "%s",
-              "Params": "", "IPNetworkID": %d,
-              "TraficSourceID": %d, "SearchEngineID": %d,
-              "SearchPhrase": "%s",
-              "AdvEngineID": %d, "IsArtifical": %d, "WindowClientWidth": %d,
-              "WindowClientHeight": %d, "ClientTimeZone": %d,
-              "ClientEventTime": %d, "SilverlightVersion1": %d, "SilverlightVersion2": %d,
-              "SilverlightVersion3": %d, "SilverlightVersion4": %d,
-              "PageCharset": "UTF-8", "CodeVersion": %d, "IsLink": %d,
-              "IsDownload": %d, "IsNotBounce": %d, "FUniqID": %d,
-              "HID": %d, "IsOldCounter": %d, "IsEvent": %d,
-              "IsParameter": %d, "DontCountHits": %d, "WithHash": %d,
-              "HitColor": "W", "UTCEventTime": %d,
-              "Age": %d, "Sex": %d, "Income": %d,
-              "Interests": %d, "Robotness": %d, "GeneralInterests": %d,
-              "RemoteIP": %d, "RemoteIP6": "%s",
-              "WindowName": %d, "OpenerName": %d, "HistoryLength": %d,
-              "BrowserLanguage": "en", "BrowserCountry": "US",
-              "SocialNetwork": "", "SocialAction": "", "HTTPError": %d,
-              "SendTiming": %d, "DNSTiming": %d, "ConnectTiming": %d,
-              "ResponseStartTiming": %d, "ResponseEndTiming": %d,
-              "FetchTiming": %d, "RedirectTiming": %d, "DOMInteractiveTiming": %d,
-              "ContentLoadTiming": %d, "OnLoadTiming": %d,
-              "RequestNum": %d, "RequestTry": %d,
-              "NetErrorCode": %d, "SocialShareNetwork": "", "SocialSharePage": "",
-              "ParamPrice": %d, "ParamOrderID": "", "ParamCurrency": "USD",
-              "ParamCurrencyID": %d,
-              "GoalsReached": %d, "OpenstatServiceName": "", "OpenstatCampaignID": "",
-              "OpenstatAdID": "", "OpenstatSourceID": "",
-              "UTMSource": "", "UTMMedium": "", "UTMCampaign": "", "UTMContent": "", "UTMTerm": "",
-              "FromTag": "", "HasGCLID": %d, "RefererHash": %d, "URLHash": %d,
-              "CLID": %d, "YCLID": %d, "ShareService": "", "ShareURL": "", "ShareTitle": ""
-            }""".formatted(
+        return String.format(
+            Locale.ROOT,
+            """
+                {
+                  "WatchID": %d, "JavaEnable": %d, "Title": "%s",
+                  "GoodEvent": %d, "EventTime": %d, "EventDate": %d,
+                  "CounterID": %d, "ClientIP": %d, "ClientIP6": "%s",
+                  "RegionID": %d, "UserID": %d,
+                  "CounterClass": %d, "OS": %d, "UserAgent": %d,
+                  "URL": "https://example.com/%s", "Referer": "https://ref.example.com/%s",
+                  "URLDomain": "example.com", "RefererDomain": "ref.example.com",
+                  "Refresh": %d, "IsRobot": %d, "RefererCategories": %d,
+                  "URLCategories": %d, "URLRegions": %d, "RefererRegions": %d,
+                  "ResolutionWidth": %d, "ResolutionHeight": %d, "ResolutionDepth": %d,
+                  "FlashMajor": %d, "FlashMinor": %d, "FlashMinor2": "%d",
+                  "NetMajor": %d, "NetMinor": %d, "UserAgentMajor": %d,
+                  "UserAgentMinor": %d, "CookieEnable": %d, "JavascriptEnable": %d,
+                  "IsMobile": %d, "MobilePhone": %d, "MobilePhoneModel": "%s",
+                  "Params": "", "IPNetworkID": %d,
+                  "TraficSourceID": %d, "SearchEngineID": %d,
+                  "SearchPhrase": "%s",
+                  "AdvEngineID": %d, "IsArtifical": %d, "WindowClientWidth": %d,
+                  "WindowClientHeight": %d, "ClientTimeZone": %d,
+                  "ClientEventTime": %d, "SilverlightVersion1": %d, "SilverlightVersion2": %d,
+                  "SilverlightVersion3": %d, "SilverlightVersion4": %d,
+                  "PageCharset": "UTF-8", "CodeVersion": %d, "IsLink": %d,
+                  "IsDownload": %d, "IsNotBounce": %d, "FUniqID": %d,
+                  "HID": %d, "IsOldCounter": %d, "IsEvent": %d,
+                  "IsParameter": %d, "DontCountHits": %d, "WithHash": %d,
+                  "HitColor": "W", "UTCEventTime": %d,
+                  "Age": %d, "Sex": %d, "Income": %d,
+                  "Interests": %d, "Robotness": %d, "GeneralInterests": %d,
+                  "RemoteIP": %d, "RemoteIP6": "%s",
+                  "WindowName": %d, "OpenerName": %d, "HistoryLength": %d,
+                  "BrowserLanguage": "en", "BrowserCountry": "US",
+                  "SocialNetwork": "", "SocialAction": "", "HTTPError": %d,
+                  "SendTiming": %d, "DNSTiming": %d, "ConnectTiming": %d,
+                  "ResponseStartTiming": %d, "ResponseEndTiming": %d,
+                  "FetchTiming": %d, "RedirectTiming": %d, "DOMInteractiveTiming": %d,
+                  "ContentLoadTiming": %d, "OnLoadTiming": %d,
+                  "RequestNum": %d, "RequestTry": %d,
+                  "NetErrorCode": %d, "SocialShareNetwork": "", "SocialSharePage": "",
+                  "ParamPrice": %d, "ParamOrderID": "", "ParamCurrency": "USD",
+                  "ParamCurrencyID": %d,
+                  "GoalsReached": %d, "OpenstatServiceName": "", "OpenstatCampaignID": "",
+                  "OpenstatAdID": "", "OpenstatSourceID": "",
+                  "UTMSource": "", "UTMMedium": "", "UTMCampaign": "", "UTMContent": "", "UTMTerm": "",
+                  "FromTag": "", "HasGCLID": %d, "RefererHash": %d, "URLHash": %d,
+                  "CLID": %d, "YCLID": %d, "ShareService": "", "ShareURL": "", "ShareTitle": ""
+                }""",
             random.nextLong(),
             random.nextInt(2),
             randomWord(random),
@@ -355,34 +366,36 @@ public class SimdJsonParserBenchmark {
     }
 
     private static String generateOtelNested(Random random) {
-        return """
-            {
-              "@timestamp": "2025-09-23T%02d:%02d:%02dZ",
-              "resource": {
-                "service.name": "%s",
-                "service.version": "1.%d.0",
-                "host.name": "host-%d",
-                "deployment.environment": "%s"
-              },
-              "scope": {
-                "name": "%s-logger",
-                "version": "2.%d.0"
-              },
-              "severity_text": "%s",
-              "severity_number": %d,
-              "body": "%s",
-              "trace_id": "%s",
-              "span_id": "%s",
-              "trace_flags": %d,
-              "attributes": {
-                "http.method": "%s",
-                "http.status_code": %d,
-                "http.url": "https://api.example.com/%s",
-                "user.id": %d,
-                "db.system": "postgresql",
-                "db.statement": "SELECT * FROM %s WHERE id = %d"
-              }
-            }""".formatted(
+        return String.format(
+            Locale.ROOT,
+            """
+                {
+                  "@timestamp": "2025-09-23T%02d:%02d:%02dZ",
+                  "resource": {
+                    "service.name": "%s",
+                    "service.version": "1.%d.0",
+                    "host.name": "host-%d",
+                    "deployment.environment": "%s"
+                  },
+                  "scope": {
+                    "name": "%s-logger",
+                    "version": "2.%d.0"
+                  },
+                  "severity_text": "%s",
+                  "severity_number": %d,
+                  "body": "%s",
+                  "trace_id": "%s",
+                  "span_id": "%s",
+                  "trace_flags": %d,
+                  "attributes": {
+                    "http.method": "%s",
+                    "http.status_code": %d,
+                    "http.url": "https://api.example.com/%s",
+                    "user.id": %d,
+                    "db.system": "postgresql",
+                    "db.statement": "SELECT * FROM %s WHERE id = %d"
+                  }
+                }""",
             random.nextInt(24),
             random.nextInt(60),
             random.nextInt(60),
@@ -409,8 +422,10 @@ public class SimdJsonParserBenchmark {
 
     private static String generateSmallSparse(Random random, int docIndex) {
         return switch (docIndex % 3) {
-            case 0 -> """
-                {"type":"A","id":%d,"ts":%d,"val":%.4f,"label":"%s","active":%b,"count":%d}""".formatted(
+            case 0 -> String.format(
+                Locale.ROOT,
+                """
+                    {"type":"A","id":%d,"ts":%d,"val":%.4f,"label":"%s","active":%b,"count":%d}""",
                 random.nextLong(),
                 random.nextLong(),
                 random.nextDouble(),
@@ -418,16 +433,20 @@ public class SimdJsonParserBenchmark {
                 random.nextBoolean(),
                 random.nextInt(10000)
             );
-            case 1 -> """
-                {"type":"B","uid":"%s","score":%.3f,"tags":%d,"region":"%s","retries":%d}""".formatted(
+            case 1 -> String.format(
+                Locale.ROOT,
+                """
+                    {"type":"B","uid":"%s","score":%.3f,"tags":%d,"region":"%s","retries":%d}""",
                 randomWord(random),
                 random.nextDouble() * 100,
                 random.nextInt(50),
                 randomWord(random),
                 random.nextInt(5)
             );
-            default -> """
-                {"type":"C","key":%d,"name":"%s","bytes":%d,"ok":%b,"lat":%.2f,"code":%d}""".formatted(
+            default -> String.format(
+                Locale.ROOT,
+                """
+                    {"type":"C","key":%d,"name":"%s","bytes":%d,"ok":%b,"lat":%.2f,"code":%d}""",
                 random.nextLong(),
                 randomWord(random),
                 random.nextLong(),

--- a/libs/simdvec/build.gradle
+++ b/libs/simdvec/build.gradle
@@ -92,10 +92,9 @@ tasks.named('test').configure {
 tasks.named('benchmark').configure {
   dependsOn ':libs:native:native-libraries:extractLibs'
   jvmArgs '--add-modules=jdk.incubator.vector', '--enable-native-access=ALL-UNNAMED'
-  // Forward the native library path to the forked JMH VMs where the benchmark bodies run,
-  // not only to the harness. Mirrors benchmarks/build.gradle's `run` task.
-  def nativeLibsPath = TestUtil.getTestLibraryPath(file('../native/libraries/build/platform/').toString())
-  args '-jvmArgsAppend', "-Des.nativelibs.path=${nativeLibsPath}"
+  // The benchmark bodies run in JMH's forked VMs; `es.nativelibs.path` needs to be passed as
+  // a system property so it get passed down to the fork.
+  systemProperty 'es.nativelibs.path', TestUtil.getTestLibraryPath(file('../native/libraries/build/platform/').toString())
 }
 
 tasks.named('benchmarkTest').configure {

--- a/libs/simdvec/build.gradle
+++ b/libs/simdvec/build.gradle
@@ -91,7 +91,8 @@ tasks.named('test').configure {
 
 tasks.named('benchmark').configure {
   dependsOn ':libs:native:native-libraries:extractLibs'
-  jvmArgs '--add-modules=jdk.incubator.vector', '--enable-native-access=ALL-UNNAMED'
+  // No `--add-modules=jdk.incubator.vector` here. Benchmarks that want the module ask for it themselves via @Fork(jvmArgsPrepend).
+  jvmArgs '--enable-native-access=ALL-UNNAMED'
   // The benchmark bodies run in JMH's forked VMs; `es.nativelibs.path` needs to be passed as
   // a system property so it get passed down to the fork.
   systemProperty 'es.nativelibs.path', TestUtil.getTestLibraryPath(file('../native/libraries/build/platform/').toString())

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/ESVectorUtilByteOperationBenchmark.java
@@ -44,6 +44,7 @@ public class ESVectorUtilByteOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "SCALAR", "PANAMA", "NATIVE" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/ESVectorUtilFloatOperationBenchmark.java
@@ -44,6 +44,7 @@ public class ESVectorUtilFloatOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "SCALAR", "PANAMA", "NATIVE" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/VectorIOBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/VectorIOBenchmark.java
@@ -69,6 +69,7 @@ public class VectorIOBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     private static final String TEST_DIR = "/home/esbench/.rally/benchmarks/races/index";

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/VectorizationInfo.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/VectorizationInfo.java
@@ -16,16 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Prints which {@link ESVectorizationProvider} the JVM resolved.
- *
- * <p>{@code ESVectorizationProvider.lookup} degrades silently: without a readable
- * {@code jdk.incubator.vector} it returns the scalar default, and without the native library it
- * returns a Panama implementation. Either way a benchmark still produces numbers, just not for the
- * implementation the author meant to measure, and the warnings that explain it go to a logger whose
- * level depends on whatever log4j configuration the benchmark classpath happens to carry. The
- * resolved class name separates the four outcomes unambiguously, on stdout, next to the results.
- *
- * <p>The provider is a JVM-wide singleton, so one line per JMH fork says it for every benchmark in
- * that fork.
  */
 public final class VectorizationInfo {
 

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/VectorizationInfo.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/VectorizationInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.vector;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.simdvec.ESVectorizationProvider;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Prints which {@link ESVectorizationProvider} the JVM resolved.
+ *
+ * <p>{@code ESVectorizationProvider.lookup} degrades silently: without a readable
+ * {@code jdk.incubator.vector} it returns the scalar default, and without the native library it
+ * returns a Panama implementation. Either way a benchmark still produces numbers, just not for the
+ * implementation the author meant to measure, and the warnings that explain it go to a logger whose
+ * level depends on whatever log4j configuration the benchmark classpath happens to carry. The
+ * resolved class name separates the four outcomes unambiguously, on stdout, next to the results.
+ *
+ * <p>The provider is a JVM-wide singleton, so one line per JMH fork says it for every benchmark in
+ * that fork.
+ */
+public final class VectorizationInfo {
+
+    private static final AtomicBoolean PRINTED = new AtomicBoolean();
+
+    private VectorizationInfo() {}
+
+    /**
+     * Prints the resolved provider, at most once per JVM. Safe to call from a static initializer:
+     * it forces provider resolution, which every benchmark body would trigger anyway, out of the
+     * measured region.
+     */
+    public static void printOnce() {
+        if (PRINTED.compareAndSet(false, true)) {
+            print(ESVectorizationProvider.getInstance().getClass().getSimpleName());
+        }
+    }
+
+    @SuppressForbidden(reason = "names the vectorization implementation that produced the benchmark's numbers")
+    private static void print(String provider) {
+        System.out.println("[vectorization] provider=" + provider);
+    }
+}

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/AshSphericalScalarQuantizerBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/AshSphericalScalarQuantizerBenchmark.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.quantization;
 
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.benchmark.vector.VectorImplementation;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 import org.elasticsearch.simdvec.AshSphericalScalarQuantizer;
 import org.elasticsearch.simdvec.ESVectorizationProvider;
@@ -41,6 +42,7 @@ public class AshSphericalScalarQuantizerBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     public enum Distribution {

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/ComputeNeighboursBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/ComputeNeighboursBenchmark.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.quantization;
 
 import org.apache.lucene.search.TaskExecutor;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.cluster.CentroidOps;
 import org.elasticsearch.index.codec.vectors.cluster.NeighborHood;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -45,6 +46,7 @@ public class ComputeNeighboursBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "1000", "2000", "3000", "5000", "10000", "20000", "50000" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/MatrixMultiplyBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/MatrixMultiplyBenchmark.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.quantization;
 
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.benchmark.vector.VectorImplementation;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 import org.elasticsearch.simdvec.ESVectorizationProvider;
 import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
@@ -40,6 +41,7 @@ public class MatrixMultiplyBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "SCALAR", "PANAMA" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/OptimizedScalarQuantizerBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/OptimizedScalarQuantizerBenchmark.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.quantization;
 
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -38,6 +39,7 @@ public class OptimizedScalarQuantizerBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "384", "702", "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/OptimizedScalarQuantizerByteBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/OptimizedScalarQuantizerByteBenchmark.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.quantization;
 
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -49,6 +50,7 @@ public class OptimizedScalarQuantizerByteBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "384", "768", "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/Pack1BitValuesBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/Pack1BitValuesBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.quantization;
 
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.benchmark.vector.VectorImplementation;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 import org.elasticsearch.simdvec.ESVectorizationProvider;
 import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
@@ -42,6 +43,7 @@ public class Pack1BitValuesBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "384", "782", "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/Stride4BitValuesBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/quantization/Stride4BitValuesBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.quantization;
 
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.benchmark.vector.VectorImplementation;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 import org.elasticsearch.simdvec.ESVectorizationProvider;
 import org.elasticsearch.simdvec.internal.vectorization.ESVectorUtilSupport;
@@ -42,6 +43,7 @@ public class Stride4BitValuesBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "384", "782", "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/RankVectorsMaxSimDotProductBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/RankVectorsMaxSimDotProductBenchmark.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.BFloat16;
 import org.elasticsearch.script.field.vectors.BFloat16RankVectors;
 import org.elasticsearch.script.field.vectors.ByteRankVectors;
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 public class RankVectorsMaxSimDotProductBenchmark {
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     public enum RankVectorType {

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16BulkOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16BulkOperationBenchmark.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.benchmark.vector.scorer;
 
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.BFloat16;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.elasticsearch.simdvec.SimdVecLibrary.BFloat16QueryType;
@@ -62,6 +63,7 @@ public class VectorScorerBFloat16BulkOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16OperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBFloat16OperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.BFloat16;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.elasticsearch.simdvec.VectorSimilarityType;
@@ -50,6 +51,7 @@ public class VectorScorerBFloat16OperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     static final ValueLayout.OfByte LAYOUT_LE_BFLOAT16 = ValueLayout.JAVA_BYTE;

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBQBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBQBenchmark.java
@@ -16,6 +16,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.benchmark.store.DirectoryType;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.benchmark.vector.store.DirectoryFactory;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
@@ -64,6 +65,7 @@ public class VectorScorerBQBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     public enum VectorImplementation {

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBulkBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerBulkBenchmark.java
@@ -17,6 +17,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.benchmark.store.DirectoryType;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.benchmark.vector.store.DirectoryFactory;
 import org.elasticsearch.core.SuppressForbidden;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -53,6 +54,7 @@ public abstract class VectorScorerBulkBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q2StripedOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q2StripedOperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.BBQTestUtils;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -56,6 +57,7 @@ public class VectorScorerD2Q2StripedOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "128", "256", "512", "1024", "1536", "2048" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4PackedOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4PackedOperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.BBQTestUtils;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -50,6 +51,7 @@ public class VectorScorerD2Q4PackedOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "128", "256", "512", "1024", "1536", "2048" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.BBQTestUtils;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -56,6 +57,7 @@ public class VectorScorerD2Q4StripedOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "128", "256", "512", "1024", "1536", "2048" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerDistanceBulkBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerDistanceBulkBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 import org.elasticsearch.simdvec.ESVectorUtil;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -42,6 +43,7 @@ public class VectorScorerDistanceBulkBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "384", "782", "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerDistanceFunctionBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerDistanceFunctionBenchmark.java
@@ -11,6 +11,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.script.field.vectors.BinaryDenseVector;
 import org.elasticsearch.script.field.vectors.BitBinaryDenseVector;
@@ -57,6 +58,7 @@ public class VectorScorerDistanceFunctionBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     public enum VectorType {

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkOperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.elasticsearch.simdvec.VectorSimilarityType;
@@ -59,6 +60,7 @@ public class VectorScorerFloat32BulkOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32OperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32OperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -43,6 +44,7 @@ public class VectorScorerFloat32OperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     static final ValueLayout.OfFloat LAYOUT_LE_FLOAT = ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4BulkOperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -60,6 +61,7 @@ public class VectorScorerInt4BulkOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4OperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt4OperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -50,6 +51,7 @@ public class VectorScorerInt4OperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     private int packedLen;

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7Benchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7Benchmark.java
@@ -16,6 +16,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.simdvec.ES92Int7VectorsScorer;
@@ -53,6 +54,7 @@ public class VectorScorerInt7Benchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "384", "782", "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7uOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt7uOperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -43,6 +44,7 @@ public class VectorScorerInt7uOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     byte[] byteArrayA;

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkOperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkOperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -58,6 +59,7 @@ public class VectorScorerInt8BulkOperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     @Param({ "1024" })

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8OperationBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8OperationBenchmark.java
@@ -10,6 +10,7 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.simdvec.SimdVecLibrary;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -43,6 +44,7 @@ public class VectorScorerInt8OperationBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     byte[] bytesA;

--- a/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
+++ b/libs/simdvec/src/benchmark/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
@@ -17,6 +17,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.benchmark.internal.BenchmarkLogging;
 import org.elasticsearch.benchmark.store.DirectoryType;
+import org.elasticsearch.benchmark.vector.VectorizationInfo;
 import org.elasticsearch.benchmark.vector.store.DirectoryFactory;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
@@ -91,6 +92,7 @@ public class VectorScorerOSQBenchmark {
 
     static {
         BenchmarkLogging.configure();
+        VectorizationInfo.printOnce();
     }
 
     public enum VectorImplementation {


### PR DESCRIPTION
Follow up of #158867 (vector benchmarks) and #158923 (swisshash benchmarks), applying the same
treatment to libsimdjson.

This PR moves `SimdJsonParserBenchmark` to `libs:simdjson` and cleans up the `benchmarks` project.
It fixes forbidden apis/checkstyle failures that were not checked before (`benchmarks` does not run them).

It also fixes two defect on #158867 I found while testing this PR:
- `es.nativelibs.path` was not passed properly
- blindly setting `--add-modules=jdk.incubator.vector` in build.gradle; each benchmark needs to decide when and where do that in its `@Fork` annotation.

In order to make these defects visible and easier to spot in the future, I added a new `VectorizationInfo.printOnce()` that prints the resolved provider class name once per JMH fork.

Relates to #153230