### PR TITLE
Adapt following deprecation of Operations.concatenate(Automaton, Automaton)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -302,10 +302,9 @@ public class XContentMapValues {
          * to match the trailing `.*` bits so we duplicate it only once.
          */
         Automaton tail = Operations.union(
-            Automata.makeEmptyString(),
-            Operations.concatenate(Automata.makeChar('.'), Automata.makeAnyString())
+            List.of(Automata.makeEmptyString(), Operations.concatenate(List.of(Automata.makeChar('.'), Automata.makeAnyString())))
         );
-        return Operations.concatenate(automaton, tail);
+        return Operations.concatenate(List.of(automaton, tail));
     }
 
     private static int step(CharacterRunAutomaton automaton, String key, int state) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpPrefixAutomatonUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpPrefixAutomatonUtil.java
@@ -48,19 +48,22 @@ public class IpPrefixAutomatonUtil {
             Automaton a = Automata.makeChar(c);
             if (c > 0 && c < 10) {
                 // all one digit prefixes expand to the two digit range, i.e. 1 -> [10..19]
-                a = Operations.union(a, Automata.makeCharRange(c * 10, c * 10 + 9));
+                List<Automaton> parts = new ArrayList<>();
+                parts.add(a);
+                parts.add(Automata.makeCharRange(c * 10, c * 10 + 9));
                 // 1 and 2 even to three digit ranges
                 if (c == 1) {
-                    a = Operations.union(a, Automata.makeCharRange(100, 199));
+                    parts.add(Automata.makeCharRange(100, 199));
                 }
                 if (c == 2) {
-                    a = Operations.union(a, Automata.makeCharRange(200, 255));
+                    parts.add(Automata.makeCharRange(200, 255));
                 }
+                a = Operations.union(parts);
             }
             if (c >= 10 && c < 26) {
                 int min = c * 10;
                 int max = Math.min(c * 10 + 9, 255);
-                a = Operations.union(a, Automata.makeCharRange(min, max));
+                a = Operations.union(List.of(a, Automata.makeCharRange(min, max)));
             }
             INCOMPLETE_IP4_GROUP_AUTOMATON_LOOKUP.put(c, a);
         }
@@ -75,10 +78,10 @@ public class IpPrefixAutomatonUtil {
         if (ipPrefix.isEmpty() == false) {
             Automaton ipv4Automaton = createIp4Automaton(ipPrefix);
             if (ipv4Automaton != null) {
-                ipv4Automaton = concatenate(IPV4_PREFIX, ipv4Automaton);
+                ipv4Automaton = concatenate(List.of(IPV4_PREFIX, ipv4Automaton));
             }
             Automaton ipv6Automaton = getIpv6Automaton(ipPrefix);
-            result = Operations.union(ipv4Automaton, ipv6Automaton);
+            result = Operations.union(List.of(ipv4Automaton, ipv6Automaton));
         } else {
             result = Automata.makeAnyBinary();
         }
@@ -87,82 +90,83 @@ public class IpPrefixAutomatonUtil {
     }
 
     private static Automaton getIpv6Automaton(String ipPrefix) {
-        Automaton ipv6Automaton = EMPTY_AUTOMATON;
         List<String> ip6Groups = parseIp6Prefix(ipPrefix);
-        if (ip6Groups.isEmpty() == false) {
-            ipv6Automaton = Automata.makeString("");
-            int groupsAdded = 0;
-            for (String group : ip6Groups) {
-                if (group.contains(".")) {
-                    // try to parse this as ipv4 ending part, but only if we already have some ipv6 specific stuff in front
-                    if (groupsAdded > 0) {
-                        ipv6Automaton = concatenate(ipv6Automaton, createIp4Automaton(group));
-                        groupsAdded += 2; // this counts as two bytes, missing bytes are padded already
+        if (ip6Groups.isEmpty()) {
+            return EMPTY_AUTOMATON;
+        }
+        List<Automaton> parts = new ArrayList<>();
+        int groupsAdded = 0;
+        for (String group : ip6Groups) {
+            if (group.contains(".")) {
+                // try to parse this as ipv4 ending part, but only if we already have some ipv6 specific stuff in front
+                if (groupsAdded > 0) {
+                    parts.add(createIp4Automaton(group));
+                    groupsAdded += 2; // this counts as two bytes, missing bytes are padded already
+                } else {
+                    return EMPTY_AUTOMATON;
+                }
+            } else if (group.endsWith(":")) {
+                groupsAdded++;
+                // full block
+                if (group.length() > 1) {
+                    group = group.substring(0, group.length() - 1);
+                    parts.add(automatonFromIPv6Group(padWithZeros(group, 4 - group.length())));
+                } else {
+                    // single colon denotes left out zeros
+                    parts.add(Operations.repeat(Automata.makeChar(0)));
+                }
+            } else {
+                // potentially partial block
+                if (groupsAdded == 0 && ONLY_ZEROS.matcher(group).matches()) {
+                    if (group.length() == 1) {
+                        // A single "0" can match IPv6 addresses displayed as "0:X:..." where the first group is
+                        // exactly 0x0000. We require the second group to be non-zero to avoid also matching all
+                        // IPv4-mapped addresses (::ffff:x.x.x.x) and addresses where "::" compresses leading zeros.
+                        parts.add(ZERO_FIRST_GROUP);
+                        parts.add(NON_ZERO_SECOND_GROUP);
+                        groupsAdded = 2;
                     } else {
+                        // Multi-zero prefixes ("00", "000", "0000") cannot match any displayed IPv6 group
+                        // since leading zeros are always stripped in IPv6 formatting.
                         return EMPTY_AUTOMATON;
                     }
-                } else if (group.endsWith(":")) {
-                    groupsAdded++;
-                    // full block
-                    if (group.length() > 1) {
-                        group = group.substring(0, group.length() - 1);
-                        ipv6Automaton = concatenate(ipv6Automaton, automatonFromIPv6Group(padWithZeros(group, 4 - group.length())));
-                    } else {
-                        // single colon denotes left out zeros
-                        ipv6Automaton = concatenate(ipv6Automaton, Operations.repeat(Automata.makeChar(0)));
-                    }
                 } else {
-                    // potentially partial block
-                    if (groupsAdded == 0 && ONLY_ZEROS.matcher(group).matches()) {
-                        if (group.length() == 1) {
-                            // A single "0" can match IPv6 addresses displayed as "0:X:..." where the first group is
-                            // exactly 0x0000. We require the second group to be non-zero to avoid also matching all
-                            // IPv4-mapped addresses (::ffff:x.x.x.x) and addresses where "::" compresses leading zeros.
-                            ipv6Automaton = concatenate(List.of(ipv6Automaton, ZERO_FIRST_GROUP, NON_ZERO_SECOND_GROUP));
-                            groupsAdded = 2;
-                        } else {
-                            // Multi-zero prefixes ("00", "000", "0000") cannot match any displayed IPv6 group
-                            // since leading zeros are always stripped in IPv6 formatting.
-                            return EMPTY_AUTOMATON;
-                        }
-                    } else {
-                        // we need to create all possibilities of byte sequences this could match
-                        groupsAdded++;
-                        ipv6Automaton = concatenate(ipv6Automaton, automatonFromIPv6Group(group));
-                    }
+                    // we need to create all possibilities of byte sequences this could match
+                    groupsAdded++;
+                    parts.add(automatonFromIPv6Group(group));
                 }
             }
-            // fill up the remainder of the 16 address bytes with wildcard matches, each group added so far counts for two bytes
-            for (int i = 0; i < 16 - groupsAdded * 2; i++) {
-                ipv6Automaton = concatenate(ipv6Automaton, Operations.optional(Automata.makeCharRange(0, 255)));
-            }
         }
-        return ipv6Automaton;
+        // fill up the remainder of the 16 address bytes with wildcard matches, each group added so far counts for two bytes
+        for (int i = 0; i < 16 - groupsAdded * 2; i++) {
+            parts.add(Operations.optional(Automata.makeCharRange(0, 255)));
+        }
+        return concatenate(parts);
     }
 
     static Automaton automatonFromIPv6Group(String ipv6Group) {
         assert ipv6Group.length() > 0 && ipv6Group.length() <= 4 : "expected a full ipv6 group or prefix";
-        Automaton result = Automata.makeEmpty();
+        List<Automaton> alternatives = new ArrayList<>();
         for (int leadingZeros = 0; leadingZeros <= 4 - ipv6Group.length(); leadingZeros++) {
             int bytesAdded = 0;
             String padded = padWithZeros(ipv6Group, leadingZeros);
-            Automaton a = Automata.makeString("");
+            List<Automaton> parts = new ArrayList<>();
             while (padded.length() >= 2) {
-                a = concatenate(a, Automata.makeChar(Integer.parseInt(padded.substring(0, 2), 16)));
+                parts.add(Automata.makeChar(Integer.parseInt(padded.substring(0, 2), 16)));
                 padded = padded.substring(2);
                 bytesAdded++;
             }
             if (padded.length() == 1) {
                 int value = Integer.parseInt(padded, 16);
-                a = concatenate(a, Automata.makeCharRange(value * 16, value * 16 + 15));
+                parts.add(Automata.makeCharRange(value * 16, value * 16 + 15));
                 bytesAdded++;
             }
             if (bytesAdded != 2) {
-                a = concatenate(a, Automata.makeCharRange(0, 255));
+                parts.add(Automata.makeCharRange(0, 255));
             }
-            result = Operations.union(result, a);
+            alternatives.add(concatenate(parts));
         }
-        return result;
+        return Operations.union(alternatives);
     }
 
     private static Pattern IPV4_GROUP_MATCHER = Pattern.compile(

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1074,7 +1074,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             }
             Automaton a = caseInsensitive
                 ? AutomatonQueries.caseInsensitivePrefix(prefix)
-                : Operations.concatenate(Automata.makeString(prefix), Automata.makeAnyString());
+                : Operations.concatenate(List.of(Automata.makeString(prefix), Automata.makeAnyString()));
             assert a.isDeterministic();
 
             CompiledAutomaton automaton = new CompiledAutomaton(a, true, true);

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -896,10 +896,9 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
 
             Automaton a = Automata.makeString(key + FlattenedFieldParser.SEPARATOR);
             if (caseInsensitive) {
-                a = Operations.concatenate(a, AutomatonQueries.caseInsensitivePrefix(prefix));
+                a = Operations.concatenate(List.of(a, AutomatonQueries.caseInsensitivePrefix(prefix)));
             } else {
-                a = Operations.concatenate(a, Automata.makeString(prefix));
-                a = Operations.concatenate(a, Automata.makeAnyString());
+                a = Operations.concatenate(List.of(a, Automata.makeString(prefix), Automata.makeAnyString()));
             }
             assert a.isDeterministic();
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -809,7 +809,7 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, SystemResourc
 
         final Automaton aliasAutomaton = new RegExp(aliasAsRegex, RegExp.ALL | RegExp.DEPRECATED_COMPLEMENT).toAutomaton();
 
-        return Operations.determinize(Operations.union(patternAutomaton, aliasAutomaton), DEFAULT_DETERMINIZE_WORK_LIMIT);
+        return Operations.determinize(Operations.union(List.of(patternAutomaton, aliasAutomaton)), DEFAULT_DETERMINIZE_WORK_LIMIT);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -266,30 +265,26 @@ public class SystemIndices {
     }
 
     private static Map<String, CharacterRunAutomaton> getProductToSystemIndicesMap(Map<String, Feature> featureDescriptors) {
-        Map<String, Automaton> productToSystemIndicesMap = new HashMap<>();
+        Map<String, List<Automaton>> productToSystemIndicesMap = new HashMap<>();
         for (Feature feature : featureDescriptors.values()) {
             feature.getIndexDescriptors().forEach(systemIndexDescriptor -> {
                 if (systemIndexDescriptor.isExternal()) {
+                    Automaton automaton = SystemIndexDescriptor.buildAutomaton(
+                        systemIndexDescriptor.getIndexPattern(),
+                        systemIndexDescriptor.getAliasName()
+                    );
                     systemIndexDescriptor.getAllowedElasticProductOrigins()
-                        .forEach(origin -> productToSystemIndicesMap.compute(origin, (key, value) -> {
-                            Automaton automaton = SystemIndexDescriptor.buildAutomaton(
-                                systemIndexDescriptor.getIndexPattern(),
-                                systemIndexDescriptor.getAliasName()
-                            );
-                            return value == null ? automaton : Operations.union(value, automaton);
-                        }));
+                        .forEach(origin -> productToSystemIndicesMap.computeIfAbsent(origin, key -> new ArrayList<>()).add(automaton));
                 }
             });
             feature.getDataStreamDescriptors().forEach(dataStreamDescriptor -> {
                 if (dataStreamDescriptor.isExternal()) {
+                    Automaton automaton = SystemIndexDescriptor.buildAutomaton(
+                        dataStreamDescriptor.getBackingIndexPattern(),
+                        dataStreamDescriptor.getDataStreamName()
+                    );
                     dataStreamDescriptor.getAllowedElasticProductOrigins()
-                        .forEach(origin -> productToSystemIndicesMap.compute(origin, (key, value) -> {
-                            Automaton automaton = SystemIndexDescriptor.buildAutomaton(
-                                dataStreamDescriptor.getBackingIndexPattern(),
-                                dataStreamDescriptor.getDataStreamName()
-                            );
-                            return value == null ? automaton : Operations.union(value, automaton);
-                        }));
+                        .forEach(origin -> productToSystemIndicesMap.computeIfAbsent(origin, key -> new ArrayList<>()).add(automaton));
                 }
             });
         }
@@ -299,7 +294,9 @@ public class SystemIndices {
             .collect(
                 Collectors.toUnmodifiableMap(
                     Entry::getKey,
-                    entry -> new CharacterRunAutomaton(Operations.determinize(entry.getValue(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT))
+                    entry -> new CharacterRunAutomaton(
+                        Operations.determinize(Operations.union(entry.getValue()), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+                    )
                 )
             );
     }
@@ -456,11 +453,10 @@ public class SystemIndices {
     }
 
     private static Automaton buildIndexAutomaton(Map<String, Feature> featureDescriptors) {
-        Optional<Automaton> automaton = featureDescriptors.values()
-            .stream()
-            .map(SystemIndices::featureToIndexAutomaton)
-            .reduce(Operations::union);
-        return Operations.determinize(automaton.orElse(EMPTY), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        return Operations.determinize(
+            unionAutomata(featureDescriptors.values().stream().map(SystemIndices::featureToIndexAutomaton)),
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+        );
     }
 
     /**
@@ -483,34 +479,38 @@ public class SystemIndices {
     }
 
     private static CharacterRunAutomaton buildNetNewIndexCharacterRunAutomaton(Map<String, Feature> featureDescriptors) {
-        Optional<Automaton> automaton = featureDescriptors.values()
-            .stream()
-            .flatMap(feature -> feature.getIndexDescriptors().stream())
-            .filter(SystemIndexDescriptor::isAutomaticallyManaged)
-            .filter(SystemIndexDescriptor::isNetNew)
-            .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getIndexPattern(), descriptor.getAliasName()))
-            .reduce(Operations::union);
-        return new CharacterRunAutomaton(Operations.determinize(automaton.orElse(EMPTY), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT));
+        return new CharacterRunAutomaton(
+            Operations.determinize(
+                unionAutomata(
+                    featureDescriptors.values()
+                        .stream()
+                        .flatMap(feature -> feature.getIndexDescriptors().stream())
+                        .filter(SystemIndexDescriptor::isAutomaticallyManaged)
+                        .filter(SystemIndexDescriptor::isNetNew)
+                        .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getIndexPattern(), descriptor.getAliasName()))
+                ),
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            )
+        );
     }
 
     private static Automaton featureToIndexAutomaton(Feature feature) {
-        Optional<Automaton> systemIndexAutomaton = feature.getIndexDescriptors()
-            .stream()
-            .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getIndexPattern(), descriptor.getAliasName()))
-            .reduce(Operations::union);
-
-        return systemIndexAutomaton.orElse(EMPTY);
+        return unionAutomata(
+            feature.getIndexDescriptors()
+                .stream()
+                .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getIndexPattern(), descriptor.getAliasName()))
+        );
     }
 
     private static Automaton buildDataStreamAutomaton(Map<String, Feature> featureDescriptors) {
-        Optional<Automaton> automaton = featureDescriptors.values()
-            .stream()
-            .flatMap(feature -> feature.getDataStreamDescriptors().stream())
-            .map(SystemDataStreamDescriptor::getDataStreamName)
-            .map(dsName -> SystemIndexDescriptor.buildAutomaton(dsName, null))
-            .reduce(Operations::union);
-
-        return automaton.isPresent() ? Operations.determinize(automaton.get(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT) : EMPTY;
+        Automaton automaton = unionAutomata(
+            featureDescriptors.values()
+                .stream()
+                .flatMap(feature -> feature.getDataStreamDescriptors().stream())
+                .map(SystemDataStreamDescriptor::getDataStreamName)
+                .map(dsName -> SystemIndexDescriptor.buildAutomaton(dsName, null))
+        );
+        return automaton == EMPTY ? EMPTY : Operations.determinize(automaton, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     }
 
     private static Predicate<String> buildDataStreamNamePredicate(Map<String, Feature> featureDescriptors) {
@@ -519,19 +519,23 @@ public class SystemIndices {
     }
 
     private static Automaton buildDataStreamBackingIndicesAutomaton(Map<String, Feature> featureDescriptors) {
-        Optional<Automaton> automaton = featureDescriptors.values()
-            .stream()
-            .map(SystemIndices::featureToDataStreamBackingIndicesAutomaton)
-            .reduce(Operations::union);
-        return Operations.determinize(automaton.orElse(EMPTY), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        return Operations.determinize(
+            unionAutomata(featureDescriptors.values().stream().map(SystemIndices::featureToDataStreamBackingIndicesAutomaton)),
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+        );
     }
 
     private static Automaton featureToDataStreamBackingIndicesAutomaton(Feature feature) {
-        Optional<Automaton> systemDataStreamAutomaton = feature.getDataStreamDescriptors()
-            .stream()
-            .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getBackingIndexPattern(), null))
-            .reduce(Operations::union);
-        return systemDataStreamAutomaton.orElse(EMPTY);
+        return unionAutomata(
+            feature.getDataStreamDescriptors()
+                .stream()
+                .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getBackingIndexPattern(), null))
+        );
+    }
+
+    private static Automaton unionAutomata(Stream<Automaton> automata) {
+        List<Automaton> list = automata.toList();
+        return list.isEmpty() ? EMPTY : Operations.union(list);
     }
 
     public SystemDataStreamDescriptor validateDataStreamAccess(String dataStreamName, ThreadContext threadContext) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/UnmappedFieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/UnmappedFieldFetcher.java
@@ -74,7 +74,7 @@ public class UnmappedFieldFetcher {
     private static CharacterRunAutomaton nestedChildrenAutomaton(List<String> nestedChildren) {
         List<Automaton> automata = new ArrayList<>();
         for (String child : nestedChildren) {
-            automata.add(Operations.concatenate(Automata.makeString(child + "."), Automata.makeAnyString()));
+            automata.add(Operations.concatenate(List.of(Automata.makeString(child + "."), Automata.makeAnyString())));
         }
         return new CharacterRunAutomaton(Operations.determinize(Operations.union(automata), AUTOMATON_MAX_DETERMINIZED_STATES));
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
@@ -165,8 +165,8 @@ public final class FieldPermissions implements Accountable, CacheKey {
         } else {
             // an automaton that includes metadata fields, including join fields created by the _parent field such
             // as _parent#type
-            Automaton metaFieldsAutomaton = Operations.concatenate(Automata.makeChar('_'), Automata.makeAnyString());
-            grantedFieldsAutomaton = Operations.union(Automatons.patterns(grantedFields), metaFieldsAutomaton);
+            Automaton metaFieldsAutomaton = Operations.concatenate(List.of(Automata.makeChar('_'), Automata.makeAnyString()));
+            grantedFieldsAutomaton = Operations.union(List.of(Automatons.patterns(grantedFields), metaFieldsAutomaton));
         }
 
         Automaton deniedFieldsAutomaton;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
@@ -226,10 +226,10 @@ public final class Automatons {
 
         final List<Automaton> automata = new ArrayList<>();
         if (prefix.isEmpty() == false) {
-            automata.add(Operations.concatenate(build.apply(prefix), Automata.makeAnyString()));
+            automata.add(Operations.concatenate(List.of(build.apply(prefix), Automata.makeAnyString())));
         }
         if (suffix.isEmpty() == false) {
-            automata.add(Operations.concatenate(Automata.makeAnyString(), build.apply(suffix)));
+            automata.add(Operations.concatenate(List.of(Automata.makeAnyString(), build.apply(suffix))));
         }
         if (infix.isEmpty() == false) {
             automata.add(Operations.concatenate(List.of(Automata.makeAnyString(), build.apply(infix), Automata.makeAnyString())));

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionEncoder.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionEncoder.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -230,7 +231,7 @@ class VersionEncoder {
 
         assert Operations.hasDeadStates(a) == false;
 
-        a = Operations.concatenate(a, Automata.makeAnyBinary());
+        a = Operations.concatenate(List.of(a, Automata.makeAnyBinary()));
         assert a.isDeterministic();
         a = Operations.determinize(a, 0);
 

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionFieldWildcardQuery.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionFieldWildcardQuery.java
@@ -27,13 +27,15 @@ import java.util.List;
 class VersionFieldWildcardQuery extends AutomatonQuery {
 
     private static final Automaton OPTIONAL_NUMERIC_CHARPREFIX = Operations.optional(
-        Operations.concatenate(Automata.makeChar(VersionEncoder.NUMERIC_MARKER_BYTE), Automata.makeCharRange(0x80, 0xFF))
+        Operations.concatenate(List.of(Automata.makeChar(VersionEncoder.NUMERIC_MARKER_BYTE), Automata.makeCharRange(0x80, 0xFF)))
     );
 
     private static final Automaton OPTIONAL_RELEASE_SEPARATOR = Operations.optional(
         Operations.union(
-            Automata.makeChar(VersionEncoder.PRERELEASE_SEPARATOR_BYTE),
-            Automata.makeChar(VersionEncoder.NO_PRERELEASE_SEPARATOR_BYTE)
+            List.of(
+                Automata.makeChar(VersionEncoder.PRERELEASE_SEPARATOR_BYTE),
+                Automata.makeChar(VersionEncoder.NO_PRERELEASE_SEPARATOR_BYTE)
+            )
         )
     );
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/FileRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/FileRolesStoreTests.java
@@ -184,7 +184,7 @@ public class FileRolesStoreTests extends ESTestCase {
             AutomatonTestUtil.sameLanguage(
                 group.privilege().getAutomaton(),
                 Operations.determinize(
-                    Operations.union(IndexPrivilege.READ.getAutomaton(), IndexPrivilege.WRITE.getAutomaton()),
+                    Operations.union(List.of(IndexPrivilege.READ.getAutomaton(), IndexPrivilege.WRITE.getAutomaton())),
                     Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
                 )
             )


### PR DESCRIPTION
See corresponding Lucene change: https://github.com/apache/lucene/pull/14209 .

Lucene deprecated the two-arg Operations.concatenate/union overloads because they encourage quadratic combine-in-a-loop usage.

One-shot callers now pass List.of(...). Loops that grew a result via repeated union/concatenate (SystemIndices, IpPrefixAutomatonUtil) collect first and combine once.