### PR TITLE
Push geo-grid STATS aggs to Lucene

### DIFF
--- a/docs/changelog/159106.yaml
+++ b/docs/changelog/159106.yaml
@@ -1,0 +1,5 @@
+area: "ES|QL, Geo"
+issues: []
+pr: 159106
+summary: Push geo-grid STATS aggs to Lucene
+type: enhancement

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneGeoGridAggOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneGeoGridAggOperator.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.lucene.query;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardId;
+import org.elasticsearch.compute.lucene.ShardContext;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.querydsl.query.QueryWarnings;
+import org.elasticsearch.core.RefCounted;
+import org.elasticsearch.core.Releasables;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.LongUnaryOperator;
+
+/**
+ * Source operator that aggregates {@code geo_point} field values into geo-grid cell counts.
+ * <p>
+ * For each document, reads the raw Lucene-encoded {@code geo_point} doc value (a {@code long}
+ * where the upper 32 bits hold the encoded latitude and the lower 32 bits hold the encoded
+ * longitude), passes it to the provided {@link GeoGridEncoder} to obtain a grid cell ID, and
+ * accumulates per-cell document counts.
+ * <p>
+ * When all segments have been processed, emits a single {@link Page} with three columns:
+ * <ol>
+ *   <li>cell IDs — {@code long}</li>
+ *   <li>per-cell document counts — {@code long}</li>
+ *   <li>a constant {@code true} "seen" flag — {@code boolean}</li>
+ * </ol>
+ * This matches the intermediate-aggregation format expected by the {@code COUNT} aggregator
+ * in grouped mode, allowing the coordinator node to perform the final merge.
+ * <p>
+ * The operator uses {@link DataPartitioning#SHARD} partitioning to ensure each driver instance
+ * owns its entire shard, which is required when reading field doc values sequentially.
+ */
+public class LuceneGeoGridAggOperator extends LuceneOperator {
+
+    /**
+     * Encodes a raw Lucene-encoded {@code geo_point} doc value into a geo-grid cell ID.
+     * <p>
+     * Implementations are provided by the ESQL planner layer, which has access to the
+     * grid-type-specific encoding libraries:
+     * <ul>
+     *   <li>Geohash: {@code Geohash.longEncode(lon, lat, precision)} (longitude first)</li>
+     *   <li>GeoTile: {@code GeoTileUtils.longEncode(lon, lat, precision)} (longitude first)</li>
+     *   <li>GeoHex: {@code H3.geoToH3(lat, lon, precision)} (latitude first — note parameter order)</li>
+     * </ul>
+     */
+    @FunctionalInterface
+    public interface GeoGridEncoder extends LongUnaryOperator {}
+
+    /**
+     * Factory for {@link LuceneGeoGridAggOperator} instances.
+     */
+    public static class Factory extends LuceneOperator.Factory {
+
+        private final IndexedByShardId<? extends RefCounted> shardRefCounters;
+        private final String fieldName;
+        private final GeoGridEncoder encoder;
+
+        public Factory(
+            IndexedByShardId<? extends ShardContext> contexts,
+            Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction,
+            int taskConcurrency,
+            String fieldName,
+            GeoGridEncoder encoder,
+            LongSupplier directoryBytesRead,
+            QueryWarnings singleValueQueryWarnings
+        ) {
+            super(
+                contexts,
+                queryFunction,
+                DataPartitioning.SHARD,
+                (ctx, q) -> LuceneSliceQueue.PartitioningStrategy.SHARD,
+                0,
+                taskConcurrency,
+                LuceneOperator.NO_LIMIT,
+                false,
+                shardContext -> ScoreMode.COMPLETE_NO_SCORES,
+                directoryBytesRead,
+                LuceneSliceQueue.MIN_DOCS_PER_SLICE,
+                singleValueQueryWarnings
+            );
+            this.shardRefCounters = contexts;
+            this.fieldName = fieldName;
+            this.encoder = encoder;
+        }
+
+        @Override
+        public SourceOperator get(DriverContext driverContext) {
+            return new LuceneGeoGridAggOperator(
+                shardRefCounters,
+                driverContext,
+                sliceQueue,
+                fieldName,
+                encoder,
+                directoryBytesRead,
+                singleValueQueryWarnings
+            );
+        }
+
+        @Override
+        public String describe() {
+            return "LuceneGeoGridAggOperator[field=" + fieldName + "]";
+        }
+    }
+
+    private final String fieldName;
+    private final GeoGridEncoder encoder;
+    /** Accumulated per-cell document counts. Populated incrementally as segments are scored. */
+    private final Map<Long, Long> cellCounts = new HashMap<>();
+
+    LuceneGeoGridAggOperator(
+        IndexedByShardId<? extends RefCounted> shardRefCounters,
+        DriverContext driverContext,
+        LuceneSliceQueue sliceQueue,
+        String fieldName,
+        GeoGridEncoder encoder,
+        LongSupplier directoryBytesRead,
+        QueryWarnings singleValueQueryWarnings
+    ) {
+        super(shardRefCounters, driverContext, Integer.MAX_VALUE, sliceQueue, directoryBytesRead, singleValueQueryWarnings);
+        this.fieldName = fieldName;
+        this.encoder = encoder;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return doneCollecting;
+    }
+
+    @Override
+    public void finish() {
+        doneCollecting = true;
+    }
+
+    @Override
+    protected Page getCheckedOutput() throws IOException {
+        final long start = System.nanoTime();
+        try {
+            final LuceneScorer scorer = getCurrentOrLoadNextScorer();
+            if (scorer != null) {
+                final LeafReader reader = scorer.leafReaderContext().reader();
+                final SortedNumericDocValues docValues = DocValues.getSortedNumeric(reader, fieldName);
+                final LeafCollector leafCollector = new LeafCollector() {
+                    @Override
+                    public void setScorer(Scorable scorer) {}
+
+                    @Override
+                    public void collect(int doc) throws IOException {
+                        if (docValues.advanceExact(doc)) {
+                            final int count = docValues.docValueCount();
+                            for (int i = 0; i < count; i++) {
+                                final long cellId = encoder.applyAsLong(docValues.nextValue());
+                                cellCounts.merge(cellId, 1L, Long::sum);
+                            }
+                        }
+                    }
+                };
+                scorer.scoreNextRange(leafCollector, reader.getLiveDocs(), Integer.MAX_VALUE);
+            }
+            // When getCurrentOrLoadNextScorer() exhausts all slices it sets doneCollecting = true and returns null.
+            // On that same call we build and return the final result (pagesEmitted == 0 guards against duplicate emission).
+            if (isFinished() && pagesEmitted == 0) {
+                return buildResult();
+            }
+            return null;
+        } finally {
+            processingNanos += System.nanoTime() - start;
+        }
+    }
+
+    private Page buildResult() {
+        if (cellCounts.isEmpty()) {
+            return null;
+        }
+        final int size = cellCounts.size();
+        LongBlock cellBlock = null;
+        LongBlock countBlock = null;
+        BooleanBlock seenBlock = null;
+        try {
+            try (
+                LongBlock.Builder cellBuilder = blockFactory.newLongBlockBuilder(size);
+                LongBlock.Builder countBuilder = blockFactory.newLongBlockBuilder(size)
+            ) {
+                for (Map.Entry<Long, Long> entry : cellCounts.entrySet()) {
+                    cellBuilder.appendLong(entry.getKey());
+                    countBuilder.appendLong(entry.getValue());
+                }
+                cellBlock = cellBuilder.build();
+                countBlock = countBuilder.build();
+            }
+            seenBlock = blockFactory.newConstantBooleanBlockWith(true, size);
+            final Page page = new Page(size, cellBlock, countBlock, seenBlock);
+            cellBlock = null;
+            countBlock = null;
+            seenBlock = null;
+            return page;
+        } finally {
+            Releasables.closeExpectNoException(cellBlock, countBlock, seenBlock);
+        }
+    }
+
+    @Override
+    protected void describe(StringBuilder sb) {
+        sb.append(", field=").append(fieldName);
+    }
+
+    /**
+     * Blocks in the output {@link Page} produced by this operator.
+     */
+    public enum OutputColumn {
+        CELL_ID(0),
+        COUNT(1),
+        SEEN(2);
+
+        public final int channel;
+
+        OutputColumn(int channel) {
+            this.channel = channel;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertFieldEx
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushCountQueryAndTagsToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushExpressionsToFieldLoad;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushGeoGridStatsToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToExternalSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushSampleToSource;
@@ -85,6 +86,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             new PushSampleToSource(),
             new ReplaceSampledStatsByExactStats(),
             new PushStatsToSource(),
+            new PushGeoGridStatsToSource(),
             new PushStatsToExternalSource(),
             new PushTopNIntoExternalSource(),
             new EnableSpatialDistancePushdown(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushGeoGridStatsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushGeoGridStatsToSource.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialGridFunction;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsGeoGridAggQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+/**
+ * Pushes {@code STATS COUNT(*) BY cell = ST_GEOHASH/GEOTILE/GEOHEX(field, prec)} down to Lucene.
+ * <p>
+ * Matches the physical plan pattern produced for:
+ * <pre>
+ *   EVAL cell = ST_GEOHASH(location, precision)
+ *   | STATS count = COUNT(*) BY cell
+ * </pre>
+ * which looks like:
+ * <pre>
+ *   AggregateExec(INITIAL)
+ *     └── EvalExec([cell = ST_GEOHASH(FieldAttr(location), precision)])
+ *           └── EsQueryExec
+ * </pre>
+ * When the conditions below are met, the {@link AggregateExec} and {@link EvalExec} are replaced
+ * by a single {@link EsGeoGridAggQueryExec} that does the cell-counting inside Lucene:
+ * <ul>
+ *   <li>Exactly one grouping expression that resolves to a {@link SpatialGridFunction}</li>
+ *   <li>The spatial field is a {@code geo_point} {@link FieldAttribute} that is not potentially unmapped</li>
+ *   <li>The spatial function has no bounds argument (unbounded grids only)</li>
+ *   <li>Exactly one aggregation: a {@link Count} without a filter, applied to either {@code *} or the grouping column</li>
+ * </ul>
+ */
+public class PushGeoGridStatsToSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
+    AggregateExec,
+    LocalPhysicalOptimizerContext> {
+
+    @Override
+    protected PhysicalPlan rule(AggregateExec aggregateExec, LocalPhysicalOptimizerContext context) {
+        // Only push down the first (partial) aggregation pass on data nodes.
+        if (aggregateExec.getMode() != AggregatorMode.INITIAL) {
+            return aggregateExec;
+        }
+
+        // Require exactly one grouping expression.
+        if (aggregateExec.groupings().size() != 1) {
+            return aggregateExec;
+        }
+
+        // Identify the child structure: EvalExec → EsQueryExec or directly EsQueryExec.
+        final EsQueryExec esQueryExec;
+        final EvalExec evalExec;
+        if (aggregateExec.child() instanceof EvalExec ev && ev.child() instanceof EsQueryExec qe) {
+            evalExec = ev;
+            esQueryExec = qe;
+        } else if (aggregateExec.child() instanceof EsQueryExec qe) {
+            evalExec = null;
+            esQueryExec = qe;
+        } else {
+            return aggregateExec;
+        }
+
+        // Resolve the grouping to a SpatialGridFunction.
+        final Expression groupingExpr = aggregateExec.groupings().get(0);
+        final SpatialGridFunction gridFn;
+        final Attribute gridAttr;
+
+        if (groupingExpr instanceof Alias alias && alias.child() instanceof SpatialGridFunction gf) {
+            // Inline pattern: BY cell = ST_GEOHASH(location, prec)
+            gridFn = gf;
+            gridAttr = alias.toAttribute();
+        } else {
+            // Via-EvalExec pattern: EVAL cell = ST_GEOHASH(location, prec) | ... BY cell
+            Attribute ref = Expressions.attribute(groupingExpr);
+            if (ref == null || evalExec == null) {
+                return aggregateExec;
+            }
+            SpatialGridFunction found = null;
+            Attribute foundAttr = null;
+            for (Alias alias : evalExec.fields()) {
+                if (alias.id().equals(ref.id()) && alias.child() instanceof SpatialGridFunction gf) {
+                    found = gf;
+                    foundAttr = alias.toAttribute();
+                    break;
+                }
+            }
+            if (found == null) {
+                return aggregateExec;
+            }
+            gridFn = found;
+            gridAttr = foundAttr;
+        }
+
+        // The spatial field must be a geo_point FieldAttribute that is not potentially unmapped.
+        // geo_shape requires a different approach (cell intersection, not point-in-cell) and is excluded.
+        if (!(gridFn.spatialField() instanceof FieldAttribute geoField)
+            || geoField.dataType() != DataType.GEO_POINT
+            || geoField.isPotentiallyUnmapped()) {
+            return aggregateExec;
+        }
+
+        // Only push down when the field has doc values indexed. The Lucene operator reads
+        // directly from SortedNumericDocValues; without doc values there is nothing to read.
+        if (context.searchStats().hasDocValues(geoField.fieldName()) == false) {
+            return aggregateExec;
+        }
+
+        // The precision parameter must be foldable (a constant integer).
+        if (gridFn.parameter().foldable() == false) {
+            return aggregateExec;
+        }
+        final int precision = ((Number) gridFn.parameter().fold(context.foldCtx())).intValue();
+
+        // Bounded grids are not supported in the pushdown; the bounding-box filter would need to be
+        // applied inside the operator, which is left as a future enhancement.
+        if (gridFn.bounds() != null) {
+            return aggregateExec;
+        }
+
+        // Validate aggregates: allow exactly one COUNT (without a filter) over * or the grouping column,
+        // plus the grouping alias that appears in the aggregates list.
+        boolean foundCount = false;
+        for (NamedExpression ne : aggregateExec.aggregates()) {
+            // The grouping column may appear in the aggregates list as a plain Attribute OR as an
+            // Alias that wraps a reference attribute. Identify it by checking the attribute ID.
+            Attribute neAttr = Expressions.attribute(ne);
+            if (neAttr != null && neAttr.id().equals(gridAttr.id())) {
+                continue; // skip the grouping column
+            }
+            if (ne instanceof Alias alias && alias.child() instanceof Count count && count.hasFilter() == false) {
+                // Accept COUNT(*) (foldable field) or COUNT(cell) where cell is the grouping attribute.
+                Expression countField = count.field();
+                if (countField.foldable()) {
+                    foundCount = true;
+                    continue;
+                }
+                Attribute countFieldAttr = Expressions.attribute(countField);
+                if (countFieldAttr != null && countFieldAttr.id().equals(gridAttr.id())) {
+                    foundCount = true;
+                    continue;
+                }
+            }
+            // Any other aggregate means we cannot push down.
+            return aggregateExec;
+        }
+        if (foundCount == false) {
+            return aggregateExec;
+        }
+
+        return new EsGeoGridAggQueryExec(
+            aggregateExec.source(),
+            esQueryExec.indexPattern(),
+            esQueryExec.query(),
+            geoField.fieldName().string(),
+            precision,
+            gridFn.dataType(),
+            aggregateExec.intermediateAttributes()
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsGeoGridAggQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsGeoGridAggQueryExec.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.NodeStringMapper;
+import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Physical plan node that pushes a geo-grid aggregation ({@code STATS COUNT(*) BY ST_GEOHASH/GEOTILE/GEOHEX(field, prec)})
+ * down to Lucene, bypassing the normal field-extraction and evaluation pipeline.
+ * <p>
+ * This is a local-only (data-node-only) plan node. It is never serialized across the wire.
+ * The planner creates it in place of the combination of {@link AggregateExec} + {@link EvalExec} + {@link EsQueryExec}
+ * when all conditions for the pushdown are met.
+ * <p>
+ * Output columns mirror the intermediate aggregation attributes of the original {@link AggregateExec}:
+ * {@code [cell_id (long), count (long), seen (boolean)]}.
+ *
+ * @see org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushGeoGridStatsToSource
+ */
+public class EsGeoGridAggQueryExec extends LeafExec implements EstimatesRowSize, DataSourceExec {
+
+    private final String indexPattern;
+    private final QueryBuilder query;
+    private final String fieldName;
+    private final int precision;
+    private final DataType gridType;
+    private final List<Attribute> attrs;
+
+    public EsGeoGridAggQueryExec(
+        Source source,
+        String indexPattern,
+        QueryBuilder query,
+        String fieldName,
+        int precision,
+        DataType gridType,
+        List<Attribute> attrs
+    ) {
+        super(source);
+        this.indexPattern = indexPattern;
+        this.query = query;
+        this.fieldName = fieldName;
+        this.precision = precision;
+        this.gridType = gridType;
+        this.attrs = attrs;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    protected NodeInfo<EsGeoGridAggQueryExec> info() {
+        return NodeInfo.create(this, EsGeoGridAggQueryExec::new, indexPattern, query, fieldName, precision, gridType, attrs);
+    }
+
+    public String indexPattern() {
+        return indexPattern;
+    }
+
+    public QueryBuilder query() {
+        return query;
+    }
+
+    public String fieldName() {
+        return fieldName;
+    }
+
+    public int precision() {
+        return precision;
+    }
+
+    public DataType gridType() {
+        return gridType;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return attrs;
+    }
+
+    @Override
+    public PhysicalPlan estimateRowSize(State state) {
+        state.add(false, attrs);
+        state.consumeAllFields(false);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexPattern, query, fieldName, precision, gridType, attrs);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        EsGeoGridAggQueryExec other = (EsGeoGridAggQueryExec) obj;
+        return Objects.equals(indexPattern, other.indexPattern)
+            && Objects.equals(query, other.query)
+            && Objects.equals(fieldName, other.fieldName)
+            && precision == other.precision
+            && gridType == other.gridType
+            && Objects.equals(attrs, other.attrs);
+    }
+
+    @Override
+    public void nodeString(StringBuilder sb, NodeStringFormat format, NodeStringMapper mapper) {
+        sb.append(nodeName()).append('[').append(mapper.index(indexPattern)).append(']');
+        sb.append(", gridType[").append(gridType.typeName()).append(']');
+        sb.append(", field[").append(mapper.opaque(fieldName)).append(']');
+        sb.append(", precision[").append(precision).append(']');
+        sb.append(", query[").append(mapper.opaque(query != null ? Strings.toString(query, false, true) : "")).append(']');
+        NodeUtils.toString(sb, attrs, format, mapper);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.planner;
 
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.BooleanClause;
@@ -25,6 +26,7 @@ import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.lucene.query.LuceneCountOperator;
+import org.elasticsearch.compute.lucene.query.LuceneGeoGridAggOperator;
 import org.elasticsearch.compute.lucene.query.LuceneOperator;
 import org.elasticsearch.compute.lucene.query.LuceneSliceQueue;
 import org.elasticsearch.compute.lucene.query.LuceneSourceOperator;
@@ -42,6 +44,8 @@ import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.geometry.utils.Geohash;
+import org.elasticsearch.h3.H3;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -70,6 +74,7 @@ import org.elasticsearch.index.search.NestedHelper;
 import org.elasticsearch.index.search.stats.ShardSearchStats;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.SearchContext;
@@ -795,6 +800,57 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             context.queryPragmas().minDocsPerSlice(LuceneSliceQueue.MIN_DOCS_PER_SLICE),
             singleValueQueryWarnings
         );
+    }
+
+    /**
+     * Build a {@link SourceOperator.SourceOperatorFactory} that counts documents per geo-grid cell.
+     *
+     * @param context      execution planner context
+     * @param query        the source query (may be {@code null} for match-all)
+     * @param fieldName    the name of the {@code geo_point} field
+     * @param precision    the grid precision
+     * @param gridType     the grid type (GEOHASH, GEOTILE, or GEOHEX)
+     */
+    public LuceneGeoGridAggOperator.Factory geoGridAggSource(
+        LocalExecutionPlannerContext context,
+        org.elasticsearch.index.query.QueryBuilder query,
+        String fieldName,
+        int precision,
+        DataType gridType
+    ) {
+        final LuceneGeoGridAggOperator.GeoGridEncoder encoder = buildEncoder(precision, gridType);
+        final var queryFunction = querySupplierForField(query, fieldName);
+        return new LuceneGeoGridAggOperator.Factory(
+            shardContexts,
+            queryFunction,
+            context.queryPragmas().taskConcurrency(),
+            fieldName,
+            encoder,
+            directoryBytesRead,
+            singleValueQueryWarnings
+        );
+    }
+
+    private static LuceneGeoGridAggOperator.GeoGridEncoder buildEncoder(int precision, DataType gridType) {
+        return switch (gridType) {
+            case GEOHASH -> docValue -> {
+                final double lat = GeoEncodingUtils.decodeLatitude((int) (docValue >> 32));
+                final double lon = GeoEncodingUtils.decodeLongitude((int) docValue);
+                return Geohash.longEncode(lon, lat, precision);
+            };
+            case GEOTILE -> docValue -> {
+                final double lat = GeoEncodingUtils.decodeLatitude((int) (docValue >> 32));
+                final double lon = GeoEncodingUtils.decodeLongitude((int) docValue);
+                return GeoTileUtils.longEncode(lon, lat, precision);
+            };
+            case GEOHEX -> docValue -> {
+                final double lat = GeoEncodingUtils.decodeLatitude((int) (docValue >> 32));
+                final double lon = GeoEncodingUtils.decodeLongitude((int) docValue);
+                // H3.geoToH3 takes latitude first, longitude second (note: different from Geohash/GeoTile)
+                return H3.geoToH3(lat, lon, precision);
+            };
+            default -> throw new IllegalArgumentException("Unsupported grid type for geo-grid pushdown: " + gridType);
+        };
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -171,6 +171,7 @@ import org.elasticsearch.xpack.esql.plan.physical.CompoundOutputEvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.DistinctByExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsGeoGridAggQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
@@ -471,6 +472,8 @@ public class LocalExecutionPlanner {
             return planEsQueryNode(esQuery, context);
         } else if (node instanceof EsStatsQueryExec statsQuery) {
             return planEsStats(statsQuery, context);
+        } else if (node instanceof EsGeoGridAggQueryExec geoGridAgg) {
+            return planEsGeoGridAgg(geoGridAgg, context);
         } else if (node instanceof LocalSourceExec localSource) {
             return planLocal(localSource, context);
         } else if (node instanceof ShowExec show) {
@@ -730,6 +733,25 @@ public class LocalExecutionPlanner {
 
         Layout.Builder layout = new Layout.Builder();
         layout.append(statsQuery.outputSet());
+        int instanceCount = Math.max(1, luceneFactory.taskConcurrency());
+        context.driverParallelism(new DriverParallelism(DriverParallelism.Type.DATA_PARALLELISM, instanceCount));
+        return PhysicalOperation.fromSource(luceneFactory, layout.build());
+    }
+
+    private PhysicalOperation planEsGeoGridAgg(EsGeoGridAggQueryExec geoGridAgg, LocalExecutionPlannerContext context) {
+        if (physicalOperationProviders instanceof EsPhysicalOperationProviders == false) {
+            throw new EsqlIllegalArgumentException("EsGeoGridAggQueryExec should only occur against a Lucene backend");
+        }
+        EsPhysicalOperationProviders esProvider = (EsPhysicalOperationProviders) physicalOperationProviders;
+        final LuceneOperator.Factory luceneFactory = esProvider.geoGridAggSource(
+            context,
+            geoGridAgg.query(),
+            geoGridAgg.fieldName(),
+            geoGridAgg.precision(),
+            geoGridAgg.gridType()
+        );
+        Layout.Builder layout = new Layout.Builder();
+        layout.append(geoGridAgg.outputSet());
         int instanceCount = Math.max(1, luceneFactory.taskConcurrency());
         context.driverParallelism(new DriverParallelism(DriverParallelism.Type.DATA_PARALLELISM, instanceCount));
         return PhysicalOperation.fromSource(luceneFactory, layout.build());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -134,6 +134,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsGeoGridAggQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec.FieldSort;
 import org.elasticsearch.xpack.esql.plan.physical.EsSourceExec;
@@ -4871,10 +4872,18 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
                     assertThat(attribute.name(), equalTo("grid"));
                     assertThat(grouping.dataType(), equalTo(dataType));
                     exchange = as(agg.child(), ExchangeExec.class);
-                    agg = as(exchange.child(), AggregateExec.class);
-                    assertAggregation(agg, "count", Count.class);
-                    var evalExec = as(agg.child(), EvalExec.class);
-                    assertChildIsGeoPointExtract(evalExec, fieldExtractPreference);
+                    if (withDocValues) {
+                        // With doc values the pushdown rule replaces AggregateExec + EvalExec with EsGeoGridAggQueryExec
+                        var geoGridAgg = as(exchange.child(), EsGeoGridAggQueryExec.class);
+                        assertThat(geoGridAgg.fieldName(), equalTo("location"));
+                        assertThat(geoGridAgg.precision(), equalTo(2));
+                        assertThat(geoGridAgg.gridType(), equalTo(dataType));
+                    } else {
+                        agg = as(exchange.child(), AggregateExec.class);
+                        assertAggregation(agg, "count", Count.class);
+                        var evalExec = as(agg.child(), EvalExec.class);
+                        assertChildIsGeoPointExtract(evalExec, fieldExtractPreference);
+                    }
                 }
             }
         }


### PR DESCRIPTION
`STATS COUNT(*) BY ST_GEOHASH/GEOTILE/GEOHEX(field, prec)`  is now pushed to Lucene on data nodes when the geo_point field has doc values, bypassing the normal field-extraction and evaluation pipeline.

Three new components wire this together:

- `LuceneGeoGridAggOperator`: reads `SortedNumericDocValues` directly, encodes each point to a cell ID via a per-type `GeoGridEncoder`, and accumulates per-cell counts in a HashMap. Emits a single Page in [cell_id, count, seen] intermediate-aggregation format so the coordinator can run the final COUNT merge unchanged. Uses SHARD partitioning so each driver owns its full shard.

- `EsGeoGridAggQueryExec`: local-only physical plan node (never serialized) that carries the index pattern, query, field name, precision, and grid type.

- `PushGeoGridStatsToSource`: optimizer rule registered in the "Push to ES" batch. Matches `AggregateExec(INITIAL)` with a single `SpatialGridFunction` grouping over a `geo_point` field that has doc values and replaces it with `EsGeoGridAggQueryExec`. Bounded grids and geo_shape fields are excluded.
