### PR TITLE
Use separate thread local buffer for Streams.copy

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Streams.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Streams.java
@@ -22,7 +22,8 @@ import java.nio.ByteBuffer;
  */
 public class Streams {
 
-    private static final ThreadLocal<byte[]> LOCAL_BUFFER = ThreadLocal.withInitial(() -> new byte[8 * 1024]);
+    private static final ThreadLocal<byte[]> LOCAL_READ_BUFFER = ThreadLocal.withInitial(() -> new byte[8 * 1024]);
+    private static final ThreadLocal<byte[]> LOCAL_COPY_BUFFER = ThreadLocal.withInitial(() -> new byte[8 * 1024]);
 
     private Streams() {
 
@@ -63,7 +64,7 @@ public class Streams {
      * @see #copy(InputStream, OutputStream, byte[], boolean)
      */
     public static long copy(final InputStream in, final OutputStream out, boolean close) throws IOException {
-        return copy(in, out, LOCAL_BUFFER.get(), close);
+        return copy(in, out, LOCAL_COPY_BUFFER.get(), close);
     }
 
     /**
@@ -77,7 +78,7 @@ public class Streams {
      * @see #copy(InputStream, OutputStream, byte[], boolean)
      */
     public static long copy(final InputStream in, final OutputStream out) throws IOException {
-        return copy(in, out, LOCAL_BUFFER.get(), true);
+        return copy(in, out, LOCAL_COPY_BUFFER.get(), true);
     }
 
     /**
@@ -107,7 +108,7 @@ public class Streams {
 
     private static int readToDirectBuffer(InputStream input, ByteBuffer b, int count) throws IOException {
         int totalRead = 0;
-        final byte[] buffer = LOCAL_BUFFER.get();
+        final byte[] buffer = LOCAL_READ_BUFFER.get();
         while (totalRead < count) {
             final int len = Math.min(count - totalRead, buffer.length);
             final int read = input.read(buffer, 0, len);

--- a/libs/core/src/main/java/org/elasticsearch/core/Streams.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Streams.java
@@ -26,10 +26,10 @@ public class Streams {
     // Separate buffer for copy since a nested read within a copy on the same thread can overwrite the buffer
     private static final ThreadLocal<byte[]> LOCAL_COPY_BUFFER = ThreadLocal.withInitial(() -> new byte[8 * 1024]);
 
-    // Buffer used by read on this thread, if any. Used to assert buffer isn't used reentrantly
-    private static final ThreadLocal<byte[]> BUFFER_IN_USE_BY_READ = new ThreadLocal<>();
-    // Buffer used by copy on this thread, if any. Used to assert buffer isn't used reentrantly
-    private static final ThreadLocal<byte[]> BUFFER_IN_USE_BY_COPY = new ThreadLocal<>();
+    // Flag used to assert copy isn't called reentrantly
+    private static final ThreadLocal<Boolean> COPY_IN_USE = Assertions.ENABLED ? new ThreadLocal<>() : null;
+    // Flag used to assert read isn't called reentrantly
+    private static final ThreadLocal<Boolean> READ_IN_USE = Assertions.ENABLED ? new ThreadLocal<>() : null;
 
     private Streams() {
 
@@ -46,9 +46,7 @@ public class Streams {
      * @throws IOException in case of I/O errors
      */
     public static long copy(final InputStream in, final OutputStream out, byte[] buffer, boolean close) throws IOException {
-        final byte[] previouslyInUseByCopy = BUFFER_IN_USE_BY_COPY.get();
-        assert previouslyInUseByCopy != buffer : "Streams.copy re-entered with the same buffer on " + Thread.currentThread().getName();
-        BUFFER_IN_USE_BY_COPY.set(buffer);
+        assert assertEnter(COPY_IN_USE, "Streams.copy");
         Exception err = null;
         try {
             long byteCount = 0;
@@ -63,11 +61,7 @@ public class Streams {
             err = e;
             throw e;
         } finally {
-            if (previouslyInUseByCopy == null) {
-                BUFFER_IN_USE_BY_COPY.remove();
-            } else {
-                BUFFER_IN_USE_BY_COPY.set(previouslyInUseByCopy);
-            }
+            assert assertExit(COPY_IN_USE, "Streams.copy");
             if (close) {
                 IOUtils.close(err, in, out);
             }
@@ -121,10 +115,8 @@ public class Streams {
     }
 
     private static int readToDirectBuffer(InputStream input, ByteBuffer b, int count) throws IOException {
+        assert assertEnter(READ_IN_USE, "Streams.read");
         final byte[] buffer = LOCAL_READ_BUFFER.get();
-        final byte[] previouslyInUseByRead = BUFFER_IN_USE_BY_READ.get();
-        assert previouslyInUseByRead != buffer : "Streams.read re-entered with the same buffer on " + Thread.currentThread().getName();
-        BUFFER_IN_USE_BY_READ.set(buffer);
         try {
             int totalRead = 0;
             while (totalRead < count) {
@@ -138,12 +130,22 @@ public class Streams {
             }
             return totalRead;
         } finally {
-            if (previouslyInUseByRead == null) {
-                BUFFER_IN_USE_BY_READ.remove();
-            } else {
-                BUFFER_IN_USE_BY_READ.set(previouslyInUseByRead);
-            }
+            assert assertExit(READ_IN_USE, "Streams.read");
         }
+    }
+
+    // Mark flag as in-use for this thread, only invoked when assertions enabled
+    private static boolean assertEnter(ThreadLocal<Boolean> flag, String operation) {
+        assert flag.get() != Boolean.TRUE : operation + " re-entered on " + Thread.currentThread().getName();
+        flag.set(Boolean.TRUE);
+        return true;
+    }
+
+    // Clears the in-use flag, only invoked when assertions enabled
+    private static boolean assertExit(ThreadLocal<Boolean> flag, String operation) {
+        assert flag.get() == Boolean.TRUE : operation + " exited without matching enter on " + Thread.currentThread().getName();
+        flag.remove();
+        return true;
     }
 
     public static int readFully(InputStream reader, byte[] dest) throws IOException {

--- a/libs/core/src/main/java/org/elasticsearch/core/Streams.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Streams.java
@@ -26,9 +26,9 @@ public class Streams {
     // Separate buffer for copy since a nested read within a copy on the same thread can overwrite the buffer
     private static final ThreadLocal<byte[]> LOCAL_COPY_BUFFER = ThreadLocal.withInitial(() -> new byte[8 * 1024]);
 
-    // Flag used to assert copy isn't called reentrantly
+    // Flag used to assert LOCAL_COPY_BUFFER isn't used reentrantly
     private static final ThreadLocal<Boolean> COPY_IN_USE = Assertions.ENABLED ? new ThreadLocal<>() : null;
-    // Flag used to assert read isn't called reentrantly
+    // Flag used to assert LOCAL_READ_BUFFER isn't used reentrantly
     private static final ThreadLocal<Boolean> READ_IN_USE = Assertions.ENABLED ? new ThreadLocal<>() : null;
 
     private Streams() {
@@ -46,7 +46,6 @@ public class Streams {
      * @throws IOException in case of I/O errors
      */
     public static long copy(final InputStream in, final OutputStream out, byte[] buffer, boolean close) throws IOException {
-        assert assertEnter(COPY_IN_USE, "Streams.copy");
         Exception err = null;
         try {
             long byteCount = 0;
@@ -61,7 +60,6 @@ public class Streams {
             err = e;
             throw e;
         } finally {
-            assert assertExit(COPY_IN_USE, "Streams.copy");
             if (close) {
                 IOUtils.close(err, in, out);
             }
@@ -72,7 +70,12 @@ public class Streams {
      * @see #copy(InputStream, OutputStream, byte[], boolean)
      */
     public static long copy(final InputStream in, final OutputStream out, boolean close) throws IOException {
-        return copy(in, out, LOCAL_COPY_BUFFER.get(), close);
+        assert assertEnter(COPY_IN_USE, "Streams.copy");
+        try {
+            return copy(in, out, LOCAL_COPY_BUFFER.get(), close);
+        } finally {
+            assert assertExit(COPY_IN_USE, "Streams.copy");
+        }
     }
 
     /**
@@ -86,7 +89,7 @@ public class Streams {
      * @see #copy(InputStream, OutputStream, byte[], boolean)
      */
     public static long copy(final InputStream in, final OutputStream out) throws IOException {
-        return copy(in, out, LOCAL_COPY_BUFFER.get(), true);
+        return copy(in, out, true);
     }
 
     /**

--- a/libs/core/src/main/java/org/elasticsearch/core/Streams.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Streams.java
@@ -23,7 +23,13 @@ import java.nio.ByteBuffer;
 public class Streams {
 
     private static final ThreadLocal<byte[]> LOCAL_READ_BUFFER = ThreadLocal.withInitial(() -> new byte[8 * 1024]);
+    // Separate buffer for copy since a nested read within a copy on the same thread can overwrite the buffer
     private static final ThreadLocal<byte[]> LOCAL_COPY_BUFFER = ThreadLocal.withInitial(() -> new byte[8 * 1024]);
+
+    // Buffer used by read on this thread, if any. Used to assert buffer isn't used reentrantly
+    private static final ThreadLocal<byte[]> BUFFER_IN_USE_BY_READ = new ThreadLocal<>();
+    // Buffer used by copy on this thread, if any. Used to assert buffer isn't used reentrantly
+    private static final ThreadLocal<byte[]> BUFFER_IN_USE_BY_COPY = new ThreadLocal<>();
 
     private Streams() {
 
@@ -40,6 +46,9 @@ public class Streams {
      * @throws IOException in case of I/O errors
      */
     public static long copy(final InputStream in, final OutputStream out, byte[] buffer, boolean close) throws IOException {
+        final byte[] previouslyInUseByCopy = BUFFER_IN_USE_BY_COPY.get();
+        assert previouslyInUseByCopy != buffer : "Streams.copy re-entered with the same buffer on " + Thread.currentThread().getName();
+        BUFFER_IN_USE_BY_COPY.set(buffer);
         Exception err = null;
         try {
             long byteCount = 0;
@@ -54,6 +63,11 @@ public class Streams {
             err = e;
             throw e;
         } finally {
+            if (previouslyInUseByCopy == null) {
+                BUFFER_IN_USE_BY_COPY.remove();
+            } else {
+                BUFFER_IN_USE_BY_COPY.set(previouslyInUseByCopy);
+            }
             if (close) {
                 IOUtils.close(err, in, out);
             }
@@ -107,18 +121,29 @@ public class Streams {
     }
 
     private static int readToDirectBuffer(InputStream input, ByteBuffer b, int count) throws IOException {
-        int totalRead = 0;
         final byte[] buffer = LOCAL_READ_BUFFER.get();
-        while (totalRead < count) {
-            final int len = Math.min(count - totalRead, buffer.length);
-            final int read = input.read(buffer, 0, len);
-            if (read == -1) {
-                break;
+        final byte[] previouslyInUseByRead = BUFFER_IN_USE_BY_READ.get();
+        assert previouslyInUseByRead != buffer : "Streams.read re-entered with the same buffer on " + Thread.currentThread().getName();
+        BUFFER_IN_USE_BY_READ.set(buffer);
+        try {
+            int totalRead = 0;
+            while (totalRead < count) {
+                final int len = Math.min(count - totalRead, buffer.length);
+                final int read = input.read(buffer, 0, len);
+                if (read == -1) {
+                    break;
+                }
+                b.put(buffer, 0, read);
+                totalRead += read;
             }
-            b.put(buffer, 0, read);
-            totalRead += read;
+            return totalRead;
+        } finally {
+            if (previouslyInUseByRead == null) {
+                BUFFER_IN_USE_BY_READ.remove();
+            } else {
+                BUFFER_IN_USE_BY_READ.set(previouslyInUseByRead);
+            }
         }
-        return totalRead;
     }
 
     public static int readFully(InputStream reader, byte[] dest) throws IOException {

--- a/libs/core/src/test/java/org/elasticsearch/core/StreamsTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/StreamsTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -28,5 +30,33 @@ public class StreamsTests extends ESTestCase {
 
         assertThat(count, equalTo((long) content.length));
         assertThat(Arrays.equals(content, out.toByteArray()), equalTo(true));
+    }
+
+    public void testCopyWithNestedStreamsReadOnSameThread() throws IOException {
+        final byte[] content = randomByteArrayOfLength(randomIntBetween(2, 5) * 8 * 1024);
+        final ByteBuffer readBuffer = ByteBuffer.allocateDirect(8 * 1024);
+        final InputStream in = new InputStream() {
+            private final ByteArrayInputStream delegate = new ByteArrayInputStream(content);
+
+            @Override
+            public int read() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                final int n = delegate.read(b, off, len);
+                if (n > 0) {
+                    readBuffer.clear();
+                    // Will overwrite the copy buffer if copy/read share one ThreadLocal buffer
+                    Streams.read(new ByteArrayInputStream(new byte[readBuffer.remaining()]), readBuffer, readBuffer.remaining());
+                }
+                return n;
+            }
+        };
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream(content.length);
+        assertThat(Streams.copy(in, out, false), equalTo((long) content.length));
+        assertArrayEquals(content, out.toByteArray());
     }
 }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -601,9 +601,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessRealTimeGetIT
   method: testDataVisibility
   issue: https://github.com/elastic/elasticsearch/issues/157732
-- class: org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotResiliencyWithReadFromObjectStoreTests
-  method: testSuccessfulSnapshotWithConcurrentDynamicMappingUpdates
-  issue: https://github.com/elastic/elasticsearch/issues/157733
 - class: org.elasticsearch.index.mapper.SyntheticVersusColumnarStoredSourceIT
   method: testFallbackMultiValueViolationRestoredIdenticallyAcrossSourceModes
   issue: https://github.com/elastic/elasticsearch/issues/157799
@@ -616,9 +613,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeohexTests
   method: testEvaluateInManyThreads {TestCase=geo_shape with literal precision and bounds}
   issue: https://github.com/elastic/elasticsearch/issues/157840
-- class: org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotResiliencyTests
-  method: testSuccessfulSnapshotWithConcurrentDynamicMappingUpdates
-  issue: https://github.com/elastic/elasticsearch/issues/157844
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
   method: testMixedOperationsDuringSplit
   issue: https://github.com/elastic/elasticsearch/issues/157847

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -726,6 +726,7 @@ public class SnapshotResiliencyTestHelper {
                 new TransportFetchPhaseResponseChunkAction(transportService, activeFetchPhaseTasks, namedWriteableRegistry);
                 Map<ActionType<?>, TransportAction<?, ?>> actions = new HashMap<>();
 
+                shardStateAction = new ShardStateAction(clusterService, transportService, allocationService, rerouteService, threadPool);
                 // Inject initialization from subclass which may be needed by initializations after this point.
                 doInit(actions, actionFilters);
 
@@ -737,7 +738,6 @@ public class SnapshotResiliencyTestHelper {
                     indicesService,
                     createSnapshotShardContextFactory()
                 );
-                shardStateAction = new ShardStateAction(clusterService, transportService, allocationService, rerouteService, threadPool);
                 nodeConnectionsService = new NodeConnectionsService(clusterService.getSettings(), threadPool, transportService);
                 actions.put(
                     TransportUpdateSnapshotStatusAction.TYPE,

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -67,6 +67,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
@@ -1198,7 +1199,11 @@ public class SnapshotResiliencyTests extends ESTestCase {
             documentCountVerified.set(true);
         });
 
-        runUntil(documentCountVerified::get, TimeUnit.MINUTES.toMillis(5L));
+        MockLog.assertThatLogger(
+            () -> runUntil(documentCountVerified::get, TimeUnit.MINUTES.toMillis(5L)),
+            Engine.class,
+            new MockLog.UnseenEventExpectation("no failed engine", Engine.class.getName(), Level.WARN, "*failed engine*")
+        );
 
         assertNotNull(safeResult(createSnapshotResponseStepListener));
         assertNotNull(safeResult(restoreSnapshotResponseStepListener));

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheBlobReaderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheBlobReaderTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.support.FilterBlobContainer;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.CountingFilterInputStream;
@@ -28,10 +29,13 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.RatioValue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -47,11 +51,13 @@ import org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommit;
 import org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitTestUtils;
 import org.elasticsearch.xpack.stateless.engine.PrimaryTermAndGeneration;
 import org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput;
+import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryMetrics;
 import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryTestUtils;
 import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
 import org.elasticsearch.xpack.stateless.lucene.StatelessCommitRef;
 import org.elasticsearch.xpack.stateless.test.FakeStatelessNode;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -62,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -399,6 +406,83 @@ public class CacheBlobReaderTests extends ESTestCase {
             assert false : e;
         }
         return 0; // cannot happen
+    }
+
+    public void testGetBytesByRangeThroughColdBlobCacheIndexInput() throws Exception {
+        final var primaryTerm = randomLongBetween(1L, 10L);
+        // Larger than Streams read buffer
+        final long minimumVbccSize = 8 * 1024 + 1;
+        try (
+            var node = new FakeVBCCStatelessNode(
+                this::newEnvironment,
+                this::newNodeEnvironment,
+                xContentRegistry(),
+                primaryTerm,
+                minimumVbccSize
+            ) {
+                @Override
+                protected StatelessSharedBlobCacheService createCacheService(
+                    NodeEnvironment nodeEnvironment,
+                    Settings settings,
+                    ThreadPool threadPool,
+                    MeterRegistry meterRegistry
+                ) {
+                    return new StatelessSharedBlobCacheService(
+                        nodeEnvironment,
+                        settings,
+                        threadPool,
+                        meterRegistry == null ? new BlobCacheMetrics(MeterRegistry.NOOP) : new BlobCacheMetrics(meterRegistry),
+                        clusterService,
+                        TestUtils.mockIndicesService(clusterService),
+                        new ThreadLocalDirectoryMetricHolder<>(BlobStoreCacheDirectoryMetrics::new)
+                    ) {
+                        @Override
+                        public Executor getShardReadThreadPoolExecutor() {
+                            // Ensure Streams.copy and nested Streams.read called on same thread
+                            return EsExecutors.DIRECT_EXECUTOR_SERVICE;
+                        }
+                    };
+                }
+            }
+        ) {
+            var vbcc = node.virtualBatchedCompoundCommit;
+            // uploadVirtualBatchedCompoundCommit() decRefs, keep the VBCC alive
+            vbcc.incRef();
+            final long vbccSize = vbcc.getTotalSizeInBytes();
+            assertThat(vbccSize, greaterThan(8 * 1024L));
+
+            final BytesStreamOutput expected = new BytesStreamOutput(Math.toIntExact(vbccSize));
+            vbcc.getBytesByRange(0, vbccSize, expected);
+
+            final BatchedCompoundCommit bcc = node.uploadVirtualBatchedCompoundCommit();
+
+            final Map<String, BlobFileRanges> blobFileRanges = new HashMap<>();
+            for (var entry : vbcc.getInternalLocations().entrySet()) {
+                blobFileRanges.put(entry.getKey(), new BlobFileRanges(entry.getValue()));
+            }
+            node.indexingDirectory.updateCommit(
+                bcc.lastCompoundCommit().generation(),
+                vbccSize,
+                blobFileRanges.keySet(),
+                blobFileRanges
+            );
+
+            // Drop local map entries so PreferLocal falls through to BlobCacheIndexInput while VBCC stays open
+            for (String fileName : Set.copyOf(blobFileRanges.keySet())) {
+                try {
+                    node.indexingDirectory.deleteFile(fileName);
+                } catch (FileNotFoundException e) {
+                    // already gone
+                }
+            }
+            node.sharedCacheService.forceEvict(key -> true);
+
+            final int blobReadsBefore = node.getBlobReads();
+            final BytesStreamOutput actual = new BytesStreamOutput(Math.toIntExact(vbccSize));
+            vbcc.getBytesByRange(0, vbccSize, actual);
+            assertThat(node.getBlobReads(), greaterThan(blobReadsBefore));
+            assertArrayEquals(BytesReference.toBytes(expected.bytes()), BytesReference.toBytes(actual.bytes()));
+        }
     }
 
     public void testCacheBlobReaderFetchFromIndexingAndSwitchToBlobStore() throws Exception {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheBlobReaderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheBlobReaderTests.java
@@ -460,12 +460,7 @@ public class CacheBlobReaderTests extends ESTestCase {
             for (var entry : vbcc.getInternalLocations().entrySet()) {
                 blobFileRanges.put(entry.getKey(), new BlobFileRanges(entry.getValue()));
             }
-            node.indexingDirectory.updateCommit(
-                bcc.lastCompoundCommit().generation(),
-                vbccSize,
-                blobFileRanges.keySet(),
-                blobFileRanges
-            );
+            node.indexingDirectory.updateCommit(bcc.lastCompoundCommit().generation(), vbccSize, blobFileRanges.keySet(), blobFileRanges);
 
             // Drop local map entries so PreferLocal falls through to BlobCacheIndexInput while VBCC stays open
             for (String fileName : Set.copyOf(blobFileRanges.keySet())) {


### PR DESCRIPTION
`testSuccessfulSnapshotWithConcurrentDynamicMappingUpdates` failed because `Streams.read()` can be nested in  `Streams.copy()`, and since the test uses a deterministic task queue they can happen on the same thread.

`Streams.copy()` does:
```
            while ((bytesRead = in.read(buffer)) != -1) {
                out.write(buffer, 0, bytesRead);
                byteCount += bytesRead;
            }
```
so if `in.read(buffer)` calls `Streams.read()` it can overwrite the thread local `buffer` and mess up the final result. In the test this led to a Lucene corruption error.

Here's the full stack trace of the `Streams.read()` nested in `Streams.copy()`:

```
        at org.elasticsearch.core.Streams.readToDirectBuffer(Streams.java:158)
        at org.elasticsearch.core.Streams.read(Streams.java:140)
        at org.elasticsearch.blobcache.shared.SharedBytes.copyToCacheFileAligned(SharedBytes.java:250)
        at org.elasticsearch.xpack.stateless.cache.reader.SequentialRangeMissingHandler.lambda$fillCacheRange$0(SequentialRangeMissingHandler.java:202)
        at org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.lambda$map$0(ActionListenerImplementations.java:124)
        at org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:105)
        at org.elasticsearch.action.ActionListenerImplementations$RunAfterActionListener.onResponse(ActionListenerImplementations.java:312)
        at org.elasticsearch.action.ActionListener$3.onResponse(ActionListener.java:438)
        at org.elasticsearch.xpack.stateless.cache.reader.SequentialRangeMissingHandler.lambda$createInputStream$2(SequentialRangeMissingHandler.java:230)
        at org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
        at org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:111)
        at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:58)
        at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:55)
        at org.elasticsearch.action.ActionRunnable$4.doRun(ActionRunnable.java:101)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:323)
        at org.elasticsearch.xpack.stateless.cache.reader.ObjectStoreCacheBlobReader.getRangeInputStream(ObjectStoreCacheBlobReader.java:56)
        at org.elasticsearch.xpack.stateless.cache.reader.MeteringCacheBlobReader.getRangeInputStream(MeteringCacheBlobReader.java:41)
        at org.elasticsearch.xpack.stateless.cache.reader.SequentialRangeMissingHandler.inputStreamFromCacheBlobReader(SequentialRangeMissingHandler.java:248)
        at org.elasticsearch.xpack.stateless.cache.reader.SequentialRangeMissingHandler.createInputStream(SequentialRangeMissingHandler.java:216)
        at org.elasticsearch.xpack.stateless.cache.reader.SequentialRangeMissingHandler.fillCacheRange(SequentialRangeMissingHandler.java:199)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile$1.fillCacheRange(SharedBlobCacheService.java:1887)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile$3.fillCacheRange(SharedBlobCacheService.java:2048)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$DelegatingRangeMissingHandler.fillCacheRange(SharedBlobCacheService.java:2214)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFileRegion.lambda$fillGapRunnable$8(SharedBlobCacheService.java:1545)
        at org.elasticsearch.action.ActionListener.run(ActionListener.java:490)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFileRegion.lambda$fillGapRunnable$9(SharedBlobCacheService.java:1540)
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:323)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFileRegion.populateAndRead(SharedBlobCacheService.java:1512)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile.readSingleRegion(SharedBlobCacheService.java:1938)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile.populate(SharedBlobCacheService.java:1915)
        at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile.populateAndRead(SharedBlobCacheService.java:1835)
        at org.elasticsearch.xpack.stateless.cache.reader.CacheFileReader.doRead(CacheFileReader.java:569)
        at org.elasticsearch.xpack.stateless.cache.reader.CacheFileReader.read(CacheFileReader.java:519)
        at org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput.readInternalSlow(BlobCacheIndexInput.java:280)
        at org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput.doReadInternal(BlobCacheIndexInput.java:265)
        at org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput.readInternal(BlobCacheIndexInput.java:218)
        at org.elasticsearch.blobcache.common.BlobCacheBufferedIndexInput.readBytes(BlobCacheBufferedIndexInput.java:133)
        at org.elasticsearch.common.lucene.store.InputStreamIndexInput.read(InputStreamIndexInput.java:62)
        at java.base/java.io.InputStream.read(InputStream.java:222)
        at org.elasticsearch.core.Streams.copy(Streams.java:85)
```

The fix is to use a separate thread local buffer for copy. ~~This wouldn't happen in production, but I think the memory footprint of an additional 8KB per thread that touches `Streams.copy` is minimal, though I'm open to other ideas.~~

In the original test the failure came from a NPE. `StatelessSnapshotResiliencyTests.StatelessNode.doInit` constructs `TransportNewCommitNotificationAction` and `TransportShardRefreshAction` which use an uninitialized `shardStateAction`, leading to a NPE when the test tried to fail the shard. I added the fix to construct shardStateAction before doInit is called. With this fix, the test wouldn't fail anymore due to the shard recovering upon the Lucene error, so I updated the test to assert we don't see any engine failure logs.

Resolves #157733
Resolves #157844