### PR TITLE
ESQL:DS: Decide PUT dataset and data source on the master

### DIFF
--- a/docs/changelog/159034.yaml
+++ b/docs/changelog/159034.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 159034
+summary: "ESQL:DS: Decide PUT dataset and data source on the master"
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/DatasetSchemaSampleSizeValidationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/DatasetSchemaSampleSizeValidationIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -245,7 +246,10 @@ public class DatasetSchemaSampleSizeValidationIT extends AbstractExternalDataSou
                 new PutDatasetAction.Request(TIMEOUT, TIMEOUT, name, dataSource, resource, null, new HashMap<>(settings))
             ).get()
         );
-        assertThat(err.getCause(), instanceOf(ValidationException.class));
-        return (ValidationException) err.getCause();
+        // PUT is decided on the elected master; a coordinator other than that node wraps the
+        // ValidationException in RemoteTransportException.
+        Throwable cause = ExceptionsHelper.unwrapCause(err.getCause());
+        assertThat(cause, instanceOf(ValidationException.class));
+        return (ValidationException) cause;
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/DatasetSchemaSampleSizeValidationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/DatasetSchemaSampleSizeValidationIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
@@ -96,7 +95,7 @@ public class DatasetSchemaSampleSizeValidationIT extends AbstractExternalDataSou
 
     public void testPutRejectsSchemaSampleSizeWhenExtensionResolvesToParquet() throws Exception {
         registerLocalDataSource("ssz_ext_ds");
-        ValidationException e = expectPutDatasetValidationFailure(
+        IllegalArgumentException e = expectPutDatasetValidationFailure(
             "ssz_ext",
             "ssz_ext_ds",
             "file:///data/events.parquet",
@@ -107,7 +106,7 @@ public class DatasetSchemaSampleSizeValidationIT extends AbstractExternalDataSou
 
     public void testPutRejectsSchemaSampleSizeWhenExplicitFormatIsParquet() throws Exception {
         registerLocalDataSource("ssz_fmt_ds");
-        ValidationException e = expectPutDatasetValidationFailure(
+        IllegalArgumentException e = expectPutDatasetValidationFailure(
             "ssz_fmt",
             "ssz_fmt_ds",
             "file:///data/events",
@@ -119,7 +118,12 @@ public class DatasetSchemaSampleSizeValidationIT extends AbstractExternalDataSou
     public void testPutRejectsSchemaSampleSizeWhenFormatCannotBeDetermined() throws Exception {
         registerLocalDataSource("ssz_ambig_ds");
         String resource = "file:///data/events";
-        ValidationException e = expectPutDatasetValidationFailure("ssz_ambig", "ssz_ambig_ds", resource, Map.of("schema_sample_size", 100));
+        IllegalArgumentException e = expectPutDatasetValidationFailure(
+            "ssz_ambig",
+            "ssz_ambig_ds",
+            resource,
+            Map.of("schema_sample_size", 100)
+        );
         assertThat(
             e.getMessage(),
             containsString(FileDataSourceValidator.cannotDetermineFormatError(resource, Set.of("schema_sample_size")))
@@ -233,7 +237,7 @@ public class DatasetSchemaSampleSizeValidationIT extends AbstractExternalDataSou
         rawDataSources.add(name);
     }
 
-    private ValidationException expectPutDatasetValidationFailure(
+    private IllegalArgumentException expectPutDatasetValidationFailure(
         String name,
         String dataSource,
         String resource,
@@ -246,10 +250,11 @@ public class DatasetSchemaSampleSizeValidationIT extends AbstractExternalDataSou
                 new PutDatasetAction.Request(TIMEOUT, TIMEOUT, name, dataSource, resource, null, new HashMap<>(settings))
             ).get()
         );
-        // PUT is decided on the elected master; a coordinator other than that node wraps the
-        // ValidationException in RemoteTransportException.
+        // PUT is decided on the elected master. A coordinator other than that node wraps the
+        // failure in RemoteTransportException, and ValidationException is not Writeable so the
+        // client sees a plain IllegalArgumentException with the same message.
         Throwable cause = ExceptionsHelper.unwrapCause(err.getCause());
-        assertThat(cause, instanceOf(ValidationException.class));
-        return (ValidationException) cause;
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
+        return (IllegalArgumentException) cause;
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceConfigChangeForwardIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceConfigChangeForwardIT.java
@@ -41,8 +41,7 @@ import static org.hamcrest.Matchers.not;
  *
  * <p>{@code TransportMasterNodeAction} re-enters {@code doExecute} on the master. A listener wrapped
  * there would fire on both the forwarding coordinator and the master, and phone-home sums nodes.
- * Coord pre-check records locally and must not wrap the forwarded listener; success and CAS refusal
- * record on the master's acked listener only.
+ * Success and CAS refusal record on the master's acked listener only.
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
 public class ExternalSourceConfigChangeForwardIT extends AbstractEsqlIntegTestCase {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceTelemetryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceTelemetryIT.java
@@ -663,8 +663,8 @@ public class ExternalSourceTelemetryIT extends AbstractEsqlIntegTestCase {
     }
 
     /**
-     * Unknown-type PUT dies in the coord {@code doExecute} pre-check. Max-count is thrown from the
-     * CAS task body and is the path that reaches {@code recordingListener.onFailure}.
+     * Unknown-type PUT is refused in {@code putDataSource} before the task is submitted. Max-count
+     * is thrown from the CAS task body and is the path that reaches {@code recordingListener.onFailure}.
      */
     public void testConfigChangesRecordMaxCountFromTaskBody() throws Exception {
         long rejectedBefore = clusterTotal(

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
@@ -273,7 +273,7 @@ public class DataSourceCrudIT extends ESIntegTestCase {
      * Regression: {@code DataSourceService.putDataSource} must re-validate against the authoritative state it
      * reads inside the cluster-state-update task, not just the pre-encryption snapshot taken before submitting
      * it. Races two PUTs behind a blocked master task queue (mirrors {@link #testDispatchVsTaskExecuteRace}):
-     * both are coordinator-pre-validated against the same state (secret still present), but the one that
+     * both are validated against the same master snapshot (secret still present), but the one that
      * clears the secret is submitted first, so by the time the second PUT's task actually runs, the secret it
      * was relying on to carry forward is gone. That PUT must fail, not silently persist an incomplete data
      * source.
@@ -304,8 +304,8 @@ public class DataSourceCrudIT extends ESIntegTestCase {
         });
         safeAwait(barrier); // master is now blocked inside the no-op task
 
-        // Both requests are coordinator-pre-validated against the same pre-block state, where the data source
-        // (and its secret) still exists, so the PUT's pre-check passes. Submission order controls processing
+        // Both requests are validated against the same pre-block master state, where the data source
+        // (and its secret) still exists, so pre-submit validation passes. Submission order controls processing
         // order once the barrier releases: the delete runs first, so by the time the PUT's task actually runs,
         // the entry it was relying on to carry the secret forward from is already gone.
         ActionFuture<AcknowledgedResponse> deleteFuture = client().execute(

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
@@ -34,12 +34,10 @@ import static org.hamcrest.Matchers.hasSize;
  * the publication carrying the create, that node cannot see the stored secret and must not validate the
  * request as if none had ever been set.
  *
- * <p>Three master-eligible nodes keep a quorum of two when one is blocked from applying cluster
- * state, so the create still commits. Two nodes would not: blocking the non-master node leaves no
- * quorum, the publication does not commit, and the follow-up PUT then fails as if no secret had
- * ever been stored.
+ * <p>A dedicated master is the only voter, so blocking a data-only node from applying cluster state
+ * cannot steal quorum. The create still commits; the blocked node simply cannot ack.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 3, numClientNodes = 0, supportsDedicatedMasters = false)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class DataSourcePutStaleCurrentIT extends ESIntegTestCase {
 
     /** Short, so the blocked node's missing ack is not waited out for the full default. */
@@ -52,8 +50,12 @@ public class DataSourcePutStaleCurrentIT extends ESIntegTestCase {
     }
 
     public void testUpdateKeepsTheSecretOnANodeThatHasNotYetAppliedTheCreate() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
+        ensureStableCluster(3);
+
         final String master = internalCluster().getMasterName();
-        final String lagging = randomValueOtherThan(master, () -> randomFrom(internalCluster().getNodeNames()));
+        final String lagging = randomFrom(dataNodes);
         final String name = "cb";
 
         // From here the lagging node stops applying published cluster state, so it never sees the create.

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
@@ -7,7 +7,10 @@
 
 package org.elasticsearch.xpack.esql.datasources.datasource;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.coordination.Coordinator;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -35,7 +38,9 @@ import static org.hamcrest.Matchers.hasSize;
  * request as if none had ever been set.
  *
  * <p>A dedicated master is the only voter, so blocking a data-only node from applying cluster state
- * cannot steal quorum. The create still commits; the blocked node simply cannot ack.
+ * cannot steal quorum. The create still commits; the blocked node simply cannot ack. Publication
+ * waits for that node until {@code cluster.publish.timeout}, and the master applies only then, so
+ * the tests shorten that timeout for the follow-up PUT's CAS task to run.
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class DataSourcePutStaleCurrentIT extends ESIntegTestCase {
@@ -47,6 +52,14 @@ public class DataSourcePutStaleCurrentIT extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return List.of(TestEncryptionServicePlugin.class, DataSourceCrudIT.LocalStateDataSource.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(Coordinator.PUBLISH_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(2))
+            .build();
     }
 
     public void testUpdateKeepsTheSecretOnANodeThatHasNotYetAppliedTheCreate() throws Exception {
@@ -72,16 +85,23 @@ public class DataSourcePutStaleCurrentIT extends ESIntegTestCase {
             // The update omits the secret, which the master can carry forward. It must not be refused.
             client(lagging).execute(PutDataSourceAction.INSTANCE, request(name, Map.of("region", "eu-west-2"))).actionGet(TIMEOUT);
 
-            // GET is a local read: ask the master, which holds the committed metadata, while the
-            // lagging node is still blocked.
-            GetDataSourceAction.Response got = client(master).execute(
-                GetDataSourceAction.INSTANCE,
-                new GetDataSourceAction.Request(TIMEOUT, new String[] { name })
-            ).actionGet(TIMEOUT);
-            assertThat(got.getDataSources(), hasSize(1));
-            DataSource ds = got.getDataSources().iterator().next();
-            assertThat(ds.settings().get("region").nonSecretValue(), equalTo("eu-west-2"));
-            assertThat(decryptSecret(ds.settings().get("secret_access_key")), equalTo("AKIAXYZ"));
+            // GET is a local read of applied state. The master applies only once publication ends
+            // (publish timeout while the lagging node is blocked), so poll until that is visible.
+            assertBusy(() -> {
+                GetDataSourceAction.Response got;
+                try {
+                    got = client(master).execute(
+                        GetDataSourceAction.INSTANCE,
+                        new GetDataSourceAction.Request(TIMEOUT, new String[] { name })
+                    ).actionGet(TIMEOUT);
+                } catch (ResourceNotFoundException e) {
+                    throw new AssertionError("data source not yet visible on the master", e);
+                }
+                assertThat(got.getDataSources(), hasSize(1));
+                DataSource ds = got.getDataSources().iterator().next();
+                assertThat(ds.settings().get("region").nonSecretValue(), equalTo("eu-west-2"));
+                assertThat(decryptSecret(ds.settings().get("secret_access_key")), equalTo("AKIAXYZ"));
+            });
         } finally {
             blocked.stopDisrupting();
             internalCluster().clearDisruptionScheme();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.datasource;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.disruption.BlockClusterStateProcessing;
+import org.elasticsearch.xpack.encryption.spi.EncryptedData;
+import org.elasticsearch.xpack.encryption.spi.EncryptionService;
+import org.elasticsearch.xpack.esql.datasources.DataSourceCredentials;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSource;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceSetting;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * An update that keeps an already-stored secret must not depend on which node receives it.
+ *
+ * <p>A client that creates a data source carrying a secret and then updates another of its settings omits
+ * the secret, expecting it to be carried forward. When the update lands on a node that has not yet applied
+ * the publication carrying the create, that node cannot see the stored secret and must not validate the
+ * request as if none had ever been set.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+public class DataSourcePutStaleCurrentIT extends ESIntegTestCase {
+
+    /** Short, so the blocked node's missing ack is not waited out for the full default. */
+    private static final TimeValue SHORT_ACK = TimeValue.timeValueSeconds(1);
+    private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(TestEncryptionServicePlugin.class, DataSourceCrudIT.LocalStateDataSource.class);
+    }
+
+    public void testUpdateKeepsTheSecretOnANodeThatHasNotYetAppliedTheCreate() throws Exception {
+        final String master = internalCluster().getMasterName();
+        final String lagging = randomValueOtherThan(master, () -> randomFrom(internalCluster().getNodeNames()));
+        final String name = "cb";
+
+        // From here the lagging node stops applying published cluster state, so it never sees the create.
+        final BlockClusterStateProcessing blocked = new BlockClusterStateProcessing(lagging, random());
+        internalCluster().setDisruptionScheme(blocked);
+        blocked.startDisrupting();
+        try {
+            AcknowledgedResponse created = client(master).execute(
+                PutDataSourceAction.INSTANCE,
+                request(name, Map.of("region", "us-east-1", "secret_access_key", "AKIAXYZ"))
+            ).actionGet(TIMEOUT);
+            assertThat("the blocked node cannot ack", created.isAcknowledged(), equalTo(false));
+
+            // The update omits the secret, which the master can carry forward. It must not be refused.
+            client(lagging).execute(PutDataSourceAction.INSTANCE, request(name, Map.of("region", "eu-west-2"))).actionGet(TIMEOUT);
+
+            // GET is a local read: ask the master, which holds the committed metadata, while the
+            // lagging node is still blocked.
+            GetDataSourceAction.Response got = client(master).execute(
+                GetDataSourceAction.INSTANCE,
+                new GetDataSourceAction.Request(TIMEOUT, new String[] { name })
+            ).actionGet(TIMEOUT);
+            assertThat(got.getDataSources(), hasSize(1));
+            DataSource ds = got.getDataSources().iterator().next();
+            assertThat(ds.settings().get("region").nonSecretValue(), equalTo("eu-west-2"));
+            assertThat(decryptSecret(ds.settings().get("secret_access_key")), equalTo("AKIAXYZ"));
+        } finally {
+            blocked.stopDisrupting();
+            internalCluster().clearDisruptionScheme();
+        }
+    }
+
+    private static PutDataSourceAction.Request request(String name, Map<String, Object> settings) {
+        return new PutDataSourceAction.Request(TIMEOUT, SHORT_ACK, name, "test_requires_secret", null, new HashMap<>(settings));
+    }
+
+    private static Object decryptSecret(DataSourceSetting secret) {
+        DataSourceCredentials credentials = new DataSourceCredentials(new EncryptionService() {
+            @Override
+            public EncryptedData encrypt(byte[] bytes) {
+                return new EncryptedData(TestEncryptionServicePlugin.TEST_KEY_ID, bytes);
+            }
+
+            @Override
+            public byte[] decrypt(EncryptedData encryptedData) {
+                return encryptedData.payload();
+            }
+        });
+        Map<String, Object> input = new HashMap<>();
+        input.put("secret", secret.rawValue());
+        return credentials.decryptInPlace(input).get("secret");
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourcePutStaleCurrentIT.java
@@ -33,8 +33,13 @@ import static org.hamcrest.Matchers.hasSize;
  * the secret, expecting it to be carried forward. When the update lands on a node that has not yet applied
  * the publication carrying the create, that node cannot see the stored secret and must not validate the
  * request as if none had ever been set.
+ *
+ * <p>Three master-eligible nodes keep a quorum of two when one is blocked from applying cluster
+ * state, so the create still commits. Two nodes would not: blocking the non-master node leaves no
+ * quorum, the publication does not commit, and the follow-up PUT then fails as if no secret had
+ * ever been stored.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 3, numClientNodes = 0, supportsDedicatedMasters = false)
 public class DataSourcePutStaleCurrentIT extends ESIntegTestCase {
 
     /** Short, so the blocked node's missing ack is not waited out for the full default. */

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
@@ -31,8 +31,13 @@ import static org.hamcrest.Matchers.hasSize;
  * When the two land on different nodes and the second node has not yet applied the publication that
  * carries the parent, the request must still be registered: the master re-validates authoritatively
  * and holds the only state that can decide.
+ *
+ * <p>Three master-eligible nodes keep a quorum of two when one is blocked from applying cluster
+ * state, so the create still commits. Two nodes would not: blocking the non-master node leaves no
+ * quorum, the publication does not commit, and the follow-up PUT then fails as if the parent never
+ * existed.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 3, numClientNodes = 0, supportsDedicatedMasters = false)
 public class DatasetPutStaleParentIT extends ESIntegTestCase {
 
     /** Short, so the blocked node's missing ack is not waited out for the full default. */

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
@@ -32,12 +32,10 @@ import static org.hamcrest.Matchers.hasSize;
  * carries the parent, the request must still be registered: the master re-validates authoritatively
  * and holds the only state that can decide.
  *
- * <p>Three master-eligible nodes keep a quorum of two when one is blocked from applying cluster
- * state, so the create still commits. Two nodes would not: blocking the non-master node leaves no
- * quorum, the publication does not commit, and the follow-up PUT then fails as if the parent never
- * existed.
+ * <p>A dedicated master is the only voter, so blocking a data-only node from applying cluster state
+ * cannot steal quorum. The create still commits; the blocked node simply cannot ack.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 3, numClientNodes = 0, supportsDedicatedMasters = false)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class DatasetPutStaleParentIT extends ESIntegTestCase {
 
     /** Short, so the blocked node's missing ack is not waited out for the full default. */
@@ -50,8 +48,12 @@ public class DatasetPutStaleParentIT extends ESIntegTestCase {
     }
 
     public void testDatasetRegistersOnANodeThatHasNotYetAppliedTheParent() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
+        ensureStableCluster(3);
+
         final String master = internalCluster().getMasterName();
-        final String lagging = randomValueOtherThan(master, () -> randomFrom(internalCluster().getNodeNames()));
+        final String lagging = randomFrom(dataNodes);
 
         // The lagging node stops applying published cluster state, so it cannot see anything created from now on.
         final BlockClusterStateProcessing blocked = new BlockClusterStateProcessing(lagging, random());

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.datasource;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.disruption.BlockClusterStateProcessing;
+import org.elasticsearch.xpack.esql.datasources.dataset.GetDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.dataset.PutDatasetAction;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Registering a dataset must not depend on which node receives the request.
+ *
+ * <p>A client that creates a data source and then creates a dataset against it issues two calls with
+ * nothing in between. The first is a success status, so the second is entitled to see the parent.
+ * When the two land on different nodes and the second node has not yet applied the publication that
+ * carries the parent, the request must still be registered: the master re-validates authoritatively
+ * and holds the only state that can decide.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+public class DatasetPutStaleParentIT extends ESIntegTestCase {
+
+    /** Short, so the blocked node's missing ack is not waited out for the full default. */
+    private static final TimeValue SHORT_ACK = TimeValue.timeValueSeconds(1);
+    private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(TestEncryptionServicePlugin.class, DataSourceCrudIT.LocalStateDataSource.class);
+    }
+
+    public void testDatasetRegistersOnANodeThatHasNotYetAppliedTheParent() throws Exception {
+        final String master = internalCluster().getMasterName();
+        final String lagging = randomValueOtherThan(master, () -> randomFrom(internalCluster().getNodeNames()));
+
+        // The lagging node stops applying published cluster state, so it cannot see anything created from now on.
+        final BlockClusterStateProcessing blocked = new BlockClusterStateProcessing(lagging, random());
+        internalCluster().setDisruptionScheme(blocked);
+        blocked.startDisrupting();
+        try {
+            // Created on the master. The lagging node cannot ack, so this answers acknowledged=false —
+            // a success status that a client reasonably reads as "created".
+            AcknowledgedResponse created = client(master).execute(
+                PutDataSourceAction.INSTANCE,
+                new PutDataSourceAction.Request(TIMEOUT, SHORT_ACK, "cb", "test", null, new HashMap<>())
+            ).actionGet(TIMEOUT);
+            assertThat("the blocked node cannot ack", created.isAcknowledged(), equalTo(false));
+
+            // The same client now registers the dataset, and it reaches the node that is behind.
+            client(lagging).execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(TIMEOUT, SHORT_ACK, "hits", "cb", "test://hits", null, new HashMap<>())
+            ).actionGet(TIMEOUT);
+
+            // GET is a local read: ask the master, which holds the committed metadata, while the
+            // lagging node is still blocked.
+            GetDatasetAction.Request get = new GetDatasetAction.Request(TIMEOUT);
+            get.indices("hits");
+            GetDatasetAction.Response got = client(master).execute(GetDatasetAction.INSTANCE, get).actionGet(TIMEOUT);
+            assertThat(got.getDatasets(), hasSize(1));
+            Dataset dataset = got.getDatasets().iterator().next();
+            assertThat(dataset.name(), equalTo("hits"));
+            assertThat(dataset.dataSource().getName(), equalTo("cb"));
+            assertThat(dataset.resource(), equalTo("test://hits"));
+        } finally {
+            blocked.stopDisrupting();
+            internalCluster().clearDisruptionScheme();
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DatasetPutStaleParentIT.java
@@ -7,8 +7,11 @@
 
 package org.elasticsearch.xpack.esql.datasources.datasource;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -33,7 +36,9 @@ import static org.hamcrest.Matchers.hasSize;
  * and holds the only state that can decide.
  *
  * <p>A dedicated master is the only voter, so blocking a data-only node from applying cluster state
- * cannot steal quorum. The create still commits; the blocked node simply cannot ack.
+ * cannot steal quorum. The create still commits; the blocked node simply cannot ack. Publication
+ * waits for that node until {@code cluster.publish.timeout}, and the master applies only then, so
+ * the tests shorten that timeout for the follow-up PUT's CAS task to run.
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class DatasetPutStaleParentIT extends ESIntegTestCase {
@@ -45,6 +50,14 @@ public class DatasetPutStaleParentIT extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return List.of(TestEncryptionServicePlugin.class, DataSourceCrudIT.LocalStateDataSource.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(Coordinator.PUBLISH_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(2))
+            .build();
     }
 
     public void testDatasetRegistersOnANodeThatHasNotYetAppliedTheParent() throws Exception {
@@ -74,16 +87,23 @@ public class DatasetPutStaleParentIT extends ESIntegTestCase {
                 new PutDatasetAction.Request(TIMEOUT, SHORT_ACK, "hits", "cb", "test://hits", null, new HashMap<>())
             ).actionGet(TIMEOUT);
 
-            // GET is a local read: ask the master, which holds the committed metadata, while the
-            // lagging node is still blocked.
-            GetDatasetAction.Request get = new GetDatasetAction.Request(TIMEOUT);
-            get.indices("hits");
-            GetDatasetAction.Response got = client(master).execute(GetDatasetAction.INSTANCE, get).actionGet(TIMEOUT);
-            assertThat(got.getDatasets(), hasSize(1));
-            Dataset dataset = got.getDatasets().iterator().next();
-            assertThat(dataset.name(), equalTo("hits"));
-            assertThat(dataset.dataSource().getName(), equalTo("cb"));
-            assertThat(dataset.resource(), equalTo("test://hits"));
+            // GET is a local read of applied state. The master applies only once publication ends
+            // (publish timeout while the lagging node is blocked), so poll until that is visible.
+            assertBusy(() -> {
+                GetDatasetAction.Request get = new GetDatasetAction.Request(TIMEOUT);
+                get.indices("hits");
+                GetDatasetAction.Response got;
+                try {
+                    got = client(master).execute(GetDatasetAction.INSTANCE, get).actionGet(TIMEOUT);
+                } catch (ResourceNotFoundException e) {
+                    throw new AssertionError("dataset not yet visible on the master", e);
+                }
+                assertThat(got.getDatasets(), hasSize(1));
+                Dataset dataset = got.getDatasets().iterator().next();
+                assertThat(dataset.name(), equalTo("hits"));
+                assertThat(dataset.dataSource().getName(), equalTo("cb"));
+                assertThat(dataset.resource(), equalTo("test://hits"));
+            });
         } finally {
             blocked.stopDisrupting();
             internalCluster().clearDisruptionScheme();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
@@ -93,9 +93,9 @@ public class DatasetService {
 
     /**
      * Validate the put-dataset request against the supplied project metadata and build the domain
-     * {@link Dataset}. Callable from the coordinator (pre-check, possibly against stale state) and
-     * from inside the CAS task (authoritative, against master's current state). Throws cleanly on
-     * missing parent, unknown validator, or validation failure.
+     * {@link Dataset}. Called from {@link #putDataset} against the master's applied state and again
+     * inside the CAS task against the state that task reads. Throws cleanly on missing parent,
+     * unknown validator, or validation failure.
      */
     Dataset validatePutDataset(ProjectMetadata projectMetadata, PutDatasetAction.Request request) {
         final DataSource parent = DataSourceMetadata.get(projectMetadata).get(request.dataSource());
@@ -149,9 +149,9 @@ public class DatasetService {
     }
 
     /**
-     * Create or replace a dataset. Validation is expected to have run on the coordinator (via
-     * {@link #validatePutDataset}); the task re-validates under CAS to guard against the parent
-     * being delete-recreated between coord-validate and task-execute.
+     * Create or replace a dataset. Validates against the master's applied state, then the task
+     * re-validates under CAS to guard against the parent being delete-recreated between that
+     * snapshot and task execute.
      */
     public void putDataset(ProjectId projectId, PutDatasetAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         final ProjectMetadata projectMetadata = clusterService.state().metadata().getProject(projectId);
@@ -180,14 +180,9 @@ public class DatasetService {
         taskQueue.submitTask("update-esql-dataset-metadata-[" + request.name() + "]", task, task.timeout());
     }
 
-    /** Records a pre-submit or transport pre-check refusal. Used by PUT transport {@code doExecute}. */
+    /** Records a pre-submit refusal (unknown parent, validation failure, and similar). */
     public void recordRejected(String type, Exception e) {
         ConfigChangeTelemetry.recordRejected(metrics, ConfigChangeTelemetry.KIND_DATASET, type, e);
-    }
-
-    /** Like {@link #recordRejected(String, Exception)}, resolving type from the parent data source. */
-    public void recordRejected(ProjectMetadata project, String dataSourceName, Exception e) {
-        recordRejected(parentType(project, dataSourceName), e);
     }
 
     private static String parentType(ProjectMetadata project, String dataSourceName) {
@@ -211,7 +206,7 @@ public class DatasetService {
         final DatasetMetadata metadata = getMetadata(project);
         final Dataset current = metadata.get(dataset.name());
         if (dataset.equals(current)) {
-            // Became a no-op between the coordinator check and the task — nothing to write.
+            // Became a no-op between the pre-submit snapshot and the task — nothing to write.
             return currentState;
         }
         if (current == null && metadata.datasets().size() >= maxDatasetsCount) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
@@ -93,9 +93,9 @@ public class DatasetService {
 
     /**
      * Validate the put-dataset request against the supplied project metadata and build the domain
-     * {@link Dataset}. Called from {@link #putDataset} against the master's applied state and again
-     * inside the CAS task against the state that task reads. Throws cleanly on missing parent,
-     * unknown validator, or validation failure.
+     * {@link Dataset}. Called from {@link #putDataset} against the master's applied state when that
+     * snapshot already has the parent, and always inside the CAS task against the state that task
+     * reads. Throws cleanly on missing parent, unknown validator, or validation failure.
      */
     Dataset validatePutDataset(ProjectMetadata projectMetadata, PutDatasetAction.Request request) {
         final DataSource parent = DataSourceMetadata.get(projectMetadata).get(request.dataSource());
@@ -149,23 +149,28 @@ public class DatasetService {
     }
 
     /**
-     * Create or replace a dataset. Validates against the master's applied state, then the task
-     * re-validates under CAS to guard against the parent being delete-recreated between that
-     * snapshot and task execute.
+     * Create or replace a dataset. Validates against the master's applied state when that snapshot
+     * already has the parent, then the task re-validates under CAS to guard against the parent being
+     * delete-recreated between that snapshot and task execute.
+     *
+     * <p>Applied state can lag a committed create: the master applies a publication only after every
+     * node has applied, or {@code cluster.publish.timeout} fires. A missing parent in that snapshot
+     * is therefore not failed here -- the CAS task re-validates against MasterService state.
      */
     public void putDataset(ProjectId projectId, PutDatasetAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         final ProjectMetadata projectMetadata = clusterService.state().metadata().getProject(projectId);
-        final Dataset dataset;
         try {
-            dataset = validatePutDataset(projectMetadata, request);
+            final Dataset dataset = validatePutDataset(projectMetadata, request);
+            // No-op if identical to the registered dataset -- skip the cluster-state update (mirrors ViewService.putView).
+            if (dataset.equals(getMetadata(projectMetadata).get(dataset.name()))) {
+                listener.onResponse(AcknowledgedResponse.TRUE);
+                return;
+            }
+        } catch (ResourceNotFoundException ignored) {
+            // Parent missing from applied state; a committed create may still be in-flight on MasterService.
         } catch (Exception e) {
             recordRejected(parentType(projectMetadata, request.dataSource()), e);
             listener.onFailure(e);
-            return;
-        }
-        // No-op if identical to the registered dataset — skip the cluster-state update (mirrors ViewService.putView).
-        if (dataset.equals(getMetadata(projectMetadata).get(dataset.name()))) {
-            listener.onResponse(AcknowledgedResponse.TRUE);
             return;
         }
         logger.debug("submitting put dataset [{}] with parent [{}]", request.name(), request.dataSource());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportPutDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportPutDatasetAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportPutDatasetAction extends AcknowledgedTransportMasterNodeProjectAction<PutDatasetAction.Request> {
     private final DatasetService datasetService;
-    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutDatasetAction(
@@ -45,24 +44,6 @@ public class TransportPutDatasetAction extends AcknowledgedTransportMasterNodePr
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.datasetService = datasetService;
-        this.projectResolver = projectResolver;
-    }
-
-    @Override
-    protected void doExecute(Task task, PutDatasetAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        // Coord-side pre-check: parent lookup + validator dispatch against local (possibly stale)
-        // cluster state. Fails fast without a master round-trip on unknown type, missing parent,
-        // or validator rejection. The task body re-validates against master's authoritative state.
-        var projectId = projectResolver.getProjectId();
-        var project = clusterService.state().metadata().getProject(projectId);
-        try {
-            datasetService.validatePutDataset(project, request);
-        } catch (Exception e) {
-            datasetService.recordRejected(project, request.dataSource(), e);
-            listener.onFailure(e);
-            return;
-        }
-        super.doExecute(task, request, listener);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
@@ -196,7 +196,7 @@ public class DataSourceService {
         taskQueue.submitTask("update-esql-data-source-metadata-[" + request.name() + "]", task, task.timeout());
     }
 
-    /** Records a pre-submit or transport pre-check refusal. Used by PUT transport {@code doExecute}. */
+    /** Records a pre-submit refusal (unknown type, validation failure, and similar). */
     public void recordRejected(String type, Exception e) {
         ConfigChangeTelemetry.recordRejected(metrics, ConfigChangeTelemetry.KIND_DATASOURCE, type, e);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Setting;
@@ -148,20 +149,29 @@ public class DataSourceService {
      * also re-validates against that same fresh state, so a concurrent change to a secret this request relies
      * on carrying forward fails the PUT instead of silently persisting an incomplete data source. Every other
      * field is a full replace, matching the pre-existing PUT semantics.
+     *
+     * <p>Pre-submit validation reads {@link ClusterService#state()}, which is applied state. The master
+     * applies a publication only after every node has applied -- or {@code cluster.publish.timeout} fires --
+     * so a committed create can be missing from that snapshot. A {@link ValidationException} against a
+     * missing current entry is therefore not failed here: the CAS task re-validates against MasterService
+     * state, which already includes the committed create. Newly-supplied secrets are then encrypted on the
+     * CAS thread, only on that rare lag path.
      */
     public void putDataSource(ProjectId projectId, PutDataSourceAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        final DataSource validated;
-        final DataSourceSettings encryptedNew;
+        final ProjectMetadata projectSnapshot = clusterService.state().metadata().getProject(projectId);
+        DataSourceSettings preEncrypted = null;
         try {
-            final ProjectMetadata projectSnapshot = clusterService.state().metadata().getProject(projectId);
-            validated = validatePutDataSource(projectSnapshot, request);
-            encryptedNew = applyEncryption(validated.name(), validated.settings());
+            final DataSource validated = validatePutDataSource(projectSnapshot, request);
+            preEncrypted = applyEncryption(validated.name(), validated.settings());
         } catch (Exception e) {
-            recordRejected(request.type(), e);
-            listener.onFailure(e);
-            return;
+            if (getMetadata(projectSnapshot).get(request.name()) != null || e instanceof ValidationException == false) {
+                recordRejected(request.type(), e);
+                listener.onFailure(e);
+                return;
+            }
         }
-        logger.debug("submitting put data source [{}] of type [{}]", validated.name(), validated.type());
+        final DataSourceSettings encryptedNew = preEncrypted;
+        logger.debug("submitting put data source [{}] of type [{}]", request.name(), request.type());
         final AtomicReference<String> pendingOp = new AtomicReference<>();
         final AckedClusterStateUpdateTask task = new AckedClusterStateUpdateTask(
             request,
@@ -171,20 +181,23 @@ public class DataSourceService {
             public ClusterState execute(ClusterState currentState) {
                 final ProjectMetadata project = currentState.metadata().getProject(projectId);
                 final DataSourceMetadata metadata = getMetadata(project);
-                final DataSource current = metadata.get(validated.name());
+                final DataSource current = metadata.get(request.name());
                 if (current == null && metadata.dataSources().size() >= maxDataSourcesCount) {
-                    logger.warn("rejected put for data source [{}]: maximum count [{}] reached", validated.name(), maxDataSourcesCount);
+                    logger.warn("rejected put for data source [{}]: maximum count [{}] reached", request.name(), maxDataSourcesCount);
                     throw new MaxDataSourcesCountException(maxDataSourcesCount);
                 }
                 // Re-validate here, against the state just read, not the pre-encryption snapshot above: a
                 // concurrent operation could have cleared or removed a secret this request relies on carrying
                 // forward between that snapshot and this task running. Cheap (no I/O); throwing here fails the
                 // whole PUT instead of silently persisting a data source with incomplete credentials.
-                validatePutDataSource(project, request);
-                final DataSourceSettings merged = mergeCarriedForwardSecrets(current, validated.type(), encryptedNew, request);
-                final DataSource encrypted = new DataSource(validated.name(), validated.type(), validated.description(), merged);
+                final DataSource validated = validatePutDataSource(project, request);
+                final DataSourceSettings encrypted = encryptedNew != null
+                    ? encryptedNew
+                    : applyEncryption(validated.name(), validated.settings());
+                final DataSourceSettings merged = mergeCarriedForwardSecrets(current, validated.type(), encrypted, request);
+                final DataSource stored = new DataSource(validated.name(), validated.type(), validated.description(), merged);
                 final Map<String, DataSource> updated = new HashMap<>(metadata.dataSources());
-                updated.put(encrypted.name(), encrypted);
+                updated.put(stored.name(), stored);
                 pendingOp.set(current == null ? ConfigChangeTelemetry.OP_CREATED : ConfigChangeTelemetry.OP_UPDATED);
                 return ClusterState.builder(currentState)
                     .putProjectMetadata(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/TransportPutDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/TransportPutDataSourceAction.java
@@ -23,8 +23,6 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportPutDataSourceAction extends AcknowledgedTransportMasterNodeProjectAction<PutDataSourceAction.Request> {
     private final DataSourceService dataSourceService;
-    private final ClusterService clusterService;
-    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutDataSourceAction(
@@ -46,24 +44,6 @@ public class TransportPutDataSourceAction extends AcknowledgedTransportMasterNod
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.dataSourceService = dataSourceService;
-        this.clusterService = clusterService;
-        this.projectResolver = projectResolver;
-    }
-
-    @Override
-    protected void doExecute(Task task, PutDataSourceAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        // Coord-side pre-check against local (possibly stale) cluster state; the task body re-validates
-        // against master's authoritative state. Resolving the project here lets a PUT that omits an
-        // already-stored secret pass this pre-check too.
-        try {
-            var project = clusterService.state().metadata().getProject(projectResolver.getProjectId());
-            dataSourceService.validatePutDataSource(project, request);
-        } catch (Exception e) {
-            dataSourceService.recordRejected(request.type(), e);
-            listener.onFailure(e);
-            return;
-        }
-        super.doExecute(task, request, listener);
     }
 
     @Override


### PR DESCRIPTION
Coordinator-side PUT pre-checks in TransportPutDatasetAction.java and TransportPutDataSourceAction.java could refuse a valid write against stale local cluster state. Those overrides are gone; the master already validates and carries secrets forward.

Two ITs block cluster-state apply on one node, then register a dataset / omit-secret update on that node and assert the master committed the write.

Closes https://github.com/elastic/esql-planning/issues/1953 