### PR TITLE
Cache the array allocation during ASH quantization

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/AshSphericalScalarQuantizer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/AshSphericalScalarQuantizer.java
@@ -149,6 +149,19 @@ public sealed class AshSphericalScalarQuantizer permits PanamaAshSphericalScalar
         }
     }
 
+    private static final ThreadLocal<int[]> ABSZF_ARRAY = new ThreadLocal<>();
+
+    private static int[] getAbsZFArray(int dims) {
+        // cache this array, as it's the only large allocation on the quantize* paths,
+        // and it's generally used in a tight loop with the same dimensions
+        int[] absZF = ABSZF_ARRAY.get();
+        if (absZF == null || absZF.length != dims) {
+            absZF = new int[dims];
+            ABSZF_ARRAY.set(absZF);
+        }
+        return absZF;
+    }
+
     /**
      * Specialized fast path for 2-bit quantization (nSteps=1).
      * <p>
@@ -158,7 +171,8 @@ public sealed class AshSphericalScalarQuantizer permits PanamaAshSphericalScalar
      * The selected set is recovered via a threshold on |z_j| rather than by tracking indices.
      */
     protected float quantizeExact2Bit(float[] z, int zOffset, float[] out, int outOffset, int d) {
-        int[] absZF = new int[d];
+        int[] absZF = getAbsZFArray(d);
+
         double dot = calculateBaseLevel(z, zOffset, absZF);
 
         // Sorted ascending; the iteration is then done backwards
@@ -241,7 +255,8 @@ public sealed class AshSphericalScalarQuantizer permits PanamaAshSphericalScalar
      * which is why only magnitudes need sorting and not the dimension indices alongside them.
      */
     protected float quantizeExactGeneral(float[] z, int zOffset, float[] out, int outOffset, int d, int nSteps) {
-        int[] absZF = new int[d];
+        int[] absZF = getAbsZFArray(d);
+
         double baseDot = calculateBaseLevel(z, zOffset, absZF);
 
         // Sorted ascending; the iteration is then done backwards


### PR DESCRIPTION
The `intZF` array is the main allocation on the quantization path, and it's often called in a loop - so we can cache it within the thread to minimise the large allocation (1.5kB on 384 dims)