### PR TITLE
[9.5] [ESQL] Fix multifile check in windows (#158052)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -485,6 +485,3 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/156244
 - class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
   issue: https://github.com/elastic/elasticsearch/issues/158953
-- class: org.elasticsearch.xpack.esql.action.ExternalCsvHivePartitionedIT
-  method: testCommaSeparatedResourceFirstFileWinsRoundTrips
-  issue: https://github.com/elastic/elasticsearch/issues/159022

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/LocalFileAccess.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/LocalFileAccess.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.nio.file.Path;
@@ -102,6 +103,14 @@ public class LocalFileAccess {
      * @throws IllegalArgumentException if the path is rejected
      */
     public void check(StoragePath path) {
+        // A comma-separated multi-file listing (e.g. file:///a.csv,file:///b.csv) is not one filesystem path: parsing
+        // the whole string as a single Path fails on filesystems that reject when a separator carries an embedded segment,
+        // e.g. ':' on Windows.
+        var segments = GlobExpander.commaSegments(path.toString());
+        if (segments.size() > 1) {
+            segments.stream().map(StoragePath::of).forEach(this::check);
+            return;
+        }
         if ("file".equalsIgnoreCase(path.scheme()) == false) {
             return;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
@@ -615,7 +615,7 @@ public final class GlobExpander {
      * ({@link #doExpandCommaSeparated}) and the identity that names its result ({@link #effectiveWholePathPattern}),
      * so the two cannot disagree on which segments a path has.
      */
-    private static List<String> commaSegments(String pathList) {
+    public static List<String> commaSegments(String pathList) {
         String[] raw = pathList.split(",");
         List<String> segments = new ArrayList<>(raw.length);
         for (String segment : raw) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/LocalFileAccessTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/LocalFileAccessTests.java
@@ -163,7 +163,7 @@ public class LocalFileAccessTests extends ESTestCase {
 
     public void testCommaListingAllSegmentsUnderAllowedRootSucceeds() throws IOException {
         Path allowed = createTempDir();
-        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        Settings settings = Settings.builder().putList("esql.datasource.local_allowed_paths", allowed.toString()).build();
         LocalFileAccess access = LocalFileAccess.create(settings);
 
         Path a = allowed.resolve("a.csv");
@@ -179,7 +179,7 @@ public class LocalFileAccessTests extends ESTestCase {
 
     public void testDuplicateListingUnderAllowedRootSucceeds() throws IOException {
         Path allowed = createTempDir();
-        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        Settings settings = Settings.builder().putList("esql.datasource.local_allowed_paths", allowed.toString()).build();
         LocalFileAccess access = LocalFileAccess.create(settings);
 
         Path file = allowed.resolve("dupes.csv");
@@ -193,7 +193,7 @@ public class LocalFileAccessTests extends ESTestCase {
     public void testCommaListingWithOneSegmentOutsideRootRejected() throws IOException {
         Path allowed = createTempDir();
         Path outside = createTempDir();
-        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        Settings settings = Settings.builder().putList("esql.datasource.local_allowed_paths", allowed.toString()).build();
         LocalFileAccess access = LocalFileAccess.create(settings);
 
         Path allowedFile = allowed.resolve("a.csv");
@@ -204,13 +204,13 @@ public class LocalFileAccessTests extends ESTestCase {
         // one. Validating only the whole (or first) string left this gap.
         String listing = "file://" + allowedFile.toAbsolutePath() + ",file://" + outsideFile.toAbsolutePath();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> access.check(StoragePath.of(listing)));
-        assertThat(e.getMessage(), containsString("esql.external.local_allowed_paths"));
+        assertThat(e.getMessage(), containsString("esql.datasource.local_allowed_paths"));
         assertThat(e.getMessage(), containsString(outsideFile.toAbsolutePath().toString()));
     }
 
     public void testCommaListingMixingLiteralAndGlobUnderRootSucceeds() throws IOException {
         Path allowed = createTempDir();
-        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        Settings settings = Settings.builder().putList("esql.datasource.local_allowed_paths", allowed.toString()).build();
         LocalFileAccess access = LocalFileAccess.create(settings);
 
         Path literal = allowed.resolve("a.csv");
@@ -226,7 +226,7 @@ public class LocalFileAccessTests extends ESTestCase {
             IllegalArgumentException.class,
             () -> access.check(StoragePath.of("file:///some/a.csv,file:///some/b.csv"))
         );
-        assertThat(e.getMessage(), containsString("esql.external.local_allowed_paths"));
+        assertThat(e.getMessage(), containsString("esql.datasource.local_allowed_paths"));
     }
 
     // --- UNRESTRICTED sentinel ---

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/LocalFileAccessTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/LocalFileAccessTests.java
@@ -159,6 +159,76 @@ public class LocalFileAccessTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("esql.datasource.local_allowed_paths"));
     }
 
+    // --- Comma-separated multi-file listings ---
+
+    public void testCommaListingAllSegmentsUnderAllowedRootSucceeds() throws IOException {
+        Path allowed = createTempDir();
+        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        LocalFileAccess access = LocalFileAccess.create(settings);
+
+        Path a = allowed.resolve("a.csv");
+        Path b = allowed.resolve("b.csv");
+        Files.createFile(a);
+        Files.createFile(b);
+        // A comma listing must be gated per segment, not parsed as a single filesystem path — the latter throws
+        // InvalidPathException on Windows on the second segment's drive-letter/scheme ':'. Both segments are allowed.
+        String listing = "file://" + a.toAbsolutePath() + ",file://" + b.toAbsolutePath();
+        access.check(StoragePath.of(listing));
+        access.check(listing);
+    }
+
+    public void testDuplicateListingUnderAllowedRootSucceeds() throws IOException {
+        Path allowed = createTempDir();
+        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        LocalFileAccess access = LocalFileAccess.create(settings);
+
+        Path file = allowed.resolve("dupes.csv");
+        Files.createFile(file);
+        // The same file listed twice (mirrors the *ExternalReadConfigParityIT duplicate-listing tests): each identical
+        // segment is a valid single location, so the whole listing must pass.
+        String uri = "file://" + file.toAbsolutePath();
+        access.check(StoragePath.of(uri + "," + uri));
+    }
+
+    public void testCommaListingWithOneSegmentOutsideRootRejected() throws IOException {
+        Path allowed = createTempDir();
+        Path outside = createTempDir();
+        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        LocalFileAccess access = LocalFileAccess.create(settings);
+
+        Path allowedFile = allowed.resolve("a.csv");
+        Path outsideFile = outside.resolve("secret.csv");
+        Files.createFile(allowedFile);
+        Files.createFile(outsideFile);
+        // Every listed file must be gated: a listing may not smuggle a file outside the allowlist alongside an allowed
+        // one. Validating only the whole (or first) string left this gap.
+        String listing = "file://" + allowedFile.toAbsolutePath() + ",file://" + outsideFile.toAbsolutePath();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> access.check(StoragePath.of(listing)));
+        assertThat(e.getMessage(), containsString("esql.external.local_allowed_paths"));
+        assertThat(e.getMessage(), containsString(outsideFile.toAbsolutePath().toString()));
+    }
+
+    public void testCommaListingMixingLiteralAndGlobUnderRootSucceeds() throws IOException {
+        Path allowed = createTempDir();
+        Settings settings = Settings.builder().putList("esql.external.local_allowed_paths", allowed.toString()).build();
+        LocalFileAccess access = LocalFileAccess.create(settings);
+
+        Path literal = allowed.resolve("a.csv");
+        Files.createFile(literal);
+        // A glob segment is gated on its non-glob prefix (as for a lone glob), and a literal segment on itself.
+        String listing = "file://" + literal.toAbsolutePath() + ",file://" + allowed.toAbsolutePath() + "/data-*.csv";
+        access.check(StoragePath.of(listing));
+    }
+
+    public void testCommaListingRejectedWhenDisabled() {
+        LocalFileAccess access = LocalFileAccess.create(Settings.EMPTY);
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> access.check(StoragePath.of("file:///some/a.csv,file:///some/b.csv"))
+        );
+        assertThat(e.getMessage(), containsString("esql.external.local_allowed_paths"));
+    }
+
     // --- UNRESTRICTED sentinel ---
 
     public void testUnrestrictedAllowsAnything() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ESQL] Fix multifile check in windows (#158052)](https://github.com/elastic/elasticsearch/pull/158052)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)