### PR TITLE
[9.5] Convert RecursiveChunker to iterative and cap separator list size (#158589)

### DIFF
--- a/docs/changelog/158589.yaml
+++ b/docs/changelog/158589.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 158589
+summary: Convert `RecursiveChunker` to iterative and cap separator list size
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/ChunkingSettingsBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/ChunkingSettingsBuilder.java
@@ -22,10 +22,20 @@ public class ChunkingSettingsBuilder {
     public static final float WORDS_PER_TOKEN = 0.75f;
 
     public static ChunkingSettings fromMap(Map<String, Object> settings) {
-        return fromMap(settings, true);
+        return fromMap(settings, true, false);
     }
 
     public static ChunkingSettings fromMap(Map<String, Object> settings, boolean returnDefaultValues) {
+        return fromMap(settings, returnDefaultValues, false);
+    }
+
+    /**
+     * @param enforceRequestLimits when {@code true}, policy limits such as the maximum separator count for
+     *                             recursive chunking are enforced. Pass {@code true} for user-facing request paths
+     *                             and {@code false} for persistence-read paths that may encounter settings created
+     *                             before the limit existed.
+     */
+    public static ChunkingSettings fromMap(Map<String, Object> settings, boolean returnDefaultValues, boolean enforceRequestLimits) {
 
         if (returnDefaultValues) {
             if (settings == null) {
@@ -51,7 +61,7 @@ public class ChunkingSettingsBuilder {
             case NONE -> NoneChunkingSettings.INSTANCE;
             case WORD -> WordBoundaryChunkingSettings.fromMap(new HashMap<>(settings));
             case SENTENCE -> SentenceBoundaryChunkingSettings.fromMap(new HashMap<>(settings));
-            case RECURSIVE -> RecursiveChunkingSettings.fromMap(new HashMap<>(settings));
+            case RECURSIVE -> RecursiveChunkingSettings.fromMap(new HashMap<>(settings), enforceRequestLimits);
         };
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunker.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunker.java
@@ -12,6 +12,7 @@ import com.ibm.icu.text.BreakIterator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.ChunkingSettings;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -41,8 +42,7 @@ public class RecursiveChunker implements Chunker {
                 input,
                 new ChunkOffset(0, input.length()),
                 recursiveChunkingSettings.getSeparators(),
-                recursiveChunkingSettings.maxChunkSize(),
-                0
+                recursiveChunkingSettings.maxChunkSize()
             );
         } else {
             throw new IllegalArgumentException(
@@ -51,29 +51,71 @@ public class RecursiveChunker implements Chunker {
         }
     }
 
-    private List<ChunkOffset> chunk(String input, ChunkOffset offset, List<String> separators, int maxChunkSize, int separatorIndex) {
-        if (offset.start() == offset.end() || isChunkWithinMaxSize(buildChunkOffsetAndCount(input, offset), maxChunkSize)) {
-            return List.of(offset);
+    /**
+     * Iteratively splits {@code initialOffset} into chunks that each fit within {@code maxChunkSize},
+     * trying separators in list order and falling back to the sentence boundary chunker when all
+     * separators are exhausted.
+     * <p>
+     * An explicit worklist ({@link ArrayDeque}) replaces what was previously a recursive call,
+     * so the JVM call-stack depth is constant regardless of the number of separators.
+     * Chunks that already fit are emitted immediately; only oversized chunks are pushed
+     * back onto the worklist for further splitting with the next separator.
+     * Oversized chunks are pushed in reverse order so that they are popped (and therefore
+     * emitted) in document order.
+     */
+    private List<ChunkOffset> chunk(String input, ChunkOffset initialOffset, List<String> separators, int maxChunkSize) {
+        if (initialOffset.start() == initialOffset.end()) {
+            return List.of(initialOffset);
         }
 
-        if (separatorIndex > separators.size() - 1) {
-            return chunkWithBackupChunker(input, offset, maxChunkSize);
+        var initialChunk = buildChunkOffsetAndCount(input, initialOffset);
+        if (isChunkWithinMaxSize(initialChunk, maxChunkSize)) {
+            return List.of(initialOffset);
         }
 
-        var potentialChunks = mergeChunkOffsetsUpToMaxChunkSize(
-            splitTextBySeparatorRegex(input, offset, separators.get(separatorIndex)),
-            maxChunkSize
-        );
-        var actualChunks = new ArrayList<ChunkOffset>();
-        for (var potentialChunk : potentialChunks) {
-            if (isChunkWithinMaxSize(potentialChunk, maxChunkSize)) {
-                actualChunks.add(potentialChunk.chunkOffset());
-            } else {
-                actualChunks.addAll(chunk(input, potentialChunk.chunkOffset(), separators, maxChunkSize, separatorIndex + 1));
+        var chunks = new ArrayList<ChunkOffset>();
+        var worklist = new ArrayDeque<PendingChunk>();
+        worklist.push(new PendingChunk(initialChunk, 0));
+
+        while (worklist.isEmpty() == false) {
+            var pending = worklist.pop();
+            var chunkOffsetAndCount = pending.chunkOffsetAndCount();
+            var offset = chunkOffsetAndCount.chunkOffset();
+            int separatorIndex = pending.separatorIndex();
+
+            // Emit directly if the chunk is empty or already fits within the limit.
+            if (offset.start() == offset.end() || isChunkWithinMaxSize(chunkOffsetAndCount, maxChunkSize)) {
+                chunks.add(offset);
+                continue;
+            }
+
+            if (separatorIndex >= separators.size()) {
+                chunks.addAll(chunkWithBackupChunker(input, offset, maxChunkSize));
+                continue;
+            }
+
+            var potentialChunks = mergeChunkOffsetsUpToMaxChunkSize(
+                splitTextBySeparatorRegex(input, offset, separators.get(separatorIndex)),
+                maxChunkSize
+            );
+
+            // Emit fit chunks immediately; push oversized chunks in reverse so they pop in document order.
+            for (int i = 0; i < potentialChunks.size(); i++) {
+                var potentialChunk = potentialChunks.get(i);
+                if (isChunkWithinMaxSize(potentialChunk, maxChunkSize)) {
+                    chunks.add(potentialChunk.chunkOffset());
+                } else {
+                    // All remaining chunks from this split need further processing.
+                    // Push them in reverse order so the earliest chunk is popped first.
+                    for (int j = potentialChunks.size() - 1; j >= i; j--) {
+                        worklist.push(new PendingChunk(potentialChunks.get(j), separatorIndex + 1));
+                    }
+                    break;
+                }
             }
         }
 
-        return actualChunks;
+        return chunks;
     }
 
     private boolean isChunkWithinMaxSize(ChunkOffsetAndCount chunkOffsetAndCount, int maxChunkSize) {
@@ -147,4 +189,11 @@ public class RecursiveChunker implements Chunker {
     }
 
     private record ChunkOffsetAndCount(ChunkOffset chunkOffset, int wordCount) {}
+
+    /**
+     * A chunk that still needs to be checked or further split, together with the index of the
+     * next separator to try if it turns out to be too large. The word count is carried alongside
+     * the offset so that fitness checks on pop do not require re-counting.
+     */
+    private record PendingChunk(ChunkOffsetAndCount chunkOffsetAndCount, int separatorIndex) {}
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettings.java
@@ -31,6 +31,7 @@ public class RecursiveChunkingSettings implements ChunkingSettings {
     public static final String NAME = "RecursiveChunkingSettings";
     private static final ChunkingStrategy STRATEGY = ChunkingStrategy.RECURSIVE;
     static final int MAX_CHUNK_SIZE_LOWER_LIMIT = 10;
+    static final int MAX_SEPARATOR_COUNT = 50;
 
     private static final Set<String> VALID_KEYS = Set.of(
         ChunkingSettingsOptions.STRATEGY.toString(),
@@ -66,10 +67,26 @@ public class RecursiveChunkingSettings implements ChunkingSettings {
             validationException.addValidationError("Recursive chunking settings can not have an empty list of separators");
         }
 
+        if (separators != null && separators.size() > MAX_SEPARATOR_COUNT) {
+            validationException.addValidationError(
+                ChunkingSettingsOptions.SEPARATORS + " list size [" + separators.size() + "] must not exceed [" + MAX_SEPARATOR_COUNT + "]"
+            );
+        }
+
         validationException.throwIfValidationErrorsExist();
     }
 
     public static RecursiveChunkingSettings fromMap(Map<String, Object> map) {
+        return fromMap(map, false);
+    }
+
+    /**
+     * @param enforceRequestLimits when {@code true}, policy limits such as {@link #MAX_SEPARATOR_COUNT} are enforced.
+     *                             Pass {@code true} for user-facing request paths (ES|QL CHUNK, text_similarity_reranker,
+     *                             PUT/UPDATE _inference) and {@code false} for persistence-read paths that may encounter
+     *                             settings created before the limit existed.
+     */
+    public static RecursiveChunkingSettings fromMap(Map<String, Object> map, boolean enforceRequestLimits) {
         ValidationException validationException = new ValidationException();
 
         var invalidSettings = map.keySet().stream().filter(key -> VALID_KEYS.contains(key) == false).toArray();
@@ -111,6 +128,12 @@ public class RecursiveChunkingSettings implements ChunkingSettings {
             separators = separatorGroup.getSeparators();
         } else if (separators != null && separators.isEmpty()) {
             validationException.addValidationError("Recursive chunking settings can not have an empty list of separators");
+        }
+
+        if (enforceRequestLimits && separators != null && separators.size() > MAX_SEPARATOR_COUNT) {
+            validationException.addValidationError(
+                ChunkingSettingsOptions.SEPARATORS + " list size [" + separators.size() + "] must not exceed [" + MAX_SEPARATOR_COUNT + "]"
+            );
         }
 
         validationException.throwIfValidationErrorsExist();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkerTests.java
@@ -234,6 +234,64 @@ public class RecursiveChunkerTests extends ESTestCase {
         assertExpectedChunksGenerated(input, settings, expectedChunks);
     }
 
+    /**
+     * With the maximum allowed number of non-matching separators the chunker must complete
+     * normally (no {@link StackOverflowError}) and fall through to the backup sentence chunker.
+     */
+    public void testChunkWithManyNonMatchingSeparators() {
+        var separators = new ArrayList<String>();
+        for (int i = 0; i < RecursiveChunkingSettings.MAX_SEPARATOR_COUNT; i++) {
+            separators.add("NON_MATCHING_SEPARATOR_" + i);
+        }
+        RecursiveChunkingSettings settings = generateChunkingSettings(10, separators);
+        // Two sentences of ten words each so the input exceeds max_chunk_size and no separator can split it.
+        String input = generateTestText(2, List.of(""));
+
+        // No separator matches, so the whole input falls through to the backup sentence chunker.
+        assertExpectedChunksGenerated(
+            input,
+            settings,
+            List.of(new Chunker.ChunkOffset(0, TEST_SENTENCE.length()), new Chunker.ChunkOffset(TEST_SENTENCE.length(), input.length()))
+        );
+    }
+
+    /**
+     * Chunks must be returned in document order even when neighbouring chunks are resolved at
+     * very different separator depths. Here the newline separator splits into a two-sentence
+     * first part and a one-sentence trailing part. The first part still exceeds max_chunk_size
+     * so it descends through the remaining separators until the tab separator finally splits it,
+     * while the trailing part already fits and is emitted directly.
+     */
+    public void testChunkOrderingIsPreservedWhenChunksResolveAtDifferentDepths() {
+        var separators = new ArrayList<String>();
+        for (int i = 0; i < 10; i++) {
+            separators.add("NON_MATCHING_A_" + i);
+        }
+        separators.add("\n");
+        for (int i = 0; i < 10; i++) {
+            separators.add("NON_MATCHING_B_" + i);
+        }
+        separators.add("\t");
+        for (int i = 0; i < 10; i++) {
+            separators.add("NON_MATCHING_C_" + i);
+        }
+
+        RecursiveChunkingSettings settings = generateChunkingSettings(10, separators);
+        String input = generateTestText(3, List.of("\t", "\n"));
+
+        var expectedFirstChunkOffsetEnd = TEST_SENTENCE.length();
+        var expectedSecondChunkOffsetEnd = TEST_SENTENCE.length() * 2 + "\t".length();
+        assertExpectedChunksGenerated(
+            input,
+            settings,
+            List.of(
+                new Chunker.ChunkOffset(0, expectedFirstChunkOffsetEnd),
+                new Chunker.ChunkOffset(expectedFirstChunkOffsetEnd, expectedSecondChunkOffsetEnd),
+                new Chunker.ChunkOffset(expectedSecondChunkOffsetEnd, input.length())
+            )
+        );
+    }
+
     private void assertExpectedChunksGenerated(String input, RecursiveChunkingSettings settings, List<Chunker.ChunkOffset> expectedChunks) {
         RecursiveChunker chunker = new RecursiveChunker();
         List<Chunker.ChunkOffset> chunks = chunker.chunk(input, settings);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/RecursiveChunkingSettingsTests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.elasticsearch.xpack.core.inference.chunking.RecursiveChunkingSettings.MAX_CHUNK_SIZE_LOWER_LIMIT;
+import static org.elasticsearch.xpack.core.inference.chunking.RecursiveChunkingSettings.MAX_SEPARATOR_COUNT;
 import static org.hamcrest.Matchers.containsString;
 
 public class RecursiveChunkingSettingsTests extends AbstractWireSerializingTestCase<RecursiveChunkingSettings> {
@@ -117,6 +118,58 @@ public class RecursiveChunkingSettingsTests extends AbstractWireSerializingTestC
         Map<String, Object> invalidSettings = buildChunkingSettingsMap(randomIntBetween(10, 300), Optional.empty(), Optional.of(List.of()));
 
         assertThrows(ValidationException.class, () -> RecursiveChunkingSettings.fromMap(invalidSettings));
+    }
+
+    public void testFromMapTooManySeparatorsEnforced() {
+        int count = MAX_SEPARATOR_COUNT + randomIntBetween(1, 100);
+        List<String> separators = buildSeparatorList(count);
+        Map<String, Object> invalidSettings = buildChunkingSettingsMap(
+            randomIntBetween(10, 300),
+            Optional.empty(),
+            Optional.of(separators)
+        );
+
+        var e = assertThrows(ValidationException.class, () -> RecursiveChunkingSettings.fromMap(invalidSettings, true));
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("separators list size [%s] must not exceed [%s]", count, MAX_SEPARATOR_COUNT))
+        );
+    }
+
+    public void testFromMapTooManySeparatorsNotEnforced() {
+        int count = MAX_SEPARATOR_COUNT + randomIntBetween(1, 100);
+        List<String> separators = buildSeparatorList(count);
+        Map<String, Object> settings = buildChunkingSettingsMap(randomIntBetween(10, 300), Optional.empty(), Optional.of(separators));
+
+        RecursiveChunkingSettings result = RecursiveChunkingSettings.fromMap(settings);
+        assertEquals(count, result.getSeparators().size());
+    }
+
+    public void testFromMapSeparatorsAtMaxLimit() {
+        List<String> separators = buildSeparatorList(MAX_SEPARATOR_COUNT);
+        Map<String, Object> validSettings = buildChunkingSettingsMap(randomIntBetween(10, 300), Optional.empty(), Optional.of(separators));
+
+        RecursiveChunkingSettings settings = RecursiveChunkingSettings.fromMap(validSettings, true);
+        assertEquals(MAX_SEPARATOR_COUNT, settings.getSeparators().size());
+    }
+
+    public void testValidateWithTooManySeparators() {
+        int count = MAX_SEPARATOR_COUNT + randomIntBetween(1, 100);
+        List<String> separators = buildSeparatorList(count);
+        var settings = new RecursiveChunkingSettings(randomIntBetween(MAX_CHUNK_SIZE_LOWER_LIMIT, 300), separators);
+        var e = assertThrows(ValidationException.class, settings::validate);
+        assertThat(
+            e.getMessage(),
+            containsString(Strings.format("separators list size [%s] must not exceed [%s]", count, MAX_SEPARATOR_COUNT))
+        );
+    }
+
+    private static List<String> buildSeparatorList(int count) {
+        List<String> separators = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            separators.add("SEP_" + i);
+        }
+        return separators;
     }
 
     private Map<String, Object> buildChunkingSettingsMap(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Chunk.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Chunk.java
@@ -285,6 +285,6 @@ public class Chunk extends EsqlScalarFunction implements OptionalArgument {
             }
             return value;
         }));
-        return ChunkingSettingsBuilder.fromMap(chunkingSettingsMap);
+        return ChunkingSettingsBuilder.fromMap(chunkingSettingsMap, true, true);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
@@ -310,7 +310,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
             mergedTaskSettings = mergedTaskSettings.updatedTaskSettings(newTaskSettings);
         }
         if (newChunkingSettings != null) {
-            replacementChunkingSettings = ChunkingSettingsBuilder.fromMap(newChunkingSettings);
+            replacementChunkingSettings = ChunkingSettingsBuilder.fromMap(newChunkingSettings, true, true);
         }
 
         return new ModelConfigurations(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/ChunkScorerConfig.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/ChunkScorerConfig.java
@@ -35,6 +35,10 @@ public class ChunkScorerConfig implements Writeable, ToXContentObject {
     }
 
     public static ChunkingSettings chunkingSettingsFromMap(Map<String, Object> map) {
+        return chunkingSettingsFromMap(map, false);
+    }
+
+    public static ChunkingSettings chunkingSettingsFromMap(Map<String, Object> map, boolean enforceRequestLimits) {
 
         if (map == null) {
             return null;
@@ -48,7 +52,7 @@ public class ChunkScorerConfig implements Writeable, ToXContentObject {
             return defaultChunkingSettings(maxChunkSize);
         }
 
-        return ChunkingSettingsBuilder.fromMap(map, false);
+        return ChunkingSettingsBuilder.fromMap(map, false, enforceRequestLimits);
     }
 
     public ChunkScorerConfig(StreamInput in) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -88,7 +88,7 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
             Integer size = (Integer) args[0];
             @SuppressWarnings("unchecked")
             Map<String, Object> chunkingSettingsMap = (Map<String, Object>) args[1];
-            ChunkingSettings chunkingSettings = ChunkScorerConfig.chunkingSettingsFromMap(chunkingSettingsMap);
+            ChunkingSettings chunkingSettings = ChunkScorerConfig.chunkingSettingsFromMap(chunkingSettingsMap, true);
             return new ChunkScorerConfig(size, chunkingSettings);
         });
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
@@ -131,7 +131,9 @@ public abstract class SenderService<M extends Model> implements InferenceService
             ChunkingSettings chunkingSettings = null;
             if (CHUNKING_TASK_TYPES.contains(taskType)) {
                 chunkingSettings = ChunkingSettingsBuilder.fromMap(
-                    removeFromMapOrDefaultEmpty(config, ModelConfigurations.CHUNKING_SETTINGS)
+                    removeFromMapOrDefaultEmpty(config, ModelConfigurations.CHUNKING_SETTINGS),
+                    true,
+                    true
                 );
             }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -212,7 +212,9 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             ChunkingSettings chunkingSettings;
             if (TaskType.TEXT_EMBEDDING.equals(taskType) || TaskType.SPARSE_EMBEDDING.equals(taskType)) {
                 chunkingSettings = ChunkingSettingsBuilder.fromMap(
-                    removeFromMapOrDefaultEmpty(config, ModelConfigurations.CHUNKING_SETTINGS)
+                    removeFromMapOrDefaultEmpty(config, ModelConfigurations.CHUNKING_SETTINGS),
+                    true,
+                    true
                 );
             } else {
                 chunkingSettings = null;


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Convert RecursiveChunker to iterative and cap separator list size (#158589)