### PR TITLE
[CI] Honor JAVA_HOME when launching GradleRunner

### DIFF
--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -62,7 +62,9 @@ GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
 
-if command -v java > /dev/null; then
+if [[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/java" ]]; then
+  "$JAVA_HOME/bin/java" -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+elif command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
 else
   "$GRADLEW" -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"


### PR DESCRIPTION
## Summary
- Follow-up to #158822: forward-port only the `run-gradle.sh` JAVA_HOME handling to `main`. `example-plugins.sh` does not exist here and is not needed.
- After the move to GradleRunner, this script launched `java -jar` from PATH, so a `JAVA_HOME` override from a CI wrapper was ignored.
- Prefer `$JAVA_HOME/bin/java` when it is executable. Otherwise keep the existing PATH `java` / `gradlew` fallbacks, including `TESTS_SEED` and `EXTRA_GRADLE_ARGS`.
