### PR TITLE
[8.19] [ML] Extend reindexed AD results template and generalize heal beyond job_id (#153755)

### DIFF
--- a/docs/changelog/153755.yaml
+++ b/docs/changelog/153755.yaml
@@ -1,0 +1,6 @@
+area: Machine Learning
+issues:
+  - 147686
+pr: 153755
+summary: Extend AD results template for reindexed indices and generalize heal beyond job_id mapping
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -549,20 +549,50 @@ public final class MlIndexAndAlias {
      * @param expectedType  The expected Elasticsearch field type string (e.g. {@code "keyword"}).
      * @return              {@code true} iff the field exists and has the expected type.
      */
-    @SuppressWarnings("unchecked")
     public static boolean hasFieldTypedAs(IndexMetadata indexMetadata, String fieldName, String expectedType) {
-        if (indexMetadata == null || indexMetadata.mapping() == null) {
+        return hasFieldTypedAs(indexMetadata, List.of(fieldName), expectedType);
+    }
+
+    /**
+     * Returns {@code true} if the mapping of {@code indexMetadata} contains a field at
+     * {@code fieldPath} whose {@code "type"} attribute equals {@code expectedType}.
+     * <p>
+     * Each path segment except the last is resolved through a {@code properties} block
+     * (e.g. {@code List.of("anomaly_score_explanation", "by_field_relative_rarity")}).
+     * Returns {@code false} for absent metadata, missing mappings, missing intermediate
+     * {@code properties} blocks, missing field, or non-matching type.
+     *
+     * @param indexMetadata The index metadata to inspect. May be {@code null}.
+     * @param fieldPath     Dot-path segments from the top-level {@code properties} block.
+     * @param expectedType  The expected Elasticsearch field type string (e.g. {@code "double"}).
+     * @return              {@code true} iff the field exists and has the expected type.
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean hasFieldTypedAs(IndexMetadata indexMetadata, List<String> fieldPath, String expectedType) {
+        if (indexMetadata == null || indexMetadata.mapping() == null || fieldPath.isEmpty()) {
             return false;
         }
-        var rawProperties = indexMetadata.mapping().sourceAsMap().get("properties");
-        if (rawProperties instanceof Map<?, ?> == false) {
+        Object current = indexMetadata.mapping().sourceAsMap().get("properties");
+        if (current instanceof Map<?, ?> == false) {
             return false;
         }
-        var rawField = ((Map<String, Object>) rawProperties).get(fieldName);
-        if (rawField instanceof Map<?, ?> == false) {
-            return false;
+        Map<String, Object> properties = (Map<String, Object>) current;
+        for (int i = 0; i < fieldPath.size(); i++) {
+            Object rawField = properties.get(fieldPath.get(i));
+            if (rawField instanceof Map<?, ?> == false) {
+                return false;
+            }
+            Map<String, Object> field = (Map<String, Object>) rawField;
+            if (i == fieldPath.size() - 1) {
+                return expectedType.equals(field.get("type"));
+            }
+            Object nestedProperties = field.get("properties");
+            if (nestedProperties instanceof Map<?, ?> == false) {
+                return false;
+            }
+            properties = (Map<String, Object>) nestedProperties;
         }
-        return expectedType.equals(((Map<String, Object>) rawField).get("type"));
+        return false;
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -447,4 +447,25 @@ public class MlIndexAndAliasTests extends ESTestCase {
         }
         return builder.build();
     }
+
+    public void testHasFieldTypedAs_NestedPathMatchesExpectedType() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index")
+            .settings(indexSettings(IndexVersion.current(), 1, 0))
+            .putMapping(healthyResultsMappingForMlIndexAndAliasTests())
+            .build();
+
+        assertTrue(
+            MlIndexAndAlias.hasFieldTypedAs(indexMetadata, List.of("anomaly_score_explanation", "by_field_relative_rarity"), "double")
+        );
+        assertFalse(
+            MlIndexAndAlias.hasFieldTypedAs(indexMetadata, List.of("anomaly_score_explanation", "by_field_relative_rarity"), "float")
+        );
+        assertFalse(MlIndexAndAlias.hasFieldTypedAs(indexMetadata, List.of("anomaly_score_explanation", "missing_field"), "double"));
+    }
+
+    private static String healthyResultsMappingForMlIndexAndAliasTests() {
+        return """
+            {"properties":{"job_id":{"type":"keyword"},"anomaly_score_explanation":{"properties":{\
+            "by_field_relative_rarity":{"type":"double"}}}}}""";
+    }
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
@@ -2,7 +2,7 @@
   "priority": 2147483647,
   "version" : ${xpack.ml.version.id},
   "index_patterns" : [
-    ".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*"
+    ".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*", ".reindexed-v8-ml-anomalies-*"
   ],
   "template" : {
     "settings" : {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdate.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdate.java
@@ -70,8 +70,8 @@ import static org.elasticsearch.xpack.core.ml.utils.MlIndexAndAlias.has6DigitSuf
 
 /**
  * Rollover the various .ml-anomalies result indices updating the read and write aliases.
- * Also detects and heals indices that were rolled over with an incorrect dynamic job_id
- * mapping (the reindexed-ml-anomalies bug introduced in ES 8.18/8.19, including
+ * Also detects and heals indices that were rolled over with incorrect mappings from the
+ * reindexed-ml-anomalies bug introduced in ES 8.18/8.19 (including
  * {@code .reindexed-v7-ml-anomalies-*} and {@code .reindexed-v8-ml-anomalies-*} lineages).
  */
 public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction {
@@ -83,7 +83,7 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
      * the normal rollover loop. Dynamically updatable.
      * <p>
      * Setting key retains {@code reindexed_v7} for backwards compatibility; the heal applies to
-     * all {@code .reindexed-*-ml-anomalies-*} indices with broken {@code job_id} mappings.
+     * all {@code .reindexed-*-ml-anomalies-*} indices with broken results-index mappings.
      */
     public static final Setting<Boolean> HEAL_REINDEXED_V7_ENABLED = Setting.boolSetting(
         "xpack.ml.anomalies.heal_reindexed_v7.enabled",
@@ -95,8 +95,23 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
     /**
      * Index pattern used to resolve all reindexed ML anomalies candidates (e.g.
      * {@code .reindexed-v7-ml-anomalies-*}, {@code .reindexed-v8-ml-anomalies-*}).
+     * Broader than the composable template's explicit v7/v8 {@code index_patterns} because
+     * runtime index resolution is not subject to template-overlap validation.
      */
     static final String REINDEXED_ANOMALIES_PATTERN = ".reindexed-*-ml-anomalies-*";
+
+    /**
+     * {@code anomaly_score_explanation} fields that must be typed as {@code double} in the
+     * managed AD results index template. Dynamic mapping may guess {@code float} instead.
+     */
+    static final List<String> ANOMALY_SCORE_EXPLANATION_DOUBLE_FIELDS = List.of(
+        "lower_confidence_bound",
+        "typical_value",
+        "upper_confidence_bound",
+        "by_field_relative_rarity"
+    );
+
+    private static final String ANOMALY_SCORE_EXPLANATION_OBJECT = "anomaly_score_explanation";
 
     /**
      * Strips {@code .reindexed-<version>-} from a concrete index name, leaving {@code ml-anomalies-...}
@@ -167,7 +182,7 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
 
     /**
      * Executes updates related to ML anomaly indices.
-     * - Heals any <code>.reindexed-*-ml-anomalies-*</code> indices with broken {@code job_id} mappings if necessary.
+     * - Heals any <code>.reindexed-*-ml-anomalies-*</code> indices with broken results mappings if necessary.
      * - Runs the rollover process for ML anomaly indices against a fresh {@link ClusterState} so rollovers see
      *   aliases already moved off reindexed lineages by the heal step.
      * If either task fails, an aggregated {@link ElasticsearchStatusException} is thrown
@@ -466,8 +481,8 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
      *                     same new target index.
      */
     private void healOneBadIndex(String badIndex, ClusterState state, Map<String, String> targetByBase) {
-        // Determine if the mapping is broken (absent or non-keyword job_id)
-        if (hasCorrectJobIdMapping(badIndex, state)) {
+        // Determine if the mapping is broken (e.g. non-keyword job_id or float anomaly_score_explanation fields)
+        if (isIndexMappingHealthy(badIndex, state)) {
             return;
         }
 
@@ -507,7 +522,7 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
         emitAdvisoryNotifications(badIndex, targetIndex, jobIds);
 
         logger.warn(
-            "The ML anomalies index [{}] was missing required keyword mapping for [job_id]. "
+            "The ML anomalies index [{}] had incompatible results-index mappings. "
                 + "Aliases for jobs [{}] have been moved to a compatible anomalies index [{}].",
             badIndex,
             jobIds,
@@ -517,12 +532,35 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
     }
 
     /**
+     * Returns {@code true} iff the index carries the managed AD results mappings required for
+     * job open and alias-filtered reads ({@code job_id: keyword} and
+     * {@code anomaly_score_explanation.*: double}).
+     */
+    private boolean isIndexMappingHealthy(String indexName, ClusterState state) {
+        return hasCorrectJobIdMapping(indexName, state) && hasCorrectAnomalyScoreExplanationMapping(indexName, state);
+    }
+
+    /**
      * Returns {@code true} iff the {@code job_id} field in {@code indexName}'s mapping
      * is typed as {@code keyword} (i.e. the ML index template was applied correctly).
      */
     private boolean hasCorrectJobIdMapping(String indexName, ClusterState state) {
         var indexMetadata = state.metadata().index(indexName);
         return MlIndexAndAlias.hasFieldTypedAs(indexMetadata, Job.ID.getPreferredName(), "keyword");
+    }
+
+    /**
+     * Returns {@code true} iff every {@link #ANOMALY_SCORE_EXPLANATION_DOUBLE_FIELDS} entry in
+     * {@code anomaly_score_explanation} is typed as {@code double}.
+     */
+    private boolean hasCorrectAnomalyScoreExplanationMapping(String indexName, ClusterState state) {
+        var indexMetadata = state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(indexName);
+        for (String fieldName : ANOMALY_SCORE_EXPLANATION_DOUBLE_FIELDS) {
+            if (MlIndexAndAlias.hasFieldTypedAs(indexMetadata, List.of(ANOMALY_SCORE_EXPLANATION_OBJECT, fieldName), "double") == false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -537,7 +575,7 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
             var latestMeta = state.metadata().index(latest);
             if (latestMeta != null
                 && MlIndexAndAlias.indexIsReadWriteCompatibleInV9(latestMeta.getCreationVersion())
-                && hasCorrectJobIdMapping(latest, state)) {
+                && isIndexMappingHealthy(latest, state)) {
                 logger.debug("[ml_anomalies_reindexed_v7_heal] reusing existing target index [{}] for base [{}]", latest, targetBase);
                 return latest;
             }
@@ -691,8 +729,8 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
         String affectedJobs = String.join(", ", jobIds);
         String clusterMessage = Strings.format(
             "Anomaly detection historical results are stranded in index [%s] because an Elasticsearch upgrade "
-                + "on one of the affected versions (pre-8.18.8, pre-8.19.5, pre-9.0.8, pre-9.1.5, pre-9.2.0) "
-                + "produced a broken dynamic job_id mapping. "
+                + "on one of the affected versions (pre-8.18.8, pre-8.19.19, pre-9.0.8, pre-9.1.5, pre-9.2.0, "
+                + "pre-9.3.8, pre-9.4.4, pre-9.5.1, pre-9.6.0) produced broken ML anomaly results index mappings. "
                 + "New results are now written to [%s] with the correct mappings and will appear in the UI again. "
                 + "Affected jobs: [%s]. "
                 + "To recover the historical results, ensure your user has read and write on .ml-anomalies-* "
@@ -711,7 +749,7 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
         );
 
         String perJobMessage = Strings.format(
-            "Historical anomaly results for this job are stranded in index [%s] due to a broken job_id mapping from "
+            "Historical anomaly results for this job are stranded in index [%s] due to broken results-index mappings from "
                 + "an earlier upgrade. New results are now being written to [%s]. "
                 + "See the cluster-wide ML notification (job type: System) for the recovery procedure. "
                 + "Details: https://github.com/elastic/elasticsearch/issues/147686",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -42,8 +42,10 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
      * add a comment with a reason each time the base number is incremented.
      *
      * 10000001: ".reindexed-v7-ml-anomalies-*" added to ml-anomalies index pattern
+     * 10000002: ".reindexed-v7-ml-state*" and ".reindexed-v8-ml-state*" added to ml-state index pattern
+     * 10000003: ".reindexed-v8-ml-anomalies-*" added alongside the existing v7 reindexed anomalies pattern
      */
-    public static final int ML_INDEX_TEMPLATE_VERSION = 10000001 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
+    public static final int ML_INDEX_TEMPLATE_VERSION = 10000003 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
         + NotificationsIndex.NOTIFICATIONS_INDEX_MAPPINGS_VERSION + MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
         + NotificationsIndex.NOTIFICATIONS_INDEX_TEMPLATE_VERSION;
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdateTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdateTests.java
@@ -305,9 +305,9 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
     }
 
     public void testHealReindexedV7_NoOp_WhenMappingAlreadyKeyword() {
-        // job_id is already keyword — do NOT touch this index (operator has fixed it manually)
+        // job_id and anomaly_score_explanation fields are already correct — do NOT touch this index
         String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
-        ClusterState cs = clusterStateWithBadIndex(badIndex, IndexVersion.current(), List.of("jobA"), keywordJobIdMapping());
+        ClusterState cs = clusterStateWithBadIndex(badIndex, IndexVersion.current(), List.of("jobA"), healthyResultsMapping());
         var client = mock(Client.class);
         AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
         SystemAuditor systemAuditor = mock(SystemAuditor.class);
@@ -319,6 +319,90 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
         verify(client, never()).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());
         verify(auditor, never()).warning(any(), any());
         verify(systemAuditor, never()).warning(anyString());
+    }
+
+    public void testAnomalyScoreExplanationDoubleFieldsMatchResultsTemplate() {
+        IndexMetadata indexMetadata = IndexMetadata.builder(".test-template-mapping")
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            )
+            .putMapping(AnomalyDetectorsIndex.resultsMapping())
+            .build();
+
+        for (String fieldName : MlAnomaliesIndexUpdate.ANOMALY_SCORE_EXPLANATION_DOUBLE_FIELDS) {
+            assertTrue(
+                "results template must declare anomaly_score_explanation." + fieldName + " as double",
+                MlIndexAndAlias.hasFieldTypedAs(indexMetadata, List.of("anomaly_score_explanation", fieldName), "double")
+            );
+        }
+    }
+
+    public void testHealReindexedV7_HealWhenJobIdKeywordButAnomalyScoreExplanationFloat() {
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        String targetIndex = ".ml-anomalies-shared-000001";
+        ClusterState cs = clusterStateWithBadIndex(
+            badIndex,
+            IndexVersion.current(),
+            List.of("jobA"),
+            keywordJobIdWithFloatAnomalyScoreExplanationMapping()
+        );
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        var client = mockClientForHeal(targetIndex);
+
+        updater(client, cs, auditor, systemAuditor, HEAL_ENABLED).runUpdate(cs);
+
+        verify(client).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+        verify(client).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());
+        verify(systemAuditor).warning(anyString());
+        verify(auditor).warning(eq("jobA"), anyString());
+    }
+
+    public void testHealReindexedV7_DoesNotReuseTargetWithFloatAnomalyScoreExplanation() {
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        String unhealthyTarget = ".ml-anomalies-shared-000001";
+        String newTarget = ".ml-anomalies-shared-000002";
+
+        IndexMetadata.Builder unhealthyTargetMeta = IndexMetadata.builder(unhealthyTarget)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_target")
+            )
+            .putMapping(keywordJobIdWithFloatAnomalyScoreExplanationMapping());
+
+        IndexMetadata.Builder badMeta = IndexMetadata.builder(badIndex)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_bad")
+            )
+            .putMapping(textJobIdMapping())
+            .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.resultsWriteAlias("jobA")).writeIndex(true).isHidden(true).build())
+            .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.jobResultsAliasedName("jobA")).isHidden(true).build());
+
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().put(unhealthyTargetMeta).put(badMeta))
+            .build();
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        var client = mockClientForHeal(newTarget);
+
+        updater(client, cs, auditor, systemAuditor, HEAL_ENABLED).runUpdate(cs);
+
+        verify(client).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+        verify(client).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());
+        verify(systemAuditor).warning(anyString());
+        verify(auditor).warning(eq("jobA"), anyString());
     }
 
     public void testHealReindexedV7_NoOp_WhenAliasesAlreadyMoved() {
@@ -465,7 +549,7 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_old")
             )
-            .putMapping(keywordJobIdMapping())
+            .putMapping(healthyResultsMapping())
             .putAlias(AliasMetadata.builder(readAlias).isHidden(true).build());
 
         IndexMetadata.Builder newMeta = IndexMetadata.builder(newCanonical)
@@ -476,7 +560,7 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_new")
             )
-            .putMapping(keywordJobIdMapping())
+            .putMapping(healthyResultsMapping())
             .putAlias(AliasMetadata.builder(readAlias).isHidden(true).build())
             .putAlias(AliasMetadata.builder(writeAlias).writeIndex(true).isHidden(true).build());
 
@@ -586,7 +670,27 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
         return "{\"properties\":{\"job_id\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\"}}}}}";
     }
 
-    /** Mapping JSON where job_id is keyword (healthy). */
+    /** Mapping JSON where job_id is keyword and anomaly_score_explanation doubles are correct. */
+    private static String healthyResultsMapping() {
+        return """
+            {"properties":{"job_id":{"type":"keyword"},"anomaly_score_explanation":{"properties":{\
+            "lower_confidence_bound":{"type":"double"},\
+            "typical_value":{"type":"double"},\
+            "upper_confidence_bound":{"type":"double"},\
+            "by_field_relative_rarity":{"type":"double"}}}}}""";
+    }
+
+    /** Mapping JSON where job_id is keyword but by_field_relative_rarity was dynamically mapped as float. */
+    private static String keywordJobIdWithFloatAnomalyScoreExplanationMapping() {
+        return """
+            {"properties":{"job_id":{"type":"keyword"},"anomaly_score_explanation":{"properties":{\
+            "lower_confidence_bound":{"type":"double"},\
+            "typical_value":{"type":"double"},\
+            "upper_confidence_bound":{"type":"double"},\
+            "by_field_relative_rarity":{"type":"float"}}}}}""";
+    }
+
+    /** Mapping JSON where job_id is keyword (healthy) without anomaly_score_explanation fields. */
     private static String keywordJobIdMapping() {
         return "{\"properties\":{\"job_id\":{\"type\":\"keyword\"}}}";
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -82,6 +83,37 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
         );
 
         putIndexTemplateRequestCaptor = ArgumentCaptor.forClass(TransportPutComposableIndexTemplateAction.Request.class);
+    }
+
+    public void testResultsTemplate() {
+        MlIndexTemplateRegistry registry = new MlIndexTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            true,
+            xContentRegistry
+        );
+
+        registry.clusterChanged(createClusterChangedEvent(nodes));
+
+        verify(projectClient, times(4)).execute(
+            same(TransportPutComposableIndexTemplateAction.TYPE),
+            putIndexTemplateRequestCaptor.capture(),
+            any()
+        );
+
+        TransportPutComposableIndexTemplateAction.Request req = putIndexTemplateRequestCaptor.getAllValues()
+            .stream()
+            .filter(r -> r.name().equals(AnomalyDetectorsIndex.jobResultsIndexPrefix()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected the ml anomalies results index template to be put"));
+        ComposableIndexTemplate indexTemplate = req.indexTemplate();
+        assertThat(
+            indexTemplate.indexPatterns(),
+            containsInAnyOrder(".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*", ".reindexed-v8-ml-anomalies-*")
+        );
+        assertThat(indexTemplate.priority(), equalTo(2147483647L));
     }
 
     public void testStateTemplate() {

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -52,14 +52,13 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
     @ClassRule
     public static ElasticsearchCluster cluster = buildCluster();
 
-    public MlMappingsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
-        super(upgradedNodes);
-    }
-
-    @Override
-    protected ElasticsearchCluster getUpgradeCluster() {
-        return cluster;
-    }
+    /**
+     * Mirrors {@code MlIndexTemplateRegistry#ML_INDEX_TEMPLATE_VERSION}; kept here because rolling-upgrade
+     * tests cannot depend on the ML plugin module.
+     */
+    private static final int ML_INDEX_TEMPLATE_VERSION = 10000003 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
+        + NotificationsIndex.NOTIFICATIONS_INDEX_MAPPINGS_VERSION + MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
+        + NotificationsIndex.NOTIFICATIONS_INDEX_TEMPLATE_VERSION;
 
     @BeforeClass
     public static void maybeSkip() {
@@ -103,6 +102,25 @@ public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
             assertLegacyIndicesRollover();
             assertAnomalyIndicesRollover();
             assertNotificationsIndexAliasCreated();
+                assertBusy(
+                    () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
+                        client(),
+                        ".ml-anomalies-",
+                        ML_INDEX_TEMPLATE_VERSION,
+                        List.of(".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*", ".reindexed-v8-ml-anomalies-*")
+                    )
+                );
+                assertBusy(
+                    () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
+                        client(),
+                        ".ml-state",
+                        ML_INDEX_TEMPLATE_VERSION,
+                        Arrays.asList(AnomalyDetectorsIndex.jobStateIndexPatterns())
+                    )
+                );
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Extend reindexed AD results template and generalize heal beyond job_id (#153755)](https://github.com/elastic/elasticsearch/pull/153755)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)