### PR TITLE
[9.4] ESQL: unmapped_fields="load" results in 500 EsqlIllegalArgumentException (#146959)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -53,12 +53,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
   issue: https://github.com/elastic/elasticsearch/issues/145904
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeUnmappedLoadIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/148619
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/148619
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/150569

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -266,6 +266,13 @@ public class EsqlCapabilities {
         OPTIONAL_FIELDS_FIX_NULL_MATCH_FIELD_IN_JOIN_AND_ENRICH,
 
         /**
+         * Fix for 500 return code when loading from {@code _source} (hence {@code KEYWORD}) and passing to a convert function that doesn't
+         * take {@code KEYWORD}s.
+         * See https://github.com/elastic/elasticsearch/issues/145998.
+         */
+        OPTIONAL_FIELDS_FIX_UNMAPPED_LOAD_CONVERT_FUNCTION,
+
+        /**
          * Support for optional fields (might or might not be present in the mappings) using DEFAULT/NULLIFY/LOAD.
          * V2: Prevent pushing down filters and sorts to Lucene of potentially unmapped fields.
          * V3: Fix synthetic _source numeric load bug (#143916)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2350,17 +2350,17 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
      * Any fields which could not be resolved by conversion functions will be converted to UnresolvedAttribute instances in a later rule
      * (See {@link UnionTypesCleanup} below).
      */
-    private static class ResolveUnionTypes extends Rule<LogicalPlan, LogicalPlan> {
+    private static class ResolveUnionTypes extends ParameterizedRule<LogicalPlan, LogicalPlan, AnalyzerContext> {
 
         record TypeResolutionKey(String fieldName, DataType fieldType) {}
 
         @Override
-        public LogicalPlan apply(LogicalPlan plan) {
+        public LogicalPlan apply(LogicalPlan plan, AnalyzerContext context) {
             List<Attribute.IdIgnoringWrapper> unionFieldAttributes = new ArrayList<>();
-            return plan.transformUp(LogicalPlan.class, p -> p.childrenResolved() == false ? p : doRule(p, unionFieldAttributes));
+            return plan.transformUp(LogicalPlan.class, p -> p.childrenResolved() == false ? p : doRule(p, unionFieldAttributes, context));
         }
 
-        private LogicalPlan doRule(LogicalPlan plan, List<Attribute.IdIgnoringWrapper> unionFieldAttributes) {
+        private LogicalPlan doRule(LogicalPlan plan, List<Attribute.IdIgnoringWrapper> unionFieldAttributes, AnalyzerContext context) {
             Holder<Integer> alreadyAddedUnionFieldAttributes = new Holder<>(unionFieldAttributes.size());
             // Collect field attributes from previous runs
             if (plan instanceof EsRelation rel) {
@@ -2376,7 +2376,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             // Replace the entire convert function with a new FieldAttribute (containing type conversion knowledge)
             plan = plan.transformExpressionsOnly(e -> {
                 if (e instanceof ConvertFunction convert) {
-                    return resolveConvertFunction(convert, unionFieldAttributes);
+                    return resolveConvertFunction(convert, unionFieldAttributes, context.unmappedResolution() == UnmappedResolution.LOAD);
                 }
                 return e;
             });
@@ -2414,7 +2414,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             return res;
         }
 
-        private Expression resolveConvertFunction(ConvertFunction convert, List<Attribute.IdIgnoringWrapper> unionFieldAttributes) {
+        private Expression resolveConvertFunction(
+            ConvertFunction convert,
+            List<Attribute.IdIgnoringWrapper> unionFieldAttributes,
+            boolean loadUnmappedFields
+        ) {
             Expression convertExpression = (Expression) convert;
             if (convert.field() instanceof FieldAttribute fa && fa.field() instanceof InvalidMappedField imf) {
                 HashMap<TypeResolutionKey, Expression> typeResolutions = new HashMap<>();
@@ -2434,11 +2438,16 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         typeResolutions(fa, convert, type, imf, typeResolutions);
                     }
                 });
-                Expression potentiallyUnmappedConversion = imf.isPotentiallyUnmapped()
-                    ? ResolveUnionTypes.typeSpecificConvert(convert, fa.source(), KEYWORD, imf)
-                    : null;
+
                 // If all mapped types were resolved, create a new FieldAttribute with the resolved MultiTypeEsField
                 if (typeResolutions.size() == imf.getTypesToIndices().size()) {
+                    if (skipMultiTypeForPotentiallyUnmappedKeyword(loadUnmappedFields, imf, supportedTypes)) {
+                        return convertExpression;
+                    }
+
+                    Expression potentiallyUnmappedConversion = imf.isPotentiallyUnmapped()
+                        ? ResolveUnionTypes.typeSpecificConvert(convert, fa.source(), KEYWORD, imf)
+                        : null;
                     var resolvedField = resolvedMultiTypeEsField(fa, typeResolutions, potentiallyUnmappedConversion);
                     return createIfDoesNotAlreadyExist(fa, resolvedField, unionFieldAttributes);
                 }
@@ -2489,10 +2498,18 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     }
                 } else if (convert.field() instanceof AbstractConvertFunction subConvert) {
                     return convertExpression.replaceChildren(
-                        Collections.singletonList(resolveConvertFunction(subConvert, unionFieldAttributes))
+                        Collections.singletonList(resolveConvertFunction(subConvert, unionFieldAttributes, loadUnmappedFields))
                     );
                 }
             return convertExpression;
+        }
+
+        private static boolean skipMultiTypeForPotentiallyUnmappedKeyword(
+            boolean loadUnmappedFields,
+            InvalidMappedField imf,
+            Set<DataType> supportedTypes
+        ) {
+            return loadUnmappedFields && imf.isPotentiallyUnmapped() && supportedTypes.contains(KEYWORD) == false;
         }
 
         private Expression createIfDoesNotAlreadyExist(

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/290_unmapped_load_partial_keyword_convert.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/290_unmapped_load_partial_keyword_convert.yml
@@ -1,0 +1,101 @@
+---
+setup:
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings_regex, contains ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ optional_fields_fix_unmapped_load_convert_function ]
+      reason: 'requires SET unmapped_fields="load" and current error message for partially unmapped non-keyword fields'
+  #
+  # The table below represents the field mappings for the three indices created in this test.
+  # In `FROM index*`, all the fields except lambda are PUNKs: partially unmapped non-keyword fields.
+  #
+  # | Field      | index1  |   index2   | index3  |
+  # |------------|---------|------------|---------|
+  # | foo        | double  | long       | -       |
+  #
+  - do:
+      indices.create:
+        index: index1
+        body:
+          mappings:
+            dynamic: false
+            properties:
+              foo:
+                type: double
+  - do:
+      indices.create:
+        index: index2
+        body:
+          mappings:
+            dynamic: false
+            properties:
+              foo:
+                type: long
+  - do:
+      indices.create:
+        index: index3
+        body:
+          mappings:
+            dynamic: false
+  - do:
+      bulk:
+        index: "index3"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "foo": "1"}
+---
+'to_degrees on punk field':
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          # [foo] is double in index1
+          # [foo] is unmapped in index3
+          query: 'SET unmapped_fields="load"; FROM index1,index3 | EVAL x = TO_DEGREES(foo)'
+  - match: { status: 400 }
+  - match: { error.type: verification_exception }
+  - contains: { error.reason: 'Found 1 problem' }
+  - contains: { error.reason: 'line 1:70: Using partially unmapped non-KEYWORD field [foo] is not supported with unmapped_fields="load"' }
+---
+'to_radians on punk field':
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          # [foo] is long in index2
+          # [foo] is unmapped in index3
+          query: 'SET unmapped_fields="load"; FROM index2,index3 | EVAL x = TO_RADIANS(foo)'
+  - match: { status: 400 }
+  - match: { error.type: verification_exception }
+  - contains: { error.reason: 'Found 1 problem' }
+  - contains: { error.reason: 'line 1:70: Using partially unmapped non-KEYWORD field [foo] is not supported with unmapped_fields="load"' }
+---
+'aggregate_metric_double cast on fully unmapped field':
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          # [x] is fully unmapped; it doesn't appear in any index's mapping.
+          query: 'SET unmapped_fields="load"; FROM index2,index3 | EVAL x::aggregate_metric_double'
+  - match: { status: 400 }
+  - match: { error.type: verification_exception }
+  - contains: { error.reason: 'Found 1 problem' }
+  - contains: { error.reason: 'line 1:55: argument of [x::aggregate_metric_double] must be [numeric or aggregate_metric_double], found value [x] type [keyword]' }
+---
+'aggregate_metric_double cast on punk field':
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          # [foo] is double in index1
+          # [foo] is long in index2
+          # [foo] is unmapped in index3
+          query: 'SET unmapped_fields="load"; FROM index* | EVAL x = foo::aggregate_metric_double'
+  - match: { status: 400 }
+  - match: { error.type: verification_exception }
+  - contains: { error.reason: 'Found 1 problem' }
+  - contains: { error.reason: 'line 1:52: Cannot use field [foo] due to ambiguities being mapped as [3] incompatible types: [keyword] due to loading from _source, [double] in [index1], [long] in [index2]' }


### PR DESCRIPTION
Manual backport of #146959 to 9.4. That PR was labeled `auto-backport` + `v9.4.1` but no 9.4 backport was ever opened, so on 9.4 a partially-unmapped field loaded from `_source` as keyword and fed into a convert function with no keyword input still fails at shard execution with a 500 `illegal data type [keyword]`. That is what #148619 reports, and why both variants of `GenerativeUnmappedLoadIT` are muted on 9.4 only.

Analyzer change auto-merged and is byte-identical to main. Two conflicts resolved by hand:

- `EsqlCapabilities`: kept the 9.4 tail entry and inserted `OPTIONAL_FIELDS_FIX_UNMAPPED_LOAD_CONVERT_FUNCTION` in the same relative position as on main. Capabilities are name-keyed, so position has no runtime effect.
- `GenerativeUnmappedLoadRestTest.LOAD_ALLOWED_ERRORS`: kept 9.4's list unchanged. The original commit removed an `illegal data type [keyword]` pattern that 9.4 never had, and main's extra patterns belong to later unrelated fixes. The new analysis-time 400 is matched by 9.4's existing `is not supported with unmapped_fields` pattern.

Unmutes `single_node` and `multi_node` `GenerativeUnmappedLoadIT`.

Verified locally on 9.4: esql and qa:server compile; the backported YAML suite passes (4 cases, none skipped); single-node `GenerativeUnmappedLoadIT` passes on a random seed; multi-node passes with the issue's reproduce seed `DE5ACE537F629835`.

Note for the issue: later comments on #148619 describe unrelated main/9.5 failures (missing references, BigArrays assertion, socket timeouts). This PR fixes only the 9.4 cause the mutes cite.

Closes #148619
