### PR TITLE
Update Kibana system user permissions in light of sml index rename

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -769,7 +769,7 @@ class KibanaOwnedReservedRoleDescriptors {
                 // Context Engine's SML storage. A regular (non-system) index that Kibana
                 // creates and manages itself at startup, including its alias.
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-*")
+                    .indices(".ai-index-idx-elastic-index", ".ai-index-idx-elastic-index-*")
                     .privileges("all")
                     .build(),
                 // Context Engine feedback-loop signals. Per-space, regular (non-system)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1280,7 +1280,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         // Context Engine's SML storage: a regular (non-system) index that Kibana
         // creates and manages itself, including its alias.
-        Arrays.asList(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
+        Arrays.asList(".ai-index-idx-elastic-index", ".ai-index-idx-elastic-index-" + randomAlphaOfLength(randomIntBetween(0, 13)))
             .forEach(index -> assertReadWriteAndManage(kibanaRole, index));
 
         // Context Engine feedback-loop signals: per-space, regular (non-system)

--- a/x-pack/plugin/kibana/src/javaRestTest/java/org/elasticsearch/xpack/kibana/ElasticAiIndexImplicitPrivilegesIT.java
+++ b/x-pack/plugin/kibana/src/javaRestTest/java/org/elasticsearch/xpack/kibana/ElasticAiIndexImplicitPrivilegesIT.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.not;
  * <p>
  * The happy path verifies that a role holding {@code ai_index:<kiType>/read} Kibana application privileges,
  * granted in different spaces (with no explicit index privileges), can read the Elastic AI Index
- * {@code .ai-index-idx-sml-data}, and that the implicit document-level-security filter restricts results
+ * {@code .ai-index-idx-elastic-index}, and that the implicit document-level-security filter restricts results
  * to the following rule: a document is visible only when the user holds <em>all</em> the
  * actions it requires <em>within a single space</em>. Actions accumulated across different spaces
  * must not grant access, and a document scoped to every space via {@code "*"} must still be visible
@@ -63,7 +63,7 @@ public class ElasticAiIndexImplicitPrivilegesIT extends ESRestTestCase {
     private static final String ELASTIC_AI_INDEX_WORKFLOW_READ_ACTION = "ai_index:workflow/read";
     // Registered alongside the ai_index: action to prove non-ai_index: actions are filtered out of the DLS query.
     private static final String SAVED_OBJECT_GET_ACTION = "saved_object:dashboard/get";
-    private static final String ELASTIC_AI_INDEX = ".ai-index-idx-sml-data";
+    private static final String ELASTIC_AI_INDEX = ".ai-index-idx-elastic-index";
     // Installed by the stack plugin's AiIndexTemplateRegistry; match every `.ai-index-idx-*` / `.ai-index-ds-*` name.
     private static final String AI_INDEX_MANAGED_TEMPLATE = "ai-index-idx-managed";
     private static final String AI_INDEX_DS_MANAGED_TEMPLATE = "ai-index-ds-managed";


### PR DESCRIPTION
Because we're renaming again as per https://github.com/elastic/kibana/pull/290036#discussion_r3979611667

Related to https://github.com/elastic/search-team/issues/15815