### PR TITLE
[8.19] [ML] Add transient-404 retry primitive for rolling-upgrade ML REST tests (#154791)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -121,6 +121,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -1888,6 +1889,33 @@ public abstract class ESRestTestCase extends ESTestCase {
                 request.addParameter("timeout", timeout);
             }
         });
+    }
+
+    /**
+     * Performs {@code request} once, translating a {@link ResponseException} whose HTTP status is one of
+     * {@code retryableStatuses} into an {@link AssertionError}. Wrap the call in {@link #assertBusy} at the
+     * call site so the enclosing loop retries transient failures (e.g. a 404 while an index relocates during
+     * a rolling upgrade); capture the result via an {@link AtomicReference} if the response is needed outside
+     * the loop. Non-retryable ResponseExceptions propagate unchanged.
+     */
+    protected Response performRequestRaisingAssertionOnTransientStatus(Request request, RestStatus... retryableStatuses)
+        throws IOException {
+        try {
+            return client().performRequest(request);
+        } catch (ResponseException e) {
+            int status = e.getResponse().getStatusLine().getStatusCode();
+            if (isRetryableStatus(status, retryableStatuses)) {
+                throw new AssertionError(
+                    "retryable status [" + status + "] from [" + request.getMethod() + " " + request.getEndpoint() + "]",
+                    e
+                );
+            }
+            throw e;
+        }
+    }
+
+    static boolean isRetryableStatus(int status, RestStatus... retryableStatuses) {
+        return Arrays.stream(retryableStatuses).anyMatch(s -> s.getStatus() == status);
     }
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/ESRestTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/ESRestTestCaseTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.test.rest;
 
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.regex.Matcher;
@@ -34,6 +35,33 @@ public class ESRestTestCaseTests extends ESTestCase {
         assertThat(matcher.group(3), equalTo("global"));
         assertThat(matcher.group(4), equalTo("global => [*]"));
         assertThat(matcher.group(5), equalTo("1"));
+    }
+
+    public void testListedTransientStatusShouldBeRetryable() {
+        assertThat(ESRestTestCase.isRetryableStatus(RestStatus.NOT_FOUND.getStatus(), RestStatus.NOT_FOUND), is(true));
+        assertThat(
+            ESRestTestCase.isRetryableStatus(
+                RestStatus.SERVICE_UNAVAILABLE.getStatus(),
+                RestStatus.NOT_FOUND,
+                RestStatus.SERVICE_UNAVAILABLE
+            ),
+            is(true)
+        );
+    }
+
+    public void testUnlistedStatusShouldNotBeRetryable() {
+        assertThat(
+            ESRestTestCase.isRetryableStatus(
+                RestStatus.INTERNAL_SERVER_ERROR.getStatus(),
+                RestStatus.NOT_FOUND,
+                RestStatus.SERVICE_UNAVAILABLE
+            ),
+            is(false)
+        );
+    }
+
+    public void testEmptyRetryableSetShouldNotBeRetryable() {
+        assertThat(ESRestTestCase.isRetryableStatus(RestStatus.NOT_FOUND.getStatus()), is(false));
     }
 
 }

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus;
 import org.junit.Before;
@@ -123,12 +124,9 @@ public class MLModelDeploymentFullClusterRestartIT extends MlFullClusterRestartT
     @SuppressWarnings("unchecked")
     private void waitForDeploymentStarted(String modelId) throws Exception {
         assertBusy(() -> {
-            Response response;
-            try {
-                response = getTrainedModelStats(modelId);
-            } catch (ResponseException e) {
-                throw new AssertionError("Model stats not available yet", e);
-            }
+            Request request = new Request("GET", "/_ml/trained_models/" + modelId + "/_stats");
+            // Transient 404/503 while ML indices relocate or the plugin is still recovering after restart.
+            var response = performRequestRaisingAssertionOnTransientStatus(request, RestStatus.NOT_FOUND, RestStatus.SERVICE_UNAVAILABLE);
             Map<String, Object> map = entityAsMap(response);
             List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
             assertThat(stats, hasSize(1));
@@ -210,13 +208,6 @@ public class MLModelDeploymentFullClusterRestartIT extends MlFullClusterRestartT
         String endpoint = "/_ml/trained_models/" + modelId + "/deployment/_stop";
         Request request = new Request("POST", endpoint);
         client().performRequest(request);
-    }
-
-    private Response getTrainedModelStats(String modelId) throws IOException {
-        Request request = new Request("GET", "/_ml/trained_models/" + modelId + "/_stats");
-        var response = client().performRequest(request);
-        assertOK(response);
-        return response;
     }
 
     private Response infer(String input, String modelId) throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.junit.After;
 import org.junit.Before;
@@ -282,9 +283,8 @@ public class MLModelDeploymentsUpgradeIT extends AbstractXpackRollingUpgradeTest
 
     private Response getTrainedModelStats(String modelId) throws IOException {
         Request request = new Request("GET", "/_ml/trained_models/" + modelId + "/_stats");
-        var response = client().performRequest(request);
-        assertOK(response);
-        return response;
+        // Transient 404/503 while ML indices relocate or the plugin is still recovering during upgrade.
+        return performRequestRaisingAssertionOnTransientStatus(request, RestStatus.NOT_FOUND, RestStatus.SERVICE_UNAVAILABLE);
     }
 
     private Response infer(String input, String modelId) throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 import org.junit.ClassRule;
@@ -28,6 +29,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.client.WarningsHandler.PERMISSIVE;
@@ -191,12 +193,27 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractXpackRollingUpgradeTes
         assertThat(stat.toString(), actualMemoryUsage.toString(), equalTo(expectedMemoryUsage.toString()));
     }
 
-    private Response getTrainedModelStats(String modelId) throws IOException {
+    private Request trainedModelStatsRequest(String modelId) {
         Request request = new Request("GET", "/_ml/trained_models/" + modelId + "/_stats");
         request.setOptions(request.getOptions().toBuilder().setWarningsHandler(PERMISSIVE).build());
-        var response = client().performRequest(request);
-        assertOK(response);
-        return response;
+        return request;
+    }
+
+    private Response getTrainedModelStats(String modelId) throws Exception {
+        // Transient 404/503 while ML indices relocate or the plugin is still recovering during upgrade.
+        var responseHolder = new AtomicReference<Response>();
+        assertBusy(
+            () -> responseHolder.set(
+                performRequestRaisingAssertionOnTransientStatus(
+                    trainedModelStatsRequest(modelId),
+                    RestStatus.NOT_FOUND,
+                    RestStatus.SERVICE_UNAVAILABLE
+                )
+            ),
+            30,
+            TimeUnit.SECONDS
+        );
+        return responseHolder.get();
     }
 
     private Response infer(String input, String modelId) throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
@@ -31,6 +32,7 @@ import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
 import static org.hamcrest.Matchers.anyOf;
@@ -130,6 +132,22 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
+    /**
+     * Opens the test job if it was closed during rolling upgrade so results write aliases exist.
+     * The job must already exist from the {@code OLD} cluster phase.
+     */
+    private void ensureTestJobIsOpen() throws IOException {
+        Request getJob = new Request("GET", "_ml/anomaly_detectors/" + JOB_ID);
+        Response response = performRequestRaisingAssertionOnTransientStatus(getJob, RestStatus.NOT_FOUND);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> jobs = (List<Map<String, Object>>) entityAsMap(response).get("jobs");
+        assertThat(jobs, hasSize(1));
+        if ("closed".equals(jobs.get(0).get("state"))) {
+            openTestJob();
+        }
+    }
+
     // Doing this should force the config index mappings to be upgraded,
     // when the finished time is cleared on reopening the job
     private void closeAndReopenTestJob() throws IOException {
@@ -148,7 +166,11 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
         assertBusy(() -> {
             Request getMappings = new Request("GET", XPackRestTestHelper.resultsWriteAlias(JOB_ID) + "/_mappings");
-            Response response = client().performRequest(getMappings);
+            Response response = performRequestRaisingAssertionOnTransientStatus(
+                getMappings,
+                RestStatus.NOT_FOUND,
+                RestStatus.SERVICE_UNAVAILABLE
+            );
 
             Map<String, Object> responseLevel = entityAsMap(response);
             assertNotNull(responseLevel);
@@ -176,7 +198,7 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
                 "long",
                 extractValue("mappings.properties.model_size_stats.properties.peak_model_bytes.type", indexLevel)
             );
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     @SuppressWarnings("unchecked")
@@ -184,7 +206,11 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
         assertBusy(() -> {
             Request getMappings = new Request("GET", ".ml-annotations-write/_mappings");
-            Response response = client().performRequest(getMappings);
+            Response response = performRequestRaisingAssertionOnTransientStatus(
+                getMappings,
+                RestStatus.NOT_FOUND,
+                RestStatus.SERVICE_UNAVAILABLE
+            );
 
             Map<String, Object> responseLevel = entityAsMap(response);
             assertNotNull(responseLevel);
@@ -213,7 +239,7 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
                 "keyword",
                 extractValue("mappings.properties.event.type", indexLevel)
             );
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     private void assertMlLegacyTemplatesDeleted() throws Exception {
@@ -250,7 +276,11 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
                         + "version, direct access to system indices will be prevented by default"
                 )
             );
-            Response response = client().performRequest(getMappings);
+            Response response = performRequestRaisingAssertionOnTransientStatus(
+                getMappings,
+                RestStatus.NOT_FOUND,
+                RestStatus.SERVICE_UNAVAILABLE
+            );
 
             Map<String, Object> responseLevel = entityAsMap(response);
             assertNotNull(responseLevel);
@@ -269,7 +299,7 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
                 "boolean",
                 extractValue("mappings.properties.model_plot_config.properties.annotations_enabled.type", indexLevel)
             );
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     @SuppressWarnings("unchecked")
@@ -380,7 +410,11 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
     private void assertNotificationsIndexAliasCreated() throws Exception {
         assertBusy(() -> {
             Request getMappings = new Request("GET", "_alias/.ml-notifications-write");
-            Response response = client().performRequest(getMappings);
+            Response response = performRequestRaisingAssertionOnTransientStatus(
+                getMappings,
+                RestStatus.NOT_FOUND,
+                RestStatus.SERVICE_UNAVAILABLE
+            );
             Map<String, Object> responseMap = entityAsMap(response);
             assertThat(responseMap.entrySet(), hasSize(1));
             var aliases = (Map<String, Object>) responseMap.get(".ml-notifications-000002");
@@ -391,6 +425,6 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
             assertThat(writeAlias, hasEntry("is_hidden", Boolean.TRUE));
             var isWriteIndex = (Boolean) writeAlias.get("is_write_index");
             assertThat(isWriteIndex, anyOf(is(Boolean.TRUE), nullValue()));
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Add transient-404 retry primitive for rolling-upgrade ML REST tests (#154791)](https://github.com/elastic/elasticsearch/pull/154791)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)