### PR TITLE
[9.5] [Test] Randomly disable sequence numbers in ColumnarLuceneSyntheticSourceChangesSnapshotTests (#158979)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/ColumnarLuceneSyntheticSourceChangesSnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ColumnarLuceneSyntheticSourceChangesSnapshotTests.java
@@ -24,7 +24,7 @@ public class ColumnarLuceneSyntheticSourceChangesSnapshotTests extends LuceneSyn
             .put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), SourceFieldMapper.Mode.COLUMNAR_STORED.name())
             .put(IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING.getKey(), true)
             .put(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey(), SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY.name())
-            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true)
+            .put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), randomBoolean())
             .build();
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [Test] Randomly disable sequence numbers in ColumnarLuceneSyntheticSourceChangesSnapshotTests (#158979)