### PR TITLE
View validation

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/ViewResolutionBenchmarkBase.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/ViewResolutionBenchmarkBase.java
@@ -61,7 +61,6 @@ import org.elasticsearch.xpack.esql.parser.EsqlParser;
 import org.elasticsearch.xpack.esql.parser.QueryParams;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.plan.ResolvedSettings;
-import org.elasticsearch.xpack.esql.plan.SettingsValidationContext;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.Configuration;
@@ -155,11 +154,10 @@ public abstract class ViewResolutionBenchmarkBase {
 
         EsqlFunctionRegistry functionRegistry = new EsqlFunctionRegistry();
         InferenceSettings inferenceSettings = new InferenceSettings(Settings.EMPTY);
-        SettingsValidationContext validationCtx = new SettingsValidationContext(false, false);
         TransportVersion minimumVersion = TransportVersion.current();
 
         parser = new EsqlParser(new EsqlConfig(functionRegistry));
-        viewParser = (query, viewName) -> parser.parseView(query, new QueryParams(), validationCtx, inferenceSettings, viewName).plan();
+        viewParser = (query, viewName) -> parser.parseView(query, new QueryParams(), inferenceSettings, viewName).plan();
 
         LinkedHashMap<String, EsField> mapping = new LinkedHashMap<>();
         for (int i = 0; i < 5; i++) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/PutViewActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/PutViewActionIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.metadata.View;
+import org.elasticsearch.xpack.esql.view.PutViewAction;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+
+public class PutViewActionIT extends AbstractEsqlIntegTestCase {
+
+    public void testIndicesAreNotValidateUponCreation() {
+        assertAcked(createView("my_view", "FROM not-validated"));
+    }
+
+    public void testInvalidSyntaxQueryIsRejected() {
+        expectThrows(ElasticsearchException.class, containsString("mismatched input"), () -> createView("my_view", "NOT VALID ESQL $$$$"));
+    }
+
+    public void testSetIsRejected() {
+        expectThrows(
+            ElasticsearchException.class,
+            containsString("SET statements are not allowed in views"),
+            () -> createView("my_view", "SET time_zone=\"Europe/Berlin\"; FROM index")
+        );
+    }
+
+    private AcknowledgedResponse createView(String viewName, String query) {
+        return client().execute(
+            PutViewAction.INSTANCE,
+            new PutViewAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, new View(viewName, query))
+        ).actionGet(30, TimeUnit.SECONDS);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
@@ -19,7 +19,6 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.inference.InferenceSettings;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
@@ -151,25 +150,17 @@ public class EsqlParser {
     /**
      * Parse a view query with the given view name. The view name is used to tag all Source objects
      * so they can be correctly deserialized when the view positions exceed the outer query's length.
-     *
-     * <p>Unlike the top-level query, which is validated inside {@link EsqlQueryRequest#parse}, view
-     * bodies are parsed inside a callback that has no request object — so settings validation is
-     * performed here, where the {@link SettingsValidationContext} is available, rather than at the
-     * call site.
+     * SET statements are not allowed in view bodies and are rejected with a {@link ParsingException}.
      */
-    public EsqlStatement parseView(
-        String query,
-        QueryParams params,
-        SettingsValidationContext settingsValidationCtx,
-        InferenceSettings inferenceSettings,
-        String viewName
-    ) {
+    public EsqlStatement parseView(String query, QueryParams params, InferenceSettings inferenceSettings, String viewName) {
         var parsed = createStatement(query, params, inferenceSettings, viewName);
         if (log.isDebugEnabled()) {
             log.debug("Parsed view '{}' logical plan:\n{}", viewName, parsed.plan());
             log.debug("Parsed settings:\n[{}]", parsed.settings().stream().map(QuerySetting::toString).collect(joining("; ")));
         }
-        QuerySettings.validate(parsed, settingsValidationCtx);
+        if (parsed.settings() != null && parsed.settings().isEmpty() == false) {
+            throw new ParsingException(parsed.settings().getFirst().source(), "SET statements are not allowed in views");
+        }
         return parsed;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -391,7 +391,11 @@ public class EsqlSession {
         listener = wrapForAnonymizedFailureLog(listener);
         TimeSpanMarker parsingProfile = executionInfo.queryProfile().parsing();
         parsingProfile.start();
-        EsqlStatement statement = parse(request);
+        EsqlStatement statement = request.parse(
+            parser,
+            SettingsValidationContext.from(crossProjectModeDecider),
+            inferenceService.inferenceSettings()
+        );
         // Unwrap EXPLAIN right after parsing: Explain is a leaf plan holding the target query as a
         // field rather than a child, so plan traversals do not descend into it. It must be removed
         // before view and IN subquery resolution and pre-analysis, which would otherwise silently
@@ -443,13 +447,7 @@ public class EsqlSession {
         viewResolver.replaceViews(
             parsedPlan,
             QuerySettings.PROJECT_ROUTING.get(resolved),
-            (query, viewName) -> parser.parseView(
-                query,
-                request.params(),
-                SettingsValidationContext.from(crossProjectModeDecider),
-                inferenceService.inferenceSettings(),
-                viewName
-            ).plan(),
+            (query, viewName) -> parser.parseView(query, request.params(), inferenceService.inferenceSettings(), viewName).plan(),
             listener.delegateFailureAndWrap((l, viewResolution) -> {
                 // Validate: no InSubquery expressions should survive view and subquery resolution.
                 InSubqueryResolver.verify(viewResolution.plan());
@@ -1334,10 +1332,6 @@ public class EsqlSession {
         if (relationPage != null) {
             Releasables.closeExpectNoException(relationPage);
         }
-    }
-
-    private EsqlStatement parse(EsqlQueryRequest request) {
-        return request.parse(parser, SettingsValidationContext.from(crossProjectModeDecider), inferenceService.inferenceSettings());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewService.java
@@ -24,8 +24,10 @@ import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xpack.esql.inference.InferenceSettings;
 import org.elasticsearch.xpack.esql.parser.EsqlParser;
 import org.elasticsearch.xpack.esql.parser.QueryParams;
 
@@ -203,8 +205,8 @@ public class ViewService {
                     entry.getValue().getType().getDisplayName()
                 );
             });
-        // Parse the query to ensure it's valid, this will throw appropriate exceptions if not
-        parser.parseQuery(view.query(), new QueryParams());
+        // Parse the query to ensure it's syntactically valid; parseView rejects any SET statements
+        parser.parseView(view.query(), new QueryParams(), new InferenceSettings(Settings.EMPTY), view.name());
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/ViewAndSubqueryResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/ViewAndSubqueryResolverTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.inference.InferenceSettings;
 import org.elasticsearch.xpack.esql.parser.AbstractStatementParserTests;
 import org.elasticsearch.xpack.esql.parser.QueryParams;
-import org.elasticsearch.xpack.esql.plan.SettingsValidationContext;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
@@ -798,8 +797,7 @@ public class ViewAndSubqueryResolverTests extends AbstractStatementParserTests {
     }
 
     private LogicalPlan parse(String query, String viewName) {
-        return TEST_PARSER.parseView(query, queryParams, new SettingsValidationContext(false, false), EMPTY_INFERENCE_SETTINGS, viewName)
-            .plan();
+        return TEST_PARSER.parseView(query, queryParams, EMPTY_INFERENCE_SETTINGS, viewName).plan();
     }
 
     private void addView(String name, String query) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.optimizer.LogicalVerifier;
 import org.elasticsearch.xpack.esql.parser.AbstractStatementParserTests;
 import org.elasticsearch.xpack.esql.parser.QueryParams;
-import org.elasticsearch.xpack.esql.plan.SettingsValidationContext;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelationSerializationTests;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
@@ -2865,8 +2864,7 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
     }
 
     private LogicalPlan parse(String query, String viewName) {
-        return TEST_PARSER.parseView(query, queryParams, new SettingsValidationContext(false, false), EMPTY_INFERENCE_SETTINGS, viewName)
-            .plan();
+        return TEST_PARSER.parseView(query, queryParams, EMPTY_INFERENCE_SETTINGS, viewName).plan();
     }
 
     /**


### PR DESCRIPTION
This change ensures settings can not be added when creating a view.
It emits a clear message (opposed to parsing exception) if user tries to do so.

Closes: elastic/esql-planning#1723