### PR TITLE
Stop calling SortField.setMissingValue

### DIFF
--- a/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQueryTests.java
+++ b/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQueryTests.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
@@ -131,7 +132,7 @@ public class BitmapBKDQueryTests extends ESTestCase {
 
         abstract SortField.Type sortType();
 
-        /** Boxed as the type {@link SortField#setMissingValue} demands for this type. */
+        /** Boxed as the type {@link SortField} constructors demand for this type. */
         abstract Object missingValue(long value);
 
         /** Adds the point plus the doc values the index sort and the streaming scan's skip both read. */
@@ -431,10 +432,13 @@ public class BitmapBKDQueryTests extends ESTestCase {
      */
     private static RandomIndexWriter sortedWriter(NumberType type, Directory dir, Long missingValue) throws IOException {
         IndexWriterConfig config = newIndexWriterConfig();
-        SortedNumericSortField sortField = new SortedNumericSortField(FIELD, type.sortType());
-        if (missingValue != null) {
-            sortField.setMissingValue(type.missingValue(missingValue));
-        }
+        SortedNumericSortField sortField = new SortedNumericSortField(
+            FIELD,
+            type.sortType(),
+            false,
+            SortedNumericSelector.Type.MIN,
+            missingValue == null ? null : type.missingValue(missingValue)
+        );
         config.setIndexSort(new Sort(sortField));
         return new RandomIndexWriter(random(), dir, config);
     }

--- a/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapTermsQueryTests.java
+++ b/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapTermsQueryTests.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TopDocs;
@@ -138,7 +139,7 @@ public class BitmapTermsQueryTests extends ESTestCase {
 
         abstract SortField.Type sortType();
 
-        /** Boxed as the type {@link SortField#setMissingValue} demands for this type. */
+        /** Boxed as the type {@link SortField} constructors demand for this type. */
         abstract Object missingValue(long value);
 
         void addField(Document doc, long value) {
@@ -575,8 +576,13 @@ public class BitmapTermsQueryTests extends ESTestCase {
     public void testSortedIndexWithInterleavedMissingValues() throws IOException {
         for (NumberType type : NumberType.values()) {
             IndexWriterConfig config = newIndexWriterConfig();
-            SortedNumericSortField sortField = new SortedNumericSortField(FIELD, type.sortType());
-            sortField.setMissingValue(type.missingValue(100));
+            SortedNumericSortField sortField = new SortedNumericSortField(
+                FIELD,
+                type.sortType(),
+                false,
+                SortedNumericSelector.Type.MIN,
+                type.missingValue(100)
+            );
             config.setIndexSort(new Sort(sortField));
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir, config)) {
                 int withValue = 0;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -433,8 +433,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
     }
 
     public void testCreateShrinkWithIndexSort() throws Exception {
-        SortField expectedSortField = new SortedSetSortField("id", true, SortedSetSelector.Type.MAX);
-        expectedSortField.setMissingValue(SortedSetSortField.STRING_FIRST);
+        SortField expectedSortField = new SortedSetSortField("id", true, SortedSetSelector.Type.MAX, SortedSetSortField.STRING_FIRST);
         Sort expectedIndexSort = new Sort(expectedSortField);
         internalCluster().ensureAtLeastNumDataNodes(2);
         prepareCreate("source").setSettings(

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
@@ -445,8 +445,7 @@ public class SplitIndexIT extends ESIntegTestCase {
     }
 
     public void testCreateSplitWithIndexSort() throws Exception {
-        SortField expectedSortField = new SortedSetSortField("id", true, SortedSetSelector.Type.MAX);
-        expectedSortField.setMissingValue(SortedSetSortField.STRING_FIRST);
+        SortField expectedSortField = new SortedSetSortField("id", true, SortedSetSelector.Type.MAX, SortedSetSortField.STRING_FIRST);
         Sort expectedIndexSort = new Sort(expectedSortField);
         internalCluster().ensureAtLeastNumDataNodes(2);
         prepareCreate("source").setSettings(

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexSortIT.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -57,12 +58,15 @@ public class IndexSortIT extends ESIntegTestCase {
     }
 
     public void testIndexSort() {
-        SortField dateSort = new SortedNumericSortField("date", SortField.Type.LONG, false);
-        dateSort.setMissingValue(Long.MAX_VALUE);
-        SortField numericSort = new SortedNumericSortField("numeric_dv", SortField.Type.INT, false);
-        numericSort.setMissingValue(Integer.MAX_VALUE);
-        SortField keywordSort = new SortedSetSortField("keyword_dv", false);
-        keywordSort.setMissingValue(SortField.STRING_LAST);
+        SortField dateSort = new SortedNumericSortField("date", SortField.Type.LONG, false, SortedNumericSelector.Type.MIN, Long.MAX_VALUE);
+        SortField numericSort = new SortedNumericSortField(
+            "numeric_dv",
+            SortField.Type.INT,
+            false,
+            SortedNumericSelector.Type.MIN,
+            Integer.MAX_VALUE
+        );
+        SortField keywordSort = new SortedSetSortField("keyword_dv", false, SortedSetSelector.Type.MIN, SortField.STRING_LAST);
         Sort indexSort = new Sort(dateSort, numericSort, keywordSort);
         prepareCreate("test").setSettings(
             Settings.builder()
@@ -102,8 +106,7 @@ public class IndexSortIT extends ESIntegTestCase {
         flushAndRefresh();
         ensureYellow();
 
-        SortField sf = new SortedNumericSortField("@timestamp", SortField.Type.LONG, true, SortedNumericSelector.Type.MAX);
-        sf.setMissingValue(0L);
+        SortField sf = new SortedNumericSortField("@timestamp", SortField.Type.LONG, true, SortedNumericSelector.Type.MAX, 0L);
         Sort expectedIndexSort = new Sort(sf);
         assertSortedSegments("test", expectedIndexSort);
     }

--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -632,11 +632,7 @@ public class Lucene {
         SortField.Type sortType = readSortType(in);
         Object missingValue = readMissingValue(in);
         boolean reverse = in.readBoolean();
-        SortField sortField = new SortField(field, sortType, reverse);
-        if (missingValue != null) {
-            sortField.setMissingValue(missingValue);
-        }
-        return sortField;
+        return new SortField(field, sortType, reverse, missingValue);
     }
 
     public static void writeSortType(StreamOutput out, SortField.Type sortType) throws IOException {
@@ -649,26 +645,15 @@ public class Lucene {
      */
     public static SortField rewriteMergeSortField(SortField sortField) {
         if (sortField.getClass() == GEO_DISTANCE_SORT_TYPE_CLASS) {
-            SortField newSortField = new SortField(sortField.getField(), SortField.Type.DOUBLE);
-            newSortField.setMissingValue(sortField.getMissingValue());
-            return newSortField;
+            return new SortField(sortField.getField(), SortField.Type.DOUBLE, false, sortField.getMissingValue());
         } else if (sortField.getClass() == SortedSetSortField.class) {
-            SortField newSortField = new SortField(sortField.getField(), SortField.Type.STRING, sortField.getReverse());
-            newSortField.setMissingValue(sortField.getMissingValue());
-            return newSortField;
+            return new SortField(sortField.getField(), SortField.Type.STRING, sortField.getReverse(), sortField.getMissingValue());
         } else if (sortField instanceof SortedNumericSortField snsf) {
-            SortField newSortField = new SortField(sortField.getField(), snsf.getNumericType(), sortField.getReverse());
-            newSortField.setMissingValue(sortField.getMissingValue());
-            return newSortField;
+            return new SortField(sortField.getField(), snsf.getNumericType(), sortField.getReverse(), sortField.getMissingValue());
         } else if (sortField.getClass() == ShardDocSortField.class) {
             return new SortField(sortField.getField(), SortField.Type.LONG, sortField.getReverse());
         } else if (sortField.getComparatorSource() instanceof IndexFieldData.XFieldComparatorSource fcs) {
-            SortField newSortField = new SortField(sortField.getField(), fcs.reducedType(), sortField.getReverse());
-            Object missingValue = fcs.missingValue(sortField.getReverse());
-            if (missingValue != null) {
-                newSortField.setMissingValue(missingValue);
-            }
-            return newSortField;
+            return new SortField(sortField.getField(), fcs.reducedType(), sortField.getReverse(), fcs.missingValue(sortField.getReverse()));
         } else {
             return sortField;
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -185,17 +185,22 @@ public class Segment implements Writeable {
                 Boolean missingFirst = in.readOptionalBoolean();
                 boolean max = in.readBoolean();
                 boolean reverse = in.readBoolean();
-                fields[i] = new SortedSetSortField(field, reverse, max ? SortedSetSelector.Type.MAX : SortedSetSelector.Type.MIN);
-                if (missingFirst != null) {
-                    fields[i].setMissingValue(missingFirst ? SortedSetSortField.STRING_FIRST : SortedSetSortField.STRING_LAST);
-                }
+                Object missingValue = missingFirst == null ? null
+                    : missingFirst ? SortedSetSortField.STRING_FIRST
+                    : SortedSetSortField.STRING_LAST;
+                fields[i] = new SortedSetSortField(
+                    field,
+                    reverse,
+                    max ? SortedSetSelector.Type.MAX : SortedSetSelector.Type.MIN,
+                    missingValue
+                );
             } else if (type == SORT_STRING_SINGLE) {
                 Boolean missingFirst = in.readOptionalBoolean();
                 boolean reverse = in.readBoolean();
-                fields[i] = new SortField(field, SortField.Type.STRING, reverse);
-                if (missingFirst != null) {
-                    fields[i].setMissingValue(missingFirst ? SortedSetSortField.STRING_FIRST : SortedSetSortField.STRING_LAST);
-                }
+                Object missingValue = missingFirst == null ? null
+                    : missingFirst ? SortedSetSortField.STRING_FIRST
+                    : SortedSetSortField.STRING_LAST;
+                fields[i] = new SortField(field, SortField.Type.STRING, reverse, missingValue);
             } else {
                 Object missing = in.readGenericValue();
                 boolean max = in.readBoolean();
@@ -211,11 +216,9 @@ public class Segment implements Writeable {
                     field,
                     numericType,
                     reverse,
-                    max ? SortedNumericSelector.Type.MAX : SortedNumericSelector.Type.MIN
+                    max ? SortedNumericSelector.Type.MAX : SortedNumericSelector.Type.MIN,
+                    missing
                 );
-                if (missing != null) {
-                    fields[i].setMissingValue(missing);
-                }
             }
         }
         return new Sort(fields);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -243,7 +243,7 @@ public interface IndexFieldData<FD extends LeafFieldData> {
         }
 
         /**
-         * Return a missing value that is understandable by {@link SortField#setMissingValue(Object)}.
+         * Return a missing value that is understandable by {@link SortField} constructors.
          * Most implementations return null because they already replace the value at the fielddata level.
          * However this can't work in case of strings since there is no such thing as a string which
          * compares greater than any other string, so in that case we need to return

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -102,7 +102,7 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
         boolean requiresCustomComparator = nested != null
             || (sortMode != MultiValueMode.MAX && sortMode != MultiValueMode.MIN)
             || targetNumericType != getNumericType();
-        return buildSortField(targetNumericType, missingValue, sortMode, nested, reverse, false, requiresCustomComparator == false);
+        return buildSortField(targetNumericType, missingValue, sortMode, nested, reverse, false, requiresCustomComparator == false, null);
     }
 
     private SortField buildSortField(
@@ -112,7 +112,8 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
         Nested nested,
         boolean reverse,
         boolean useNativeSortField,
-        boolean optimizeSortWithPoints
+        boolean optimizeSortWithPoints,
+        IndexVersion indexCreatedVersion
     ) {
         XFieldComparatorSource source = comparatorSource(targetNumericType, missingValue, sortMode, nested);
         if (useNativeSortField == false || sortRequiresCustomComparator()) {
@@ -126,8 +127,24 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
         SortedNumericSelector.Type selectorType = sortMode == MultiValueMode.MAX
             ? SortedNumericSelector.Type.MAX
             : SortedNumericSelector.Type.MIN;
-        SortField sortField = new SortedNumericSortField(getFieldName(), targetNumericType.sortFieldType, reverse, selectorType);
-        sortField.setMissingValue(source.missingObject(missingValue, reverse));
+        Object missingObject = source.missingObject(missingValue, reverse);
+        if (getNumericType() == NumericType.DATE_NANOSECONDS
+            && indexCreatedVersion != null
+            && indexCreatedVersion.before(IndexVersions.V_7_14_0)
+            && missingValue.equals("_last")
+            && Long.valueOf(0L).equals(missingObject)) {
+            // 7.14 changed the default missing value of sort on date_nanos, from Long.MIN_VALUE
+            // to 0L - for compatibility we require to a missing value of MIN_VALUE to allow to
+            // open the index.
+            missingObject = Long.MIN_VALUE;
+        }
+        SortField sortField = new SortedNumericSortField(
+            getFieldName(),
+            targetNumericType.sortFieldType,
+            reverse,
+            selectorType,
+            missingObject
+        );
         sortField.setOptimizeSortWithPoints(optimizeSortWithPoints && canUseOptimizedSort(indexType()));
         return sortField;
     }
@@ -178,26 +195,16 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
         NumericType targetNumericType = useBwcLongSort ? NumericType.LONG : getNumericType();
         boolean hasNativeSelector = nested == null && (sortMode == MultiValueMode.MIN || sortMode == MultiValueMode.MAX);
         boolean useNativeSortField = hasNativeSelector && (indexSort || useBwcLongSort);
-        SortField sortField = buildSortField(
+        return buildSortField(
             targetNumericType,
             missingValue,
             sortMode,
             nested,
             reverse,
             useNativeSortField,
-            useBwcLongSort == false && hasNativeSelector
+            useBwcLongSort == false && hasNativeSelector,
+            indexCreatedVersion
         );
-
-        if (getNumericType() == NumericType.DATE_NANOSECONDS
-            && indexCreatedVersion.before(IndexVersions.V_7_14_0)
-            && missingValue.equals("_last")
-            && Long.valueOf(0L).equals(sortField.getMissingValue())) {
-            // 7.14 changed the default missing value of sort on date_nanos, from Long.MIN_VALUE
-            // to 0L - for compatibility we require to a missing value of MIN_VALUE to allow to
-            // open the index.
-            sortField.setMissingValue(Long.MIN_VALUE);
-        }
-        return sortField;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedOrdinalsIndexFieldData.java
@@ -60,11 +60,12 @@ public class SortedOrdinalsIndexFieldData extends AbstractIndexOrdinalsFieldData
 
     @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse) {
-        SortField sortField = new SortField(getFieldName(), SortField.Type.STRING, reverse);
-        sortField.setMissingValue(
+        return new SortField(
+            getFieldName(),
+            SortField.Type.STRING,
+            reverse,
             sortMissingLast(missingValue) ^ reverse ? SortedSetSortField.STRING_LAST : SortedSetSortField.STRING_FIRST
         );
-        return sortField;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
@@ -73,15 +73,12 @@ public class SortedSetOrdinalsIndexFieldData extends AbstractIndexOrdinalsFieldD
             || (sortMissingLast(missingValue) == false && sortMissingFirst(missingValue) == false)) {
             return new SortField(getFieldName(), source, reverse);
         }
-        SortField sortField = new SortedSetSortField(
+        return new SortedSetSortField(
             getFieldName(),
             reverse,
-            sortMode == MultiValueMode.MAX ? SortedSetSelector.Type.MAX : SortedSetSelector.Type.MIN
-        );
-        sortField.setMissingValue(
+            sortMode == MultiValueMode.MAX ? SortedSetSelector.Type.MAX : SortedSetSelector.Type.MIN,
             sortMissingLast(missingValue) ^ reverse ? SortedSetSortField.STRING_LAST : SortedSetSortField.STRING_FIRST
         );
-        return sortField;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortFieldValidation.java
@@ -178,9 +178,12 @@ public final class SortFieldValidation {
         for (int fieldIdx : fieldIdsWithMixedNumericSorts) {
             // Rewrite the sort field to DOUBLE
             SortField originalField = newSortFields[fieldIdx];
-            SortField doubleField = new SortField(originalField.getField(), SortField.Type.DOUBLE, originalField.getReverse());
-            doubleField.setMissingValue(originalField.getMissingValue());
-            newSortFields[fieldIdx] = doubleField;
+            newSortFields[fieldIdx] = new SortField(
+                originalField.getField(),
+                SortField.Type.DOUBLE,
+                originalField.getReverse(),
+                originalField.getMissingValue()
+            );
 
             // Convert all sort values to Double
             for (TopDocs topDocs : results) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponseTests.java
@@ -33,8 +33,7 @@ public class IndicesSegmentResponseTests extends ESTestCase {
         ShardRouting shardRouting = TestShardRouting.newShardRouting("foo", 0, "node_id", true, ShardRoutingState.STARTED);
         Segment segment = new Segment("my");
 
-        SortField sortField = new SortField("foo", SortField.Type.STRING);
-        sortField.setMissingValue(SortField.STRING_LAST);
+        SortField sortField = new SortField("foo", SortField.Type.STRING, false, SortField.STRING_LAST);
         segment.segmentSort = new Sort(sortField);
 
         ShardSegments shardSegments = new ShardSegments(shardRouting, Collections.singletonList(segment));
@@ -57,8 +56,7 @@ public class IndicesSegmentResponseTests extends ESTestCase {
             routings.add(TestShardRouting.newShardRouting("index-" + i, 0, "node_id", true, ShardRoutingState.STARTED));
         }
         Segment segment = new Segment("my");
-        SortField sortField = new SortField("foo", SortField.Type.STRING);
-        sortField.setMissingValue(SortField.STRING_LAST);
+        SortField sortField = new SortField("foo", SortField.Type.STRING, false, SortField.STRING_LAST);
         segment.segmentSort = new Sort(sortField);
         AbstractChunkedSerializingTestCase.assertChunkCount(
             new IndicesSegmentResponse(

--- a/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
@@ -612,11 +613,9 @@ public class LuceneTests extends ESTestCase {
                 if ((type == SortField.Type.SCORE || type == SortField.Type.DOC) && randomBoolean()) {
                     field = null;
                 }
-                SortField sortField = new SortField(field, type, randomBoolean());
-                Object missingValue = randomMissingValue(sortField.getType());
-                if (missingValue != null) {
-                    sortField.setMissingValue(missingValue);
-                }
+                boolean reverse = randomBoolean();
+                Object missingValue = randomMissingValue(type);
+                SortField sortField = new SortField(field, type, reverse, missingValue);
                 return Tuple.tuple(sortField, sortField);
             default:
                 throw new UnsupportedOperationException();
@@ -666,8 +665,7 @@ public class LuceneTests extends ESTestCase {
             default -> throw new UnsupportedOperationException();
         }
         SortField sortField = new SortField(field, comparatorSource, reverse);
-        SortField expected = new SortField(field, comparatorSource.reducedType(), reverse);
-        expected.setMissingValue(missingValue);
+        SortField expected = new SortField(field, comparatorSource.reducedType(), reverse, missingValue);
         return Tuple.tuple(sortField, expected);
     }
 
@@ -676,27 +674,32 @@ public class LuceneTests extends ESTestCase {
         switch (randomIntBetween(0, 3)) {
             case 0 -> {
                 SortField sortField = LatLonDocValuesField.newDistanceSort(field, 0, 0);
-                SortField expected = new SortField(field, SortField.Type.DOUBLE);
-                expected.setMissingValue(Double.POSITIVE_INFINITY);
+                SortField expected = new SortField(field, SortField.Type.DOUBLE, false, Double.POSITIVE_INFINITY);
                 return Tuple.tuple(sortField, expected);
             }
             case 1 -> {
-                SortedSetSortField sortField = new SortedSetSortField(field, randomBoolean(), randomFrom(SortedSetSelector.Type.values()));
-                SortField expected = new SortField(sortField.getField(), SortField.Type.STRING, sortField.getReverse());
                 Object missingValue = randomMissingValue(SortField.Type.STRING);
-                sortField.setMissingValue(missingValue);
-                expected.setMissingValue(missingValue);
+                SortedSetSortField sortField = new SortedSetSortField(
+                    field,
+                    randomBoolean(),
+                    randomFrom(SortedSetSelector.Type.values()),
+                    missingValue
+                );
+                SortField expected = new SortField(sortField.getField(), SortField.Type.STRING, sortField.getReverse(), missingValue);
                 return Tuple.tuple(sortField, expected);
             }
             case 2 -> {
                 SortField.Type type = randomFrom(SortField.Type.DOUBLE, SortField.Type.INT, SortField.Type.FLOAT, SortField.Type.LONG);
-                SortedNumericSortField sortField = new SortedNumericSortField(field, type, randomBoolean());
-                SortField expected = new SortField(sortField.getField(), sortField.getNumericType(), sortField.getReverse());
+                boolean reverse = randomBoolean();
                 Object missingValue = randomMissingValue(type);
-                if (missingValue != null) {
-                    sortField.setMissingValue(missingValue);
-                    expected.setMissingValue(missingValue);
-                }
+                SortedNumericSortField sortField = new SortedNumericSortField(
+                    field,
+                    type,
+                    reverse,
+                    SortedNumericSelector.Type.MIN,
+                    missingValue
+                );
+                SortField expected = new SortField(sortField.getField(), sortField.getNumericType(), reverse, missingValue);
                 return Tuple.tuple(sortField, expected);
             }
             case 3 -> {

--- a/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PruningMergePolicyTests.java
@@ -759,15 +759,14 @@ public class PruningMergePolicyTests extends ESTestCase {
                 )
             );
         }
-        var sortOnTsId = new SortField(TimeSeriesIdFieldMapper.NAME, SortField.Type.STRING);
-        sortOnTsId.setMissingValue(SortField.STRING_LAST);
+        var sortOnTsId = new SortField(TimeSeriesIdFieldMapper.NAME, SortField.Type.STRING, false, SortField.STRING_LAST);
         var sortOnTimestamp = new SortedNumericSortField(
             DataStreamTimestampFieldMapper.DEFAULT_PATH,
             SortField.Type.LONG,
             true,
-            SortedNumericSelector.Type.MAX
+            SortedNumericSelector.Type.MAX,
+            Long.MIN_VALUE
         );
-        sortOnTimestamp.setMissingValue(Long.MIN_VALUE);
         iwc.setIndexSort(new Sort(sortOnTsId, sortOnTimestamp));
         iwc.setMergedSegmentWarmer(reader -> {});
         return iwc;

--- a/server/src/test/java/org/elasticsearch/index/engine/SegmentTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/SegmentTests.java
@@ -27,36 +27,25 @@ import java.util.Objects;
 public class SegmentTests extends ESTestCase {
     static SortField randomSortField() {
         return switch (between(0, 2)) {
-            case 0 -> {
-                SortedNumericSortField field = new SortedNumericSortField(
-                    randomAlphaOfLengthBetween(1, 10),
-                    SortField.Type.INT,
-                    randomBoolean(),
-                    randomBoolean() ? SortedNumericSelector.Type.MAX : SortedNumericSelector.Type.MIN
-                );
-                if (randomBoolean()) {
-                    field.setMissingValue(randomInt());
-                }
-                yield field;
-            }
-            case 1 -> {
-                SortedSetSortField field = new SortedSetSortField(
-                    randomAlphaOfLengthBetween(1, 10),
-                    randomBoolean(),
-                    randomBoolean() ? SortedSetSelector.Type.MAX : SortedSetSelector.Type.MIN
-                );
-                if (randomBoolean()) {
-                    field.setMissingValue(randomBoolean() ? SortedSetSortField.STRING_FIRST : SortedSetSortField.STRING_LAST);
-                }
-                yield field;
-            }
-            case 2 -> {
-                SortField field = new SortField(randomAlphaOfLengthBetween(1, 10), SortField.Type.STRING, randomBoolean());
-                if (randomBoolean()) {
-                    field.setMissingValue(randomBoolean() ? SortedSetSortField.STRING_FIRST : SortedSetSortField.STRING_LAST);
-                }
-                yield field;
-            }
+            case 0 -> new SortedNumericSortField(
+                randomAlphaOfLengthBetween(1, 10),
+                SortField.Type.INT,
+                randomBoolean(),
+                randomBoolean() ? SortedNumericSelector.Type.MAX : SortedNumericSelector.Type.MIN,
+                randomBoolean() ? randomInt() : null
+            );
+            case 1 -> new SortedSetSortField(
+                randomAlphaOfLengthBetween(1, 10),
+                randomBoolean(),
+                randomBoolean() ? SortedSetSelector.Type.MAX : SortedSetSelector.Type.MIN,
+                randomBoolean() ? (randomBoolean() ? SortedSetSortField.STRING_FIRST : SortedSetSortField.STRING_LAST) : null
+            );
+            case 2 -> new SortField(
+                randomAlphaOfLengthBetween(1, 10),
+                SortField.Type.STRING,
+                randomBoolean(),
+                randomBoolean() ? (randomBoolean() ? SortedSetSortField.STRING_FIRST : SortedSetSortField.STRING_LAST) : null
+            );
             default -> throw new UnsupportedOperationException();
         };
     }

--- a/server/src/test/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollectorSearchAfterTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollectorSearchAfterTests.java
@@ -160,9 +160,7 @@ public class SinglePassGroupingCollectorSearchAfterTests extends ESTestCase {
 
             @Override
             public SortField sortField(boolean reversed) {
-                SortField sortField = new SortField("field", SortField.Type.LONG, reversed);
-                sortField.setMissingValue(reversed ? Long.MIN_VALUE : Long.MAX_VALUE);
-                return sortField;
+                return new SortField("field", SortField.Type.LONG, reversed, reversed ? Long.MIN_VALUE : Long.MAX_VALUE);
             }
         };
         assertSearchCollapse(producer, true);
@@ -182,9 +180,7 @@ public class SinglePassGroupingCollectorSearchAfterTests extends ESTestCase {
 
             @Override
             public SortField sortField(boolean reversed) {
-                SortField sortField = new SortField("field", SortField.Type.INT, reversed);
-                sortField.setMissingValue(reversed ? Integer.MIN_VALUE : Integer.MAX_VALUE);
-                return sortField;
+                return new SortField("field", SortField.Type.INT, reversed, reversed ? Integer.MIN_VALUE : Integer.MAX_VALUE);
             }
         };
         assertSearchCollapse(producer, true);
@@ -204,9 +200,7 @@ public class SinglePassGroupingCollectorSearchAfterTests extends ESTestCase {
 
             @Override
             public SortField sortField(boolean reversed) {
-                SortField sortField = new SortField("field", SortField.Type.FLOAT, reversed);
-                sortField.setMissingValue(reversed ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY);
-                return sortField;
+                return new SortField("field", SortField.Type.FLOAT, reversed, reversed ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY);
             }
         };
         assertSearchCollapse(producer, true);
@@ -226,9 +220,12 @@ public class SinglePassGroupingCollectorSearchAfterTests extends ESTestCase {
 
             @Override
             public SortField sortField(boolean reversed) {
-                SortField sortField = new SortField("field", SortField.Type.DOUBLE, reversed);
-                sortField.setMissingValue(reversed ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
-                return sortField;
+                return new SortField(
+                    "field",
+                    SortField.Type.DOUBLE,
+                    reversed,
+                    reversed ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY
+                );
             }
         };
         assertSearchCollapse(producer, true);
@@ -248,9 +245,7 @@ public class SinglePassGroupingCollectorSearchAfterTests extends ESTestCase {
 
             @Override
             public SortField sortField(boolean reversed) {
-                SortField sortField = new SortField("field", SortField.Type.STRING, reversed);
-                sortField.setMissingValue(reversed ? SortField.STRING_FIRST : SortField.STRING_LAST);
-                return sortField;
+                return new SortField("field", SortField.Type.STRING, reversed, reversed ? SortField.STRING_FIRST : SortField.STRING_LAST);
             }
         };
         assertSearchCollapse(producer, false);

--- a/server/src/test/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/grouping/SinglePassGroupingCollectorTests.java
@@ -380,8 +380,7 @@ public class SinglePassGroupingCollectorTests extends ESTestCase {
 
         MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
 
-        SortField sortField = new SortField("group", SortField.Type.LONG);
-        sortField.setMissingValue(Long.MAX_VALUE);
+        SortField sortField = new SortField("group", SortField.Type.LONG, false, Long.MAX_VALUE);
         Sort sort = new Sort(sortField);
 
         final SinglePassGroupingCollector<?> collapsingCollector = SinglePassGroupingCollector.createNumeric(

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -846,10 +846,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
         writer.close();
         reader = DirectoryReader.open(dir);
 
-        final SortField sortFieldLong = new SortField(fieldNameLong, SortField.Type.LONG);
-        final SortField sortFieldDate = new SortField(fieldNameDate, SortField.Type.LONG);
-        sortFieldLong.setMissingValue(Long.MAX_VALUE);
-        sortFieldDate.setMissingValue(Long.MAX_VALUE);
+        final SortField sortFieldLong = new SortField(fieldNameLong, SortField.Type.LONG, false, Long.MAX_VALUE);
+        final SortField sortFieldDate = new SortField(fieldNameDate, SortField.Type.LONG, false, Long.MAX_VALUE);
         final Sort sortLong = new Sort(sortFieldLong);
         final Sort sortDate = new Sort(sortFieldDate);
         final Sort sortLongDate = new Sort(sortFieldLong, sortFieldDate);

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene62/Lucene62SegmentInfoFormat.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene62/Lucene62SegmentInfoFormat.java
@@ -141,14 +141,6 @@ public class Lucene62SegmentInfoFormat extends SegmentInfoFormat {
                             throw new CorruptIndexException("invalid index sort reverse: " + b, input);
                         }
 
-                        if (sortedSetSelector != null) {
-                            sortFields[i] = new SortedSetSortField(fieldName, reverse, sortedSetSelector);
-                        } else if (sortedNumericSelector != null) {
-                            sortFields[i] = new SortedNumericSortField(fieldName, sortType, reverse, sortedNumericSelector);
-                        } else {
-                            sortFields[i] = new SortField(fieldName, sortType, reverse);
-                        }
-
                         Object missingValue;
                         b = input.readByte();
                         if (b == 0) {
@@ -192,8 +184,12 @@ public class Lucene62SegmentInfoFormat extends SegmentInfoFormat {
                                     throw new AssertionError("unhandled sortType=" + sortType);
                             }
                         }
-                        if (missingValue != null) {
-                            sortFields[i].setMissingValue(missingValue);
+                        if (sortedSetSelector != null) {
+                            sortFields[i] = new SortedSetSortField(fieldName, reverse, sortedSetSelector, missingValue);
+                        } else if (sortedNumericSelector != null) {
+                            sortFields[i] = new SortedNumericSortField(fieldName, sortType, reverse, sortedNumericSelector, missingValue);
+                        } else {
+                            sortFields[i] = new SortField(fieldName, sortType, reverse, missingValue);
                         }
                     }
                     indexSort = new Sort(sortFields);


### PR DESCRIPTION
Lucene deprecated the mutable setter in favor of constructor parameters. Pass missing values at construction to stay compatible with Lucene 11.

See https://github.com/apache/lucene/pull/15483