### PR TITLE
Read a keyword column value mode from the column

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/ColumnarPayloadSortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ColumnarPayloadSortedBinaryDocValues.java
@@ -14,6 +14,8 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringColumnReader;
+import org.elasticsearch.columnar.string.StringColumnSource;
 
 import java.io.IOException;
 
@@ -29,13 +31,44 @@ public final class ColumnarPayloadSortedBinaryDocValues extends SortingBinaryDoc
 
     private final BinaryDocValues binary;
     private final StringBinaryPayload.Decoder decoder = new StringBinaryPayload.Decoder();
+    private final Sparsity sparsity;
+    private final ValueMode valueMode;
 
     public ColumnarPayloadSortedBinaryDocValues(BinaryDocValues binary) {
+        this(binary, Sparsity.UNKNOWN, ValueMode.UNKNOWN);
+    }
+
+    private ColumnarPayloadSortedBinaryDocValues(BinaryDocValues binary, Sparsity sparsity, ValueMode valueMode) {
         this.binary = binary;
+        this.sparsity = sparsity;
+        this.valueMode = valueMode;
     }
 
     public static ColumnarPayloadSortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName) throws IOException {
-        return new ColumnarPayloadSortedBinaryDocValues(DocValues.getBinary(leafReader, valuesFieldName));
+        final BinaryDocValues binary = DocValues.getBinary(leafReader, valuesFieldName);
+        // A column records both of these, so neither costs a walk over the documents. A segment that arrives
+        // as an overlay records neither and leaves them unknown.
+        if (binary instanceof StringColumnSource source) {
+            final StringColumnReader column = source.reader();
+            return new ColumnarPayloadSortedBinaryDocValues(
+                binary,
+                column.numDocsWithField() == leafReader.maxDoc() ? Sparsity.DENSE : Sparsity.SPARSE,
+                // No value addresses means one slot a document, so none holds two. A null slot is no value,
+                // which single valued allows: it says at most one.
+                column.hasValueAddresses() ? ValueMode.UNKNOWN : ValueMode.SINGLE_VALUED
+            );
+        }
+        return new ColumnarPayloadSortedBinaryDocValues(binary);
+    }
+
+    @Override
+    public Sparsity getSparsity() {
+        return sparsity;
+    }
+
+    @Override
+    public ValueMode getValueMode() {
+        return valueMode;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ColumnarPayloadSortedBinaryDocValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ColumnarPayloadSortedBinaryDocValuesTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.columnar.ColumNARDocValuesFormat;
+import org.elasticsearch.columnar.ColumnarFieldType;
+import org.elasticsearch.columnar.string.StringBinaryPayload;
+import org.elasticsearch.columnar.string.StringColumnSource;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * What a column says about its own shape, which is what lets a single value check rewrite itself away
+ * rather than ask every document.
+ */
+public class ColumnarPayloadSortedBinaryDocValuesTests extends ESTestCase {
+
+    private static final String FIELD = "kw";
+
+    public void testOneSlotADocumentIsSingleValued() throws IOException {
+        withColumn(new String[][] { { "a" }, { "b" }, { "c" } }, values -> {
+            assertEquals(SortedBinaryDocValues.ValueMode.SINGLE_VALUED, values.getValueMode());
+            assertEquals(SortedBinaryDocValues.Sparsity.DENSE, values.getSparsity());
+        });
+    }
+
+    /** A null slot is no value, and single valued says at most one, so a column holding them still qualifies. */
+    public void testANullSlotIsStillSingleValued() throws IOException {
+        withColumn(new String[][] { { "a" }, { null }, { "c" } }, values -> {
+            assertEquals(SortedBinaryDocValues.ValueMode.SINGLE_VALUED, values.getValueMode());
+        });
+    }
+
+    public void testASecondSlotIsNotSingleValued() throws IOException {
+        withColumn(new String[][] { { "a" }, { "b", "c" } }, values -> {
+            assertNotEquals(SortedBinaryDocValues.ValueMode.SINGLE_VALUED, values.getValueMode());
+        });
+    }
+
+    /** A document the field is absent from leaves the column short of the segment, which is sparse. */
+    public void testAColumnMissingDocumentsIsSparse() throws IOException {
+        withColumn(new String[][] { { "a" }, null, { "c" } }, values -> {
+            assertEquals(SortedBinaryDocValues.Sparsity.SPARSE, values.getSparsity());
+        });
+    }
+
+    private interface Check {
+        void check(SortedBinaryDocValues values) throws IOException;
+    }
+
+    /** {@code null} in place of a document's slots writes no field for it at all. */
+    private void withColumn(String[][] docs, Check check) throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig().setCodec(columnarCodec()))) {
+                for (String[] slots : docs) {
+                    final Document doc = new Document();
+                    if (slots != null) {
+                        doc.add(new Field(FIELD, encode(slots), binaryDocValuesType()));
+                    }
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final LeafReader leaf = reader.leaves().get(0).reader();
+                assertThat("the field is a column", leaf.getBinaryDocValues(FIELD), instanceOf(StringColumnSource.class));
+                check.check(ColumnarPayloadSortedBinaryDocValues.from(leaf, FIELD));
+            }
+        }
+    }
+
+    private static BytesRef encode(String[] slots) {
+        final BytesRef[] refs = new BytesRef[slots.length];
+        for (int i = 0; i < slots.length; i++) {
+            refs[i] = slots[i] == null ? null : new BytesRef(slots[i]);
+        }
+        return BytesRef.deepCopyOf(new StringBinaryPayload.Builder().encode(Arrays.asList(refs)));
+    }
+
+    private static FieldType binaryDocValuesType() {
+        final FieldType type = new FieldType();
+        type.setDocValuesType(DocValuesType.BINARY);
+        type.freeze();
+        return type;
+    }
+
+    private static Codec columnarCodec() {
+        final Codec base = TestUtil.getDefaultCodec();
+        final DocValuesFormat columnar = new ColumNARDocValuesFormat(field -> ColumnarFieldType.STRING);
+        return new FilterCodec(base.getName(), base) {
+            private final DocValuesFormat perField = new PerFieldDocValuesFormat() {
+                @Override
+                public DocValuesFormat getDocValuesFormatForField(String field) {
+                    return columnar;
+                }
+            };
+
+            @Override
+            public DocValuesFormat docValuesFormat() {
+                return perField;
+            }
+        };
+    }
+}


### PR DESCRIPTION
`SingleValueMatchQuery` checks that each document holds at most one value before ES|QL reads a field, and skips the check on a leaf that answers single valued and dense. A columnar keyword field answered neither, so the check ran against every document, and answering it rebuilt that document's payload out of the column and took it apart again to count the values it held.

The column records how many documents it holds and whether any of them has a second slot, so both answers are read from its metadata. This is what the separate-count binary format already does through its counts skipper.
