### PR TITLE
Fix flaky SearchContextStatsTests two-segment test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -717,9 +717,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:BASELINE}
   issue: https://github.com/elastic/elasticsearch/issues/158881
-- class: org.elasticsearch.xpack.esql.stats.SearchContextStatsTests
-  method: testSkipperKeywordSingleValuedWithAbsentSegmentIsDetectedAsSingleValued
-  issue: https://github.com/elastic/elasticsearch/issues/158895
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=search/351_point_in_time_slice/PIT search respects slice scoping}
   issue: https://github.com/elastic/elasticsearch/issues/158908

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
@@ -644,11 +644,7 @@ public class SearchContextStatsTests extends MapperServiceTestCase {
         final Directory dir = newDirectory();
         final DirectoryReader reader;
         try (
-            RandomIndexWriter writer = new RandomIndexWriter(
-                random(),
-                dir,
-                newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE)
-            )
+            RandomIndexWriter writer = new RandomIndexWriter(random(), dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))
         ) {
             // Segment 1: single-valued keyword documents → skipper reports maxValueCount == 1.
             writer.addDocument(List.of(SortedSetDocValuesField.indexedField("kw", new BytesRef("A"))));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
@@ -19,6 +19,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
@@ -642,14 +643,19 @@ public class SearchContextStatsTests extends MapperServiceTestCase {
 
         final Directory dir = newDirectory();
         final DirectoryReader reader;
-        try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+        try (
+            RandomIndexWriter writer = new RandomIndexWriter(
+                random(),
+                dir,
+                newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE)
+            )
+        ) {
             // Segment 1: single-valued keyword documents → skipper reports maxValueCount == 1.
             writer.addDocument(List.of(SortedSetDocValuesField.indexedField("kw", new BytesRef("A"))));
             writer.addDocument(List.of(SortedSetDocValuesField.indexedField("kw", new BytesRef("B"))));
             writer.commit();
             // Segment 2: a document with no keyword field → getDocValuesSkipper("kw") returns null.
             writer.addDocument(List.of());
-            // Intentionally no forceMerge so the two segments remain separate.
             reader = writer.getReader();
         }
 


### PR DESCRIPTION
- `RandomIndexWriter` can randomly merge segments during `addDocument` or `getReader`, collapsing the two intended segments into one and causing the `assertEquals(..., 2, reader.leaves().size())` assertion to fail with `1`.
- Fixed by passing `newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE)` to the writer, which prevents any automatic merges and guarantees the two-segment structure the test requires.
- Removed the mute entry for this test.

Closes #158895