### PR TITLE
Clean up obsolete `onPeerRecoveryStartedOnSource`

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/CompositeRecoverySchedulingListener.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/CompositeRecoverySchedulingListener.java
@@ -72,13 +72,6 @@ public class CompositeRecoverySchedulingListener implements RecoverySchedulingLi
     }
 
     @Override
-    public void onPeerRecoveryStartedOnSource() {
-        for (RecoverySchedulingListener listener : listeners) {
-            listener.onPeerRecoveryStartedOnSource();
-        }
-    }
-
-    @Override
     public void onRecoveryDequeuedAndStartedOnTarget(RecoverySource.Type type, PriorityGroup priorityGroup) {
         for (RecoverySchedulingListener listener : listeners) {
             listener.onRecoveryDequeuedAndStartedOnTarget(type, priorityGroup);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryMetricsCollector.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryMetricsCollector.java
@@ -240,11 +240,6 @@ public class RecoveryMetricsCollector implements IndexEventListener, RecoverySch
     }
 
     @Override
-    public void onPeerRecoveryStartedOnSource() {
-        activePeerRecoveriesAsSourceMetric.add(1, peerRecoverySourceLifecycleMetricLabels());
-    }
-
-    @Override
     public void onRecoveryDequeuedAndStartedOnTarget(RecoverySource.Type type, PriorityGroup priorityGroup) {
         switch (type) {
             case EMPTY_STORE, EXISTING_STORE, SNAPSHOT, LOCAL_SHARDS, RESHARD_SPLIT -> {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySchedulingListener.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySchedulingListener.java
@@ -48,9 +48,6 @@ public interface RecoverySchedulingListener {
     /// Called when a queued incoming recovery is directly cancelled on the target by the master node, before it started running.
     default void onQueuedRecoveryCancelledOnTarget(RecoverySource.Type type, PriorityGroup priorityGroup) {}
 
-    /// Called when an outgoing peer recovery has been dispatched for execution on the source.
-    default void onPeerRecoveryStartedOnSource() {}
-
     /// Called when a previously queued incoming recovery is dequeued and dispatched for execution on the target.
     default void onRecoveryDequeuedAndStartedOnTarget(RecoverySource.Type type, PriorityGroup priorityGroup) {}
 

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/TestRecoverySchedulingListener.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/TestRecoverySchedulingListener.java
@@ -49,11 +49,6 @@ public abstract class TestRecoverySchedulingListener implements RecoveryScheduli
     }
 
     @Override
-    public void onPeerRecoveryStartedOnSource() {
-        onRecoverySchedulingChange();
-    }
-
-    @Override
     public void onRecoveryDequeuedAndStartedOnTarget(RecoverySource.Type type, PriorityGroup priorityGroup) {
         onRecoverySchedulingChange();
     }


### PR DESCRIPTION
Follows #157465, which introduced queueing in `StatelessPrimaryRelocationSourceService` and replaced its `onPeerRecoveryStartedOnSource()` call with `onPeerRecoveryDequeuedAndStartedOnSource()`. 

`onPeerRecoveryStartedOnSource()` is now no longer used anywhere.

This PR removes the dead method from all places that still declared it. This also makes `RecoverySchedulingListener` source functions consistent with the target ones.