### PR TITLE
[9.5] Deflake FUSE multivalued-score warning test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -453,9 +453,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=ml/bucket_count_ks_test_agg/Test bucket count ks test with empty alternatives}
   issue: https://github.com/elastic/elasticsearch/issues/157577
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecFuseIT
-  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
-  issue: https://github.com/elastic/elasticsearch/issues/157905
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testUnpromotableRegisterCommitForRecoveryTracksAllBlobsPessimisticallyAndWaitsUntilShardStarts
   issue: https://github.com/elastic/elasticsearch/issues/158013
@@ -471,9 +468,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithRelocationOrObjectStoreFailures
   issue: https://github.com/elastic/elasticsearch/issues/156569
-- class: org.elasticsearch.xpack.esql.CsvColumnarIT
-  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
-  issue: https://github.com/elastic/elasticsearch/issues/158511
 - class: org.elasticsearch.snapshots.SnapshotResiliencyTests
   method: testConcurrentSnapshotDeleteAndDeleteIndex
   issue: https://github.com/elastic/elasticsearch/issues/158512

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/fuse/FuseOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/fuse/FuseOperatorTestCase.java
@@ -213,6 +213,68 @@ public abstract class FuseOperatorTestCase extends OperatorTestCase {
     }
 
     /**
+     * A deterministic counterpart to {@link #simpleInput}: same page shape (group at
+     * {@link #discriminatorPosition}, score at {@link #scorePosition}), except the very first row's
+     * score column is <b>multivalued</b> ({@code [1.0, 2.0]}). FUSE cannot combine a multivalued
+     * score, so it assigns that row a null score and emits a warning. Being deterministic lets
+     * a test assert the exact warning, which the random {@link #simpleInput} can't (it only ever
+     * produces single-valued scores).
+     */
+    protected SourceOperator simpleInputWithMultivaluedScore(BlockFactory blockFactory, int size) {
+        return new AbstractBlockSourceOperator(blockFactory, 8 * 1024) {
+            @Override
+            protected int remaining() {
+                return size - currentPosition;
+            }
+
+            @Override
+            protected Page createPage(int positionOffset, int length) {
+                length = Integer.min(length, remaining());
+                Block[] blocks = new Block[blocksCount];
+                try {
+                    for (int b = 0; b < blocksCount; b++) {
+                        if (b == scorePosition) {
+                            try (var builder = blockFactory.newDoubleBlockBuilder(length)) {
+                                for (int i = 0; i < length; i++) {
+                                    if (positionOffset + i == 0) {
+                                        // the single multivalued score row that triggers the warning
+                                        builder.beginPositionEntry();
+                                        builder.appendDouble(1.0);
+                                        builder.appendDouble(2.0);
+                                        builder.endPositionEntry();
+                                    } else {
+                                        builder.appendDouble(positionOffset + i);
+                                    }
+                                }
+                                blocks[b] = builder.build();
+                            }
+                        } else if (b == discriminatorPosition) {
+                            try (var builder = blockFactory.newBytesRefBlockBuilder(length)) {
+                                for (int i = 0; i < length; i++) {
+                                    builder.appendBytesRef(new BytesRef("fork"));
+                                }
+                                blocks[b] = builder.build();
+                            }
+                        } else {
+                            try (var builder = blockFactory.newBytesRefBlockBuilder(length)) {
+                                for (int i = 0; i < length; i++) {
+                                    builder.appendBytesRef(new BytesRef("filler"));
+                                }
+                                blocks[b] = builder.build();
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    Releasables.closeExpectNoException(blocks);
+                    throw e;
+                }
+                currentPosition += length;
+                return new Page(blocks);
+            }
+        };
+    }
+
+    /**
      * A multivalued group column cannot be grouped, so FUSE assigns that row a null score and emits two
      * warnings. This mirrors the {@code fuse.fuseWithRowRRFAndMultiValueGroupColumn} and
      * {@code fuse.fuseWithRowLinearAndMultiValueGroupColumn} csv-spec cases asserted deterministically

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/fuse/LinearScoreEvalOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/fuse/LinearScoreEvalOperatorTests.java
@@ -7,8 +7,11 @@
 
 package org.elasticsearch.compute.operator.fuse;
 
+import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.test.CannedSourceOperator;
 import org.elasticsearch.compute.test.TestWarningsSource;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -17,6 +20,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class LinearScoreEvalOperatorTests extends FuseOperatorTestCase {
@@ -77,6 +81,41 @@ public class LinearScoreEvalOperatorTests extends FuseOperatorTestCase {
                 + config
                 + "]"
         );
+    }
+
+    /**
+     * A multivalued score column cannot be combined, so LINEAR assigns that row a null score and
+     * emits two warnings. This mirrors the {@code fuse.fuseWithRowLinearAndMultiValueScoreColumn}
+     * csv-spec case asserted deterministically at the operator level. Lives here rather than in
+     * {@link FuseOperatorTestCase} because only {@link LinearScoreEvalOperator} inspects the score
+     * column values; {@link RrfScoreEvalOperator} ranks rows without reading scores and never emits
+     * this warning.
+     */
+    public void testMultivaluedScoreColumnProducesWarning() {
+        DriverContext ctx = driverContext();
+
+        // The first row's score is multivalued; the rest are ordinary. size >= 3 so rows 1 and 2 exist.
+        // The assertions below assume a single output page
+        List<Page> input = List.of(
+            CannedSourceOperator.mergePages(
+                CannedSourceOperator.collectPages(simpleInputWithMultivaluedScore(ctx.blockFactory(), between(3, 100)))
+            )
+        );
+        List<Page> output = fuseOutput(simple().get(ctx), input);
+
+        try {
+            assertThat(output, hasSize(1));
+            DoubleBlock scores = output.get(0).getBlock(scorePosition);
+            assertThat(scores.isNull(0), equalTo(true));   // multivalued score -> null score
+            assertThat(scores.isNull(1), equalTo(false));  // ordinary rows keep a score
+            assertThat(scores.isNull(2), equalTo(false));
+            assertWarnings(
+                "Line 1:1: evaluation of [null] failed, treating result as null. Only first 20 failures recorded.",
+                "Line 1:1: java.lang.IllegalArgumentException: score column contains multivalued entries; assigning null scores"
+            );
+        } finally {
+            output.forEach(Page::releaseBlocks);
+        }
     }
 
     private LinearConfig randomConfig() {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fuse.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fuse.csv-spec
@@ -768,8 +768,11 @@ ROW my_score = [0, 1, 2, 3, 4]::double, _index = "my_index", my_fork = "foo"
 | KEEP _id, my_score, my_fork
 ;
 
-warning:Line 6:3: evaluation of [FUSE LINEAR SCORE BY my_score GROUP BY my_fork] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 6:3: java.lang.IllegalArgumentException: score column contains multivalued entries; assigning null scores
+// ES|QL propagates warnings via ThreadLocal headers and the header is occasionally lost
+// We choose to use warningRegex instead of warning, since these warnings can be dropped in transit
+// WarningRegex matches 0 or more warnings, so the warning is allowed but not required
+warningRegex:Line 6:3: evaluation of \[FUSE LINEAR SCORE BY my_score GROUP BY my_fork\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 6:3: java.lang.IllegalArgumentException: score column contains multivalued entries; assigning null scores
 
 _id:keyword | my_score:double | my_fork:keyword
 id_0.0      | null            | foo


### PR DESCRIPTION
Backport of #155524 to 9.5.

- `fuse.csv-spec`: change `warning:` → `warningRegex:` for `fuseWithRowLinearAndMultiValueScoreColumn`; ES|QL propagates warnings via `ThreadLocal` and they are occasionally dropped in transit, so the assertion must allow 0 or more matches.
- `FuseOperatorTestCase`: add `simpleInputWithMultivaluedScore()` helper producing a page whose first row has a multivalued score.
- `LinearScoreEvalOperatorTests`: add `testMultivaluedScoreColumnProducesWarning()` — a deterministic operator-level test running on the test thread so warnings cannot be lost.
- `muted-tests.yml`: unmute `CsvColumnarIT` (#158511) and `MultiClusterSpecFuseIT` (#157905) for this test.

Closes #158511.