### PR TITLE
[TEST] Guard batch-mode bulk test behind feature flag

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -723,9 +723,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testBlobsNotDeletedDuringFailedRelocation
   issue: https://github.com/elastic/elasticsearch/issues/158959
-- class: org.elasticsearch.action.bulk.BulkOperationTests
-  method: testTsdbTimestampErrorDuringRoutingRedirectsToFailureStoreBatchMode
-  issue: https://github.com/elastic/elasticsearch/issues/159019
 - class: org.elasticsearch.action.fieldcaps.FieldCapsWithFilterIT
   method: testSkipUnmatchedShards
   issue: https://github.com/elastic/elasticsearch/issues/159021

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
@@ -311,6 +311,7 @@ public class BulkOperationTests extends ESTestCase {
      * paths exercise the same {@code catch (DataStream.TimestampError)} block and produce identical behavior.
      */
     public void testTsdbTimestampErrorDuringRoutingRedirectsToFailureStoreBatchMode() throws Exception {
+        assumeTrue("batch indexing requires the batch_indexing feature flag", BatchIndexingEnabled.FEATURE_FLAG.isEnabled());
         Instant start = Instant.parse("2020-01-01T00:00:00Z");
         Instant end = Instant.parse("2021-01-01T00:00:00Z");
         String tsdbStreamName = "my_tsdb_stream_batch";


### PR DESCRIPTION
## Summary
* Skip `BulkOperationTests#testTsdbTimestampErrorDuringRoutingRedirectsToFailureStoreBatchMode` when the `batch_indexing` feature flag is off (non-snapshot / release builds), matching `ShardBatchIndexerCanUseBatchTests`.
* Unmute the test for #159019.

Fixes #159019

## Test plan
- [x] `./gradlew :server:test --tests org.elasticsearch.action.bulk.BulkOperationTests.testTsdbTimestampErrorDuringRoutingRedirectsToFailureStoreBatchMode -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false"` → skipped via assumeTrue
- [x] Same test on snapshot build → passes


Made with [Cursor](https://cursor.com)