### PR TITLE
[ESQL] Support remote fetch for _source

### DIFF
--- a/docs/changelog/159089.yaml
+++ b/docs/changelog/159089.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 159089
+summary: Support remote fetch for `_source`
+type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlRemoteFetchTopNTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlRemoteFetchTopNTestCase.java
@@ -446,6 +446,58 @@ public abstract class EsqlRemoteFetchTopNTestCase extends AbstractEsqlIntegTestC
         }
     }
 
+    public void testRemoteFetchDeferredSource() {
+        try (
+            EsqlQueryResponse response = runQuery(
+                "FROM " + indexName + " METADATA _source | SORT unique_sort DESC | LIMIT 3 | KEEP _source"
+            )
+        ) {
+            List<List<Object>> rows = EsqlTestUtils.getValuesList(response);
+            assertThat(rows, hasSize(3));
+            for (int row = 0; row < rows.size(); row++) {
+                Map<?, ?> source = (Map<?, ?>) rows.get(row).getFirst();
+                assertThat(((Number) source.get("unique_sort")).longValue(), equalTo(63L - row));
+                assertThat(source.get("payload"), equalTo("payload-" + (63 - row)));
+            }
+            assertRemoteFetchRows(response, 3);
+            assertFieldLoadedBeforeFetch(response, "unique_sort");
+            assertFieldNotLoadedBeforeFetch(response, "_source");
+        }
+    }
+
+    public void testRemoteFetchDeferredSyntheticSource() {
+        String syntheticIndex = indexName + "_synthetic";
+        client().admin()
+            .indices()
+            .prepareCreate(syntheticIndex)
+            .setSettings(indexSettings(4, 0).put("index.mapping.source.mode", "synthetic"))
+            .setMapping("unique_sort", "type=long", "payload", "type=keyword")
+            .get();
+
+        BulkRequestBuilder bulk = client().prepareBulk();
+        for (int i = 0; i < 8; i++) {
+            bulk.add(prepareIndex(syntheticIndex).setId(Integer.toString(i)).setSource("unique_sort", i, "payload", "payload-" + i));
+        }
+        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        try (
+            EsqlQueryResponse response = runQuery(
+                "FROM " + syntheticIndex + " METADATA _source | SORT unique_sort DESC | LIMIT 3 | KEEP _source"
+            )
+        ) {
+            List<List<Object>> rows = EsqlTestUtils.getValuesList(response);
+            assertThat(rows, hasSize(3));
+            for (int row = 0; row < rows.size(); row++) {
+                Map<?, ?> source = (Map<?, ?>) rows.get(row).getFirst();
+                assertThat(((Number) source.get("unique_sort")).longValue(), equalTo(7L - row));
+                assertThat(source.get("payload"), equalTo("payload-" + (7 - row)));
+            }
+            assertRemoteFetchRows(response, 3);
+            assertFieldLoadedBeforeFetch(response, "unique_sort");
+            assertFieldNotLoadedBeforeFetch(response, "_source");
+        }
+    }
+
     public void testNoRemoteFetchAfterAggregation() {
         try (
             EsqlQueryResponse response = runQuery(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/PlanRemoteFetch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/PlanRemoteFetch.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical;
 
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -233,6 +234,11 @@ public final class PlanRemoteFetch extends ParameterizedRule<PhysicalPlan, Physi
     }
 
     private static boolean isFetchable(Attribute attribute) {
+        if (attribute.getClass() == MetadataAttribute.class
+            && attribute.dataType() == DataType.SOURCE
+            && SourceFieldMapper.NAME.equals(attribute.name())) {
+            return true;
+        }
         if (isDirectFetchType(attribute.dataType()) == false) {
             return false;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/PlanRemoteFetchTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/PlanRemoteFetchTests.java
@@ -270,6 +270,29 @@ public class PlanRemoteFetchTests extends ESTestCase {
         assertThat(optimized.collect(RemoteFetchBoundaryExec.class), hasSize(0));
     }
 
+    public void testPlansDeferredSource() {
+        PhysicalPlan optimized = distributedPlan(
+            configuration(true, MappedFieldType.FieldExtractPreference.NONE),
+            TransportVersion.current(),
+            "FROM employees METADATA _source | SORT hire_date | LIMIT 20 | KEEP _source"
+        );
+
+        assertThat(optimized.toString(), optimized.collect(RemoteFetchBoundaryExec.class), hasSize(1));
+        List<RemoteFetchExec> fetches = optimized.collect(RemoteFetchExec.class);
+        assertThat(fetches, hasSize(1));
+        assertThat(fetches.getFirst().attributesToFetch().stream().map(Attribute::name).toList(), equalTo(List.of("_source")));
+    }
+
+    public void testDoesNotPlanArbitrarySourceTypedField() {
+        assertDeferredAttributeIsRejected(
+            new FieldAttribute(
+                Source.EMPTY,
+                "source_typed_field",
+                new EsField("source_typed_field", DataType.SOURCE, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+    }
+
     public void testPlansNormalMappedFieldImplementations() {
         List<EsField> fields = List.of(
             new KeywordEsField("deferred", Map.of(), true, 32766, false, false, EsField.TimeSeriesFieldType.NONE),


### PR DESCRIPTION
## Summary

Extends the experimental ES|QL remote-fetch path for TopN queries to support raw `METADATA _source`.

Previously, projecting `_source` caused `PlanRemoteFetch` to keep the original eager-loading plan because `DataType.SOURCE` is not a generally supported direct-fetch type. This change admits only the concrete `_source` `MetadataAttribute`; arbitrary source-typed attributes remain unsupported.

The execution path reuses the existing remote-fetch request and `SourceFieldBlockLoader`, so no transport or serialization changes are needed.

This is a follow-up to [#155628](https://github.com/elastic/elasticsearch/pull/155628).

## Testing

- Planner coverage for deferred `_source`
- Planner coverage rejecting arbitrary source-typed fields
- Stored and synthetic `_source` integration coverage
- Single-node and multi-node remote-fetch suites

```text
./gradlew :x-pack:plugin:esql:test \
  --tests org.elasticsearch.xpack.esql.optimizer.rules.physical.PlanRemoteFetchTests

./gradlew :x-pack:plugin:esql:internalClusterTest \
  --tests 'org.elasticsearch.xpack.esql.action.EsqlRemoteFetchTopN*'

./gradlew :x-pack:plugin:esql:spotlessJavaCheck
```
