### PR TITLE
[9.4] Fix flaky MlJobIT shared index green health check (#158690)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
@@ -82,6 +82,8 @@ public class MlJobIT extends ESRestTestCase {
             ).equals(warnings) == false
         )
         .build();
+    private static final String SHARED_RESULTS_FIRST_INDEX = AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX
+        + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT + MlIndexAndAlias.FIRST_INDEX_SIX_DIGIT_SUFFIX;
 
     @Override
     protected Settings restClientSettings() {
@@ -99,8 +101,7 @@ public class MlJobIT extends ESRestTestCase {
         assertThat(responseAsString, containsString("\"job_id\":\"given-farequote-config-job\""));
         assertThat(responseAsString, containsString("\"results_index_name\":\"shared\""));
 
-        String mlIndicesResponseAsString = getMlResultsIndices();
-        assertThat(mlIndicesResponseAsString, containsString("green open .ml-anomalies-shared-000001"));
+        ensureGreen(SHARED_RESULTS_FIRST_INDEX);
 
         String aliasesResponseAsString = getAliases();
         LogManager.getLogger(MlRestTestStateCleaner.class).warn(aliasesResponseAsString);
@@ -541,13 +542,7 @@ public class MlJobIT extends ESRestTestCase {
 
         putJob(jobId1, Strings.format(jobTemplate, byFieldName1));
 
-        String mlIndicesResponseAsString = getMlResultsIndices();
-        assertThat(
-            mlIndicesResponseAsString,
-            containsString(
-                "green open " + AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT
-            )
-        );
+        ensureGreen(SHARED_RESULTS_FIRST_INDEX);
 
         // Check the index mapping contains the first by_field_name
         Request getResultsMappingRequest = new Request(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix flaky MlJobIT shared index green health check (#158690)](https://github.com/elastic/elasticsearch/pull/158690)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)