### PR TITLE
[8.19] [ML] Fix NPE when preview datafeed checks date_nanos for an unmapped time field (#144909)

### DIFF
--- a/docs/changelog/144909.yaml
+++ b/docs/changelog/144909.yaml
@@ -1,0 +1,6 @@
+area: Machine Learning
+issues:
+ - 144888
+pr: 144909
+summary: Fix NPE when preview datafeed checks `date_nanos` for an unmapped time field
+type: bug

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedAction.java
@@ -7,7 +7,9 @@
 package org.elasticsearch.xpack.ml.action.datafeed;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
@@ -48,6 +50,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -206,12 +209,17 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
             client,
             TransportFieldCapabilitiesAction.TYPE,
             fieldCapabilitiesRequest,
-            listener.delegateFailureAndWrap(
-                (l, fieldCapsResponse) -> l.onResponse(
-                    fieldCapsResponse.getField(timeField).containsKey(DateFieldMapper.DATE_NANOS_CONTENT_TYPE)
-                )
-            )
+            listener.delegateFailureAndWrap((l, fieldCapsResponse) -> l.onResponse(timeFieldIsDateNanos(fieldCapsResponse, timeField)))
         );
+    }
+
+    /**
+     * Whether field caps report {@code timeField} as {@link DateFieldMapper#DATE_NANOS_CONTENT_TYPE} only.
+     * If the field is missing from the response, returns {@code false} (including Date and mixed mappings).
+     */
+    static boolean timeFieldIsDateNanos(FieldCapabilitiesResponse fieldCapsResponse, String timeField) {
+        Map<String, FieldCapabilities> fieldTypes = fieldCapsResponse.getField(timeField);
+        return fieldTypes != null && fieldTypes.containsKey(DateFieldMapper.DATE_NANOS_CONTENT_TYPE);
     }
 
     /** Visible for testing */

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
@@ -7,7 +7,12 @@
 package org.elasticsearch.xpack.ml.action.datafeed;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.fieldcaps.FieldCapabilities;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesBuilder;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
@@ -25,6 +30,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -119,5 +126,26 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
         assertThat(capturedResponse, is(nullValue()));
         assertThat(capturedFailure.getMessage(), equalTo("failed"));
         verify(dataExtractor).destroy();
+    }
+
+    public void testTimeFieldIsDateNanos_GivenFieldAbsent_ReturnsFalse() {
+        FieldCapabilitiesResponse response = FieldCapabilitiesResponse.empty();
+        assertThat(TransportPreviewDatafeedAction.timeFieldIsDateNanos(response, "time"), is(false));
+    }
+
+    public void testTimeFieldIsDateNanos_GivenDateNanos_ReturnsTrue() {
+        String timeField = "event_time";
+        var caps = new FieldCapabilitiesBuilder(timeField, DateFieldMapper.DATE_NANOS_CONTENT_TYPE).build();
+        Map<String, FieldCapabilities> byType = Map.of(DateFieldMapper.DATE_NANOS_CONTENT_TYPE, caps);
+        FieldCapabilitiesResponse response = new FieldCapabilitiesResponse(Strings.EMPTY_ARRAY, Map.of(timeField, byType));
+        assertThat(TransportPreviewDatafeedAction.timeFieldIsDateNanos(response, timeField), is(true));
+    }
+
+    public void testTimeFieldIsDateNanos_GivenDateOnly_ReturnsFalse() {
+        String timeField = "event_time";
+        var caps = new FieldCapabilitiesBuilder(timeField, DateFieldMapper.CONTENT_TYPE).build();
+        Map<String, FieldCapabilities> byType = Map.of(DateFieldMapper.CONTENT_TYPE, caps);
+        FieldCapabilitiesResponse response = new FieldCapabilitiesResponse(Strings.EMPTY_ARRAY, Map.of(timeField, byType));
+        assertThat(TransportPreviewDatafeedAction.timeFieldIsDateNanos(response, timeField), is(false));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix NPE when preview datafeed checks date_nanos for an unmapped time field (#144909)](https://github.com/elastic/elasticsearch/pull/144909)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)