### PR TITLE
Fix interrupt deadlock in `CancellableRateLimitedFluxIterator`

### DIFF
--- a/docs/changelog/158936.yaml
+++ b/docs/changelog/158936.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 158936
+summary: Fix interrupt deadlock in `CancellableRateLimitedFluxIterator`
+type: bug

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
@@ -101,7 +101,9 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
                     condition.await();
                 }
             } catch (InterruptedException e) {
-                cancelSubscription();
+                error = e;
+                cancel();
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             } finally {
                 lock.unlock();

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIteratorTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIteratorTests.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class CancellableRateLimitedFluxIteratorTests extends ESTestCase {
@@ -247,6 +248,42 @@ public class CancellableRateLimitedFluxIteratorTests extends ESTestCase {
         assertBusy(() -> expectThrows(RuntimeException.class, iterator::hasNext));
         assertBusy(() -> assertThat(cleanedElements, equalTo(Set.of(3))));
         assertThat(iterator.getQueue(), is(empty()));
+    }
+
+    public void testInterruption() throws Exception {
+        final var cancelled = new AtomicBoolean();
+        final Publisher<Integer> publisher = s -> s.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {}
+
+            @Override
+            public void cancel() {
+                cancelled.set(true);
+            }
+        });
+
+        final var iterator = new CancellableRateLimitedFluxIterator<Integer>(between(1, 10), unused -> {});
+        publisher.subscribe(iterator);
+
+        final var consumer = new Thread(() -> {
+            assertThat(expectThrows(RuntimeException.class, iterator::hasNext).getCause(), instanceOf(InterruptedException.class));
+            assertTrue(Thread.currentThread().isInterrupted());
+        });
+        consumer.start();
+        try {
+            if (randomBoolean()) {
+                // Sometimes wait for the consumer to be parked in Condition#await
+                assertBusy(() -> assertThat(consumer.getState(), equalTo(Thread.State.WAITING)));
+            }
+        } finally {
+            consumer.interrupt();
+            safeJoin(consumer);
+        }
+        assertTrue(cancelled.get());
+        assertThat(iterator.getQueue(), is(empty()));
+
+        // Subsequent hasNext() must fail immediately even on a thread that is not interrupted.
+        assertThat(expectThrows(RuntimeException.class, iterator::hasNext).getCause(), instanceOf(InterruptedException.class));
     }
 
     public void runOnNewThread(Runnable runnable) {


### PR DESCRIPTION
Today an interrupt on the Azure read path cancels the subscription and
throws an exception but does not mark the iterator as done, nor does it
reinstate the thread's interrupt flag. Some callers may call `hasNext()`
again after an exception from a previous call, and these later calls
will be swallowed by the no-op `CANCELLED_SUBSCRIPTION`, causing them to
block indefinitely, since the thread's interrupt flag is cleared.

This commit fixes the interrupt handling in this area.

Backport of #158936 to 8.19