### PR TITLE
ESQL: Fix Windows URI in secret decryption IT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -186,9 +186,6 @@ tests:
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/150356
-- class: org.elasticsearch.xpack.esql.action.FileSourceSecretDecryptionAcrossNodesIT
-  method: testJoinedDataNodeDecryptsTheSecret
-  issue: https://github.com/elastic/elasticsearch/issues/150440
 - class: org.elasticsearch.upgrades.TransformSurvivesUpgradeIT
   method: testTransformRollingUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/150442

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FileSourceSecretDecryptionAcrossNodesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FileSourceSecretDecryptionAcrossNodesIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
 import org.elasticsearch.xpack.esql.datasources.datasource.TestEncryptionServicePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
@@ -174,7 +175,7 @@ public class FileSourceSecretDecryptionAcrossNodesIT extends AbstractEsqlIntegTe
                 )
             )
         );
-        String uri = SCHEME + "://" + fixture.toAbsolutePath();
+        String uri = SCHEME + "://" + StoragePath.fileUri(fixture).substring("file://".length());
         assertAcked(
             client().execute(
                 PutDatasetAction.INSTANCE,


### PR DESCRIPTION
`FileSourceSecretDecryptionAcrossNodesIT` built its dataset location by concatenating a raw Windows `Path` into a custom-scheme URI, giving `teststorexn://C:\Users\...`. `StoragePath.of` only normalizes backslashes and folds the drive letter back into the path for the `file` scheme, so on Windows `C:` was parsed as the authority and the backslash tail as an invalid port. The sibling tests already build the location through `StoragePath.fileUri`, which yields `teststorexn:///C:/Users/...`; this test now does the same. No behavior change on POSIX, where both forms produce the identical string.

Unmutes the test. Passed locally on macOS.

Closes #150440
