### PR TITLE
[9.5] [ESQL] Only run date tests on supporting nodes (#158887)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -1124,6 +1124,7 @@ year              | 2022-05-06T14:30:00.000Z | 2022
 
 dateExtractFieldDatePart
 required_capability: fn_date_extract
+required_capability: casting_operator_for_date
 
 FROM date_extract_fields
 | EVAL result = DATE_EXTRACT(date_part, "2022-05-06T14:30:00.000Z"::date)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ESQL] Only run date tests on supporting nodes (#158887)](https://github.com/elastic/elasticsearch/pull/158887)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)