### PR TITLE
[8.19] Bound find_structure concurrency to allocated processors (#158935)

### DIFF
--- a/docs/changelog/158935.yaml
+++ b/docs/changelog/158935.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: [158927]
+pr: 158935
+summary: Limit concurrent text structure analyses to the allocated processor count
+type: bug

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/TextStructurePlugin.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/TextStructurePlugin.java
@@ -29,12 +29,14 @@ import org.elasticsearch.xpack.textstructure.rest.RestFindFieldStructureAction;
 import org.elasticsearch.xpack.textstructure.rest.RestFindMessageStructureAction;
 import org.elasticsearch.xpack.textstructure.rest.RestFindStructureAction;
 import org.elasticsearch.xpack.textstructure.rest.RestTestGrokPatternAction;
+import org.elasticsearch.xpack.textstructure.transport.TextStructExecutor;
 import org.elasticsearch.xpack.textstructure.transport.TransportFindFieldStructureAction;
 import org.elasticsearch.xpack.textstructure.transport.TransportFindMessageStructureAction;
 import org.elasticsearch.xpack.textstructure.transport.TransportFindStructureAction;
 import org.elasticsearch.xpack.textstructure.transport.TransportTestGrokPatternAction;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -46,6 +48,13 @@ import java.util.function.Supplier;
 public class TextStructurePlugin extends Plugin implements ActionPlugin {
 
     public static final String BASE_PATH = "/_text_structure/";
+
+    @Override
+    public Collection<?> createComponents(PluginServices services) {
+        // One runner for every find_*structure action. Guice is unscoped, so an @Inject
+        // constructor would mint a runner per transport action and double the processor cap.
+        return List.of(new TextStructExecutor(services.threadPool(), services.environment().settings()));
+    }
 
     @Override
     public List<RestHandler> getRestHandlers(

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
@@ -599,7 +599,27 @@ public final class TextStructureUtils {
      */
     static boolean isMoreLikelyTextThanKeyword(String str) {
         int length = str.length();
-        return length > KEYWORD_MAX_LEN || length - str.replaceAll("\\s", "").length() > KEYWORD_MAX_SPACES;
+        if (length > KEYWORD_MAX_LEN) {
+            return true;
+        }
+        int whitespaceCount = 0;
+        for (int i = 0; i < length; i++) {
+            if (isJavaRegexWhitespace(str.charAt(i))) {
+                whitespaceCount++;
+                if (whitespaceCount > KEYWORD_MAX_SPACES) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Matches {@code java.util.regex.Pattern} {@code \s}: space, tab, LF, vertical tab, form feed, CR.
+     * This is not the same character set as {@link Character#isWhitespace(char)}.
+     */
+    private static boolean isJavaRegexWhitespace(char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\u000B' || c == '\f' || c == '\r';
     }
 
     /**

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutor.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutor.java
@@ -8,25 +8,34 @@
 package org.elasticsearch.xpack.textstructure.transport;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.common.CheckedSupplier;
-import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThrottledTaskRunner;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.concurrent.ExecutorService;
 
 import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
+import static org.elasticsearch.common.util.concurrent.EsExecutors.allocatedProcessors;
 
 /**
  * workaround for https://github.com/elastic/elasticsearch/issues/97916
  * TODO delete this entire class when we can
  */
 public class TextStructExecutor {
-    private final ThreadPool threadPool;
+    private final ThrottledTaskRunner analysisRunner;
 
-    @Inject
-    public TextStructExecutor(ThreadPool threadPool) {
-        this.threadPool = threadPool;
+    public TextStructExecutor(ThreadPool threadPool, Settings settings) {
+        this.analysisRunner = new ThrottledTaskRunner("find_structure", maxConcurrentAnalyses(settings), threadPool.generic());
+    }
+
+    /**
+     * Structure analysis is CPU-bound and single-threaded per request, holding its whole expanded sample on
+     * the heap for the duration. Admitting more analyses than there are processors therefore buys no
+     * throughput and multiplies peak heap by the number of extra requests.
+     */
+    private static int maxConcurrentAnalyses(Settings settings) {
+        return allocatedProcessors(settings);
     }
 
     /**
@@ -42,6 +51,10 @@ public class TextStructExecutor {
      * {@link ActionListener#completeWith(ActionListener, CheckedSupplier)}.
      */
     <T> void execute(ActionListener<T> listener, CheckedSupplier<T, Exception> supplier) {
-        threadPool.generic().execute(ActionRunnable.supply(listener, supplier));
+        analysisRunner.enqueueTask(ActionListener.wrap(releasable -> {
+            try (releasable) {
+                ActionListener.completeWith(listener, supplier);
+            }
+        }, listener::onFailure));
     }
 }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindFieldStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindFieldStructureAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.textstructure.transport;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -39,18 +38,27 @@ public class TransportFindFieldStructureAction extends HandledTransportAction<Fi
     private final Client client;
     private final TransportService transportService;
     private final ThreadPool threadPool;
+    private final TextStructExecutor executor;
 
     @Inject
     public TransportFindFieldStructureAction(
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        TextStructExecutor executor
     ) {
-        super(FindFieldStructureAction.NAME, transportService, actionFilters, FindFieldStructureAction.Request::new, threadPool.generic());
+        super(
+            FindFieldStructureAction.NAME,
+            transportService,
+            actionFilters,
+            FindFieldStructureAction.Request::new,
+            executor.handledTransportActionExecutorService()
+        );
         this.client = client;
         this.transportService = transportService;
         this.threadPool = threadPool;
+        this.executor = executor;
     }
 
     @Override
@@ -70,8 +78,8 @@ public class TransportFindFieldStructureAction extends HandledTransportAction<Fi
                     return;
                 }
                 var messages = getMessages(searchResponse, request.getField());
-                // As matching a regular expression might take a while, we run in a different thread to avoid blocking the network thread.
-                threadPool.generic().execute(ActionRunnable.supply(delegate, () -> buildTextStructureResponse(messages, request)));
+                // Analysis is CPU-bound and holds the expanded sample on heap; enqueue on the shared throttle.
+                executor.execute(delegate, () -> buildTextStructureResponse(messages, request));
             }));
     }
 

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/TextStructurePluginTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/TextStructurePluginTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.textstructure;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.xpack.textstructure.transport.TextStructExecutor;
+
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TextStructurePluginTests extends ESTestCase {
+
+    public void testCreateComponentsShouldPublishSingleSharedExecutor() {
+        Settings settings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 2.0).build();
+        Environment environment = mock(Environment.class);
+        when(environment.settings()).thenReturn(settings);
+        Plugin.PluginServices services = mock(Plugin.PluginServices.class);
+        when(services.environment()).thenReturn(environment);
+
+        try (TestThreadPool threadPool = new TestThreadPool(getTestName(), settings)) {
+            when(services.threadPool()).thenReturn(threadPool);
+            Collection<?> components = new TextStructurePlugin().createComponents(services);
+            assertThat(components, contains(instanceOf(TextStructExecutor.class)));
+        }
+    }
+}

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtilsTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtilsTests.java
@@ -40,6 +40,33 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         assertFalse(TextStructureUtils.isMoreLikelyTextThanKeyword(randomAlphaOfLengthBetween(1, 256)));
     }
 
+    public void testValuesContainingRegexWhitespaceShouldMatchPreviousReplaceAllBehaviour() {
+        char[] regexWhitespace = { ' ', '\t', '\n', '\u000B', '\f', '\r' };
+        char[] nearMissWhitespace = { '\u00A0', '\u2003', '\u001C', '\u001D', '\u001E', '\u001F' };
+        char[] regular = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+
+        for (int i = 0; i < 1000; i++) {
+            String str = randomStringFromPools(regexWhitespace, nearMissWhitespace, regular);
+            assertEquals(referenceIsMoreLikelyTextThanKeyword(str), TextStructureUtils.isMoreLikelyTextThanKeyword(str));
+        }
+    }
+
+    private static String randomStringFromPools(char[] regexWhitespace, char[] nearMissWhitespace, char[] regular) {
+        int length = randomIntBetween(0, 300);
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            int pool = randomInt(2);
+            char[] chosen = pool == 0 ? regexWhitespace : pool == 1 ? nearMissWhitespace : regular;
+            builder.append(chosen[randomInt(chosen.length - 1)]);
+        }
+        return builder.toString();
+    }
+
+    private static boolean referenceIsMoreLikelyTextThanKeyword(String str) {
+        int length = str.length();
+        return length > 256 || length - str.replaceAll("\\s", "").length() > 5;
+    }
+
     public void testGuessTimestampGivenSingleSampleSingleField() {
         Map<String, String> sample = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
         Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutorTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutorTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.textstructure.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class TextStructExecutorTests extends ESTestCase {
+
+    public void testMoreRequestsThanProcessorsShouldRunAtMostProcessorCountConcurrently() throws Exception {
+        Settings settings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 2.0).build();
+        try (TestThreadPool threadPool = new TestThreadPool(getTestName(), settings)) {
+            TextStructExecutor executor = new TextStructExecutor(threadPool, settings);
+            int numTasks = 5;
+            CountDownLatch blockLatch = new CountDownLatch(1);
+            CountDownLatch completeLatch = new CountDownLatch(numTasks);
+            AtomicInteger running = new AtomicInteger();
+            AtomicInteger peak = new AtomicInteger();
+
+            for (int i = 0; i < numTasks; i++) {
+                executor.execute(ActionListener.wrap(r -> completeLatch.countDown(), e -> fail(e)), () -> {
+                    int current = running.incrementAndGet();
+                    peak.getAndUpdate(p -> Math.max(p, current));
+                    try {
+                        blockLatch.await();
+                        return null;
+                    } finally {
+                        running.decrementAndGet();
+                    }
+                });
+            }
+
+            assertBusy(() -> assertThat(peak.get(), greaterThan(0)));
+            assertThat(peak.get(), lessThanOrEqualTo(2));
+            blockLatch.countDown();
+            assertTrue(completeLatch.await(10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testSupplierThrowingShouldReleaseSlotAndFailListener() {
+        Settings settings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 1.0).build();
+        try (TestThreadPool threadPool = new TestThreadPool(getTestName(), settings)) {
+            TextStructExecutor executor = new TextStructExecutor(threadPool, settings);
+
+            PlainActionFuture<Void> failed = new PlainActionFuture<>();
+            executor.execute(failed, () -> { throw new RuntimeException("boom"); });
+            expectThrows(RuntimeException.class, failed::actionGet);
+
+            PlainActionFuture<String> succeeded = new PlainActionFuture<>();
+            executor.execute(succeeded, () -> "ok");
+            assertEquals("ok", succeeded.actionGet());
+        }
+    }
+
+    public void testAllRequestsShouldEventuallyComplete() throws Exception {
+        Settings settings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 1.0).build();
+        try (TestThreadPool threadPool = new TestThreadPool(getTestName(), settings)) {
+            TextStructExecutor executor = new TextStructExecutor(threadPool, settings);
+            int numTasks = 10;
+            CountDownLatch completeLatch = new CountDownLatch(numTasks);
+            AtomicInteger completed = new AtomicInteger();
+
+            for (int i = 0; i < numTasks; i++) {
+                final int taskId = i;
+                executor.execute(ActionListener.wrap(r -> {
+                    assertThat(completed.incrementAndGet(), equalTo(taskId + 1));
+                    completeLatch.countDown();
+                }, e -> fail(e)), () -> taskId);
+            }
+
+            assertTrue(completeLatch.await(10, TimeUnit.SECONDS));
+            assertThat(completed.get(), equalTo(numTasks));
+        }
+    }
+
+    public void testTwoActionTypesSharingExecutorShouldNotExceedProcessorCap() throws Exception {
+        Settings settings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 2.0).build();
+        try (TestThreadPool threadPool = new TestThreadPool(getTestName(), settings)) {
+            TextStructExecutor shared = new TextStructExecutor(threadPool, settings);
+            int tasksPerAction = 4;
+            CountDownLatch blockLatch = new CountDownLatch(1);
+            CountDownLatch completeLatch = new CountDownLatch(tasksPerAction * 2);
+            AtomicInteger running = new AtomicInteger();
+            AtomicInteger peak = new AtomicInteger();
+
+            Runnable enqueueBurst = () -> {
+                for (int i = 0; i < tasksPerAction; i++) {
+                    shared.execute(ActionTestUtils.assertNoFailureListener(r -> completeLatch.countDown()), () -> {
+                        int current = running.incrementAndGet();
+                        peak.getAndUpdate(p -> Math.max(p, current));
+                        try {
+                            blockLatch.await();
+                            return null;
+                        } finally {
+                            running.decrementAndGet();
+                        }
+                    });
+                }
+            };
+            enqueueBurst.run();
+            enqueueBurst.run();
+
+            assertBusy(() -> assertThat(peak.get(), greaterThan(0)));
+            assertThat(peak.get(), lessThanOrEqualTo(2));
+            blockLatch.countDown();
+            assertTrue(completeLatch.await(10, TimeUnit.SECONDS));
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Bound find_structure concurrency to allocated processors (#158935)