### PR TITLE
Trim empty objects post-ingest for strict-columnar

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -72,6 +72,7 @@ import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.grok.MatcherWatchdog;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
@@ -1514,7 +1515,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                      * At this point, all pipelines have been executed, and we are about to overwrite ingestDocument with the results.
                      * This is our chance to sample with both the original document and all changes.
                      */
-                    updateIndexRequestSource(indexRequest, ingestDocument);
+                    updateIndexRequestSource(indexRequest, ingestDocument, project);
                     cacheRawTimestamp(indexRequest, ingestDocument);
                     listener.onResponse(IngestPipelinesExecutionResult.SUCCESSFUL_RESULT); // document succeeded!
                 }
@@ -1658,13 +1659,86 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
     /**
      * Updates an index request based on the source of an ingest document, guarding against self-references if necessary.
+     * For strict-columnar index modes, any object fields that are empty after pipeline processing are removed from the
+     * document source before writing back, preventing pipeline-leaked empty containers (e.g. {@code {"system":{"syslog":{}}}}
+     * after groking fields out) from disabling batch indexing permanently on every bulk request.
      */
-    private static void updateIndexRequestSource(final IndexRequest request, final IngestDocument document) {
+    private static void updateIndexRequestSource(
+        final IndexRequest request,
+        final IngestDocument document,
+        final ProjectMetadata project
+    ) {
+        if (isStrictColumnarTarget(request, project)) {
+            removeEmptyObjects(document.getSource());
+        }
         boolean ensureNoSelfReferences = document.doNoSelfReferencesCheck();
         // we already check for self references elsewhere (and clear the bit), so this should always be false,
         // keeping the check and assert as a guard against extraordinarily surprising circumstances
         assert ensureNoSelfReferences == false;
         request.source(document.getSource(), request.getContentType(), ensureNoSelfReferences);
+    }
+
+    /**
+     * Returns {@code true} if the target index for this request is in a strict-columnar index mode
+     * (i.e. {@link IndexMode#isStrictColumnar()} returns {@code true}). Resolved from the cluster state,
+     * preferring the write index's {@link IndexMetadata#getIndexMode()} for data streams — the data-stream
+     * level mode can lag when the write index was created before a mode change. Falls back to template
+     * settings for indices not yet created.
+     */
+    static boolean isStrictColumnarTarget(IndexRequest indexRequest, ProjectMetadata project) {
+        String targetIndex = indexRequest.index();
+        if (targetIndex == null) {
+            return false;
+        }
+        // data stream: prefer write index's authoritative IndexMode over the data-stream-level field
+        DataStream dataStream = project.dataStreams().get(targetIndex);
+        if (dataStream != null) {
+            IndexMetadata writeMeta = project.index(dataStream.getWriteIndex());
+            if (writeMeta != null) {
+                IndexMode mode = writeMeta.getIndexMode();
+                return mode != null && mode.isStrictColumnar();
+            }
+            // write index metadata unavailable (e.g. not yet flushed to state); fall back to data-stream level
+            IndexMode mode = dataStream.getIndexMode();
+            return mode != null && mode.isStrictColumnar();
+        }
+        // concrete existing index
+        IndexMetadata indexMetadata = project.index(targetIndex);
+        if (indexMetadata != null) {
+            IndexMode mode = indexMetadata.getIndexMode();
+            return mode != null && mode.isStrictColumnar();
+        }
+        // index not yet created: consult V2 template (V2 composite templates are always used for data streams,
+        // which is the primary use case; V1 templates pre-date strict-columnar index modes so we skip them)
+        String v2Template = MetadataIndexTemplateService.findV2Template(project, targetIndex, false);
+        if (v2Template != null) {
+            Settings settings = MetadataIndexTemplateService.resolveSettings(project, v2Template);
+            return IndexSettings.MODE.get(settings).isStrictColumnar();
+        }
+        return false;
+    }
+
+    /**
+     * Recursively removes entries whose value is an empty {@link Map}, bottom-up, from the given source map.
+     * This prunes empty container objects that ingest pipelines leave behind after removing all of a nested
+     * object's fields (e.g. groking children and then renaming or removing them). The removal is in place.
+     * <p>
+     * Only {@code Map} values are descended into; lists are not modified, since removing elements from an
+     * array changes its semantics in ways that are not equivalent to the field being absent.
+     */
+    static void removeEmptyObjects(Map<String, Object> source) {
+        Iterator<Map.Entry<String, Object>> it = source.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Object> entry = it.next();
+            if (entry.getValue() instanceof Map<?, ?> nested) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> nestedMap = (Map<String, Object>) nested;
+                removeEmptyObjects(nestedMap);
+                if (nestedMap.isEmpty()) {
+                    it.remove();
+                }
+            }
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1663,11 +1663,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
      * document source before writing back, preventing pipeline-leaked empty containers (e.g. {@code {"system":{"syslog":{}}}}
      * after groking fields out) from disabling batch indexing permanently on every bulk request.
      */
-    private static void updateIndexRequestSource(
-        final IndexRequest request,
-        final IngestDocument document,
-        final ProjectMetadata project
-    ) {
+    private static void updateIndexRequestSource(final IndexRequest request, final IngestDocument document, final ProjectMetadata project) {
         if (isStrictColumnarTarget(request, project)) {
             removeEmptyObjects(document.getSource());
         }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -60,6 +60,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.VersionType;
@@ -3378,6 +3379,126 @@ public class IngestServiceTests extends ESTestCase {
 
             IndexRequest indexRequest = new IndexRequest("rollover-data-stream");
             assertTrue(IngestService.isRolloverOnWrite(metadata.getProject(), indexRequest));
+        }
+    }
+
+    public void testRemoveEmptyObjects() {
+        {   // flat empty object is removed
+            Map<String, Object> source = new HashMap<>(Map.of("empty", new HashMap<>(), "kept", "value"));
+            IngestService.removeEmptyObjects(source);
+            assertThat(source, equalTo(Map.of("kept", "value")));
+        }
+
+        {   // nested empty object is removed bottom-up: inner prune makes outer empty, then outer is pruned too
+            Map<String, Object> inner = new HashMap<>();
+            Map<String, Object> outer = new HashMap<>(Map.of("syslog", inner));
+            Map<String, Object> source = new HashMap<>(Map.of("system", outer, "message", "hello"));
+            IngestService.removeEmptyObjects(source);
+            assertThat(source, equalTo(Map.of("message", "hello")));
+        }
+
+        {   // container with a surviving sibling is kept; only the empty child is removed
+            Map<String, Object> inner = new HashMap<>(Map.of("b", new HashMap<>(), "c", 1));
+            Map<String, Object> source = new HashMap<>(Map.of("a", inner));
+            IngestService.removeEmptyObjects(source);
+            assertThat(source, equalTo(Map.of("a", Map.of("c", 1))));
+        }
+
+        {   // lists are not modified (removing elements would change array semantics)
+            List<Object> list = new ArrayList<>(List.of(new HashMap<>(), "item"));
+            Map<String, Object> source = new HashMap<>(Map.of("arr", list));
+            IngestService.removeEmptyObjects(source);
+            assertThat(source.get("arr"), equalTo(List.of(new HashMap<>(), "item")));
+        }
+
+        {   // null values are left untouched (only empty Maps are removed)
+            Map<String, Object> source = new HashMap<>();
+            source.put("nullField", null);
+            source.put("kept", "value");
+            IngestService.removeEmptyObjects(source);
+            assertThat(source.size(), equalTo(2));
+            assertThat(source.get("nullField"), nullValue());
+            assertThat(source.get("kept"), equalTo("value"));
+        }
+
+        {   // already-empty source map stays empty
+            Map<String, Object> source = new HashMap<>();
+            IngestService.removeEmptyObjects(source);
+            assertThat(source.isEmpty(), equalTo(true));
+        }
+    }
+
+    public void testIsStrictColumnarTarget() {
+        {   // null index name → false
+            IndexRequest indexRequest = new IndexRequest((String) null);
+            assertFalse(IngestService.isStrictColumnarTarget(indexRequest, ProjectMetadata.builder(randomUniqueProjectId()).build()));
+        }
+
+        {   // plain concrete index with STANDARD mode → false
+            IndexMetadata indexMetadata = IndexMetadata.builder("idx")
+                .settings(settings(IndexVersion.current()))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .build();
+            ProjectMetadata project = ProjectMetadata.builder(randomUniqueProjectId()).put(indexMetadata, false).build();
+            assertFalse(IngestService.isStrictColumnarTarget(new IndexRequest("idx"), project));
+        }
+
+        {   // concrete index with LOGSDB_COLUMNAR mode → true
+            var backingIndex = ".ds-logs-01";
+            var indexUUID = randomUUID();
+            IndexMetadata indexMetadata = IndexMetadata.builder(backingIndex)
+                .settings(
+                    settings(IndexVersion.current()).put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB_COLUMNAR)
+                        .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
+                        .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID)
+                )
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .build();
+            ProjectMetadata project = ProjectMetadata.builder(randomUniqueProjectId()).put(indexMetadata, false).build();
+            assertTrue(IngestService.isStrictColumnarTarget(new IndexRequest(backingIndex), project));
+        }
+
+        {   // data stream with LOGSDB_COLUMNAR write index → true
+            var backingIndex = ".ds-logs-columnar-01";
+            var indexUUID = randomUUID();
+            IndexMetadata writeIndexMeta = IndexMetadata.builder(backingIndex)
+                .settings(
+                    settings(IndexVersion.current()).put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB_COLUMNAR)
+                        .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
+                        .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID)
+                )
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .build();
+            var dataStream = DataStream.builder(
+                "logs-columnar",
+                DataStream.DataStreamIndices.backingIndicesBuilder(List.of(new Index(backingIndex, indexUUID))).build()
+            ).build();
+            ProjectMetadata project = ProjectMetadata.builder(randomUniqueProjectId()).put(writeIndexMeta, false).put(dataStream).build();
+            assertTrue(IngestService.isStrictColumnarTarget(new IndexRequest("logs-columnar"), project));
+        }
+
+        {   // data stream with STANDARD write index → false
+            var backingIndex = ".ds-logs-standard-01";
+            var indexUUID = randomUUID();
+            IndexMetadata writeIndexMeta = IndexMetadata.builder(backingIndex)
+                .settings(settings(IndexVersion.current()).put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .build();
+            var dataStream = DataStream.builder(
+                "logs-standard",
+                DataStream.DataStreamIndices.backingIndicesBuilder(List.of(new Index(backingIndex, indexUUID))).build()
+            ).build();
+            ProjectMetadata project = ProjectMetadata.builder(randomUniqueProjectId()).put(writeIndexMeta, false).put(dataStream).build();
+            assertFalse(IngestService.isStrictColumnarTarget(new IndexRequest("logs-standard"), project));
+        }
+
+        {   // index not in project (no matching template) → false
+            ProjectMetadata project = ProjectMetadata.builder(randomUniqueProjectId()).build();
+            assertFalse(IngestService.isStrictColumnarTarget(new IndexRequest("nonexistent"), project));
         }
     }
 


### PR DESCRIPTION
Ingest pipelines can leave behind empty container objects after groking a nested field's children and then renaming or removing all of them. For example, `logs-system.syslog-1.6.4` groks `system.syslog.timestamp` and `system.syslog.message`, renames `.message` away, and removes `.timestamp`, leaving `system.syslog: {}` in the document. Five of the fifteen pipelines in the elastic-logs rally track do this.

`EscfEncoder` encodes an empty object as a zero-byte `KEY_VALUE` leaf column ("so it stays distinguishable from an absent field"). `ShardBatchMapper` then sees that leaf, finds no mapper for it, resolves the parent dynamic to `TRUE`, and aborts the entire shard bulk to the sequential path — permanently, on every request, because the mapping never converges for an always-empty field. This caused 2,009 spurious disable events per ~4.5-minute rally run, 97% of which came from exactly those three pipeline-leaked paths.

The fix is narrow by design: after all ingest pipelines complete, trim any empty `Map` values from the document source, recursively bottom-up, but only when the target index is in a strict-columnar index mode (`IndexMode.isStrictColumnar()`). This is safe because in strict-columnar mode an unmapped empty object produces no mapper, no column, and nothing in `_source` — `DocumentParser` finds no children for it and captures nothing to ignored source — regardless of whether the index stores source or synthesises it.

The pruning is bottom-up so that `{"system":{"syslog":{}}}` prunes `syslog` first, then `system` in the same pass. Lists are not modified: removing elements from an array is not equivalent to the field being absent.

Index-mode resolution prefers the write index's `IndexMetadata` over the `DataStream`-level field (which can lag), falls back to a concrete-index lookup, and then to V2 template settings for not-yet-created indices. V1 templates pre-date strict-columnar modes and are skipped.

Validated against a second rally run: the `unmapped leaf [{}] under dynamic=TRUE` category dropped from 2,009 to 0.