### PR TITLE
[9.4] [CI] Honor JAVA_HOME when launching GradleRunner (#159055)

### DIFF
--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -62,7 +62,9 @@ GRADLEW_ARGS="${GRADLEW#./gradlew }"
 
 echo "--- Running gradle tasks"
 
-if command -v java > /dev/null; then
+if [[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/java" ]]; then
+  "$JAVA_HOME/bin/java" -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
+elif command -v java > /dev/null; then
   java -jar "$RUNNER_JAR" -- $GRADLEW_ARGS -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"
 else
   "$GRADLEW" -S --max-workers=$MAX_WORKERS $TESTS_SEED_PARAM ${EXTRA_GRADLE_ARGS:-} "$@"


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [CI] Honor JAVA_HOME when launching GradleRunner (#159055)