### PR TITLE
Guard match_only_text columnar gate on doc-values layout

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -1204,12 +1204,14 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     }
 
     @Override
-    public boolean doSupportsColumnarParse(IndexSettings indexSettings) {
+    protected boolean doSupportsColumnarParse(IndexSettings indexSettings) {
         // usesBinaryDocValues() requires doc_values to be enabled which means synthetic-source stored-fallback is unreachable.
         // Additionally, this excludes the low-cardinality SORTED_SET encoding.
         // copy_to has no equivalent in mapColumnBatch (no per-value dispatch to other fields), so fields using it fall back.
         // match_only_text has no ignore_above/null_value/normalizer; multi-fields are handled by the base class.
-        return fieldType().usesBinaryDocValues() && copyTo().copyToFields().isEmpty();
+        return fieldType().usesBinaryDocValues()
+            && (fieldType().usesArrayOrderBinaryDocValues() || docValuesParameters.multiValue() == false)
+            && copyTo().copyToFields().isEmpty();
     }
 
     // TODO: make the batch supply a recycler to wire up recycling instead of NON_RECYCLING_INSTANCE.
@@ -1226,7 +1228,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     }
 
     @Override
-    public void doMapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
+    protected void doMapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
         final boolean emitTerms = indexed;
         final boolean emitDvs = docValuesParameters.enabled();
         if (emitTerms == false && emitDvs == false) {
@@ -1326,6 +1328,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     private void mapColumnBatchSingleValue(BatchMappingContext ctx, EscfColumn source, boolean emitTerms, boolean emitDvs) {
         final int docCount = ctx.docCount();
+        assert docValuesParameters.multiValue() == false
+            : "mapColumnBatchSingleValue called on multi_value=true field [" + fullPath() + "]; this would corrupt doc-values";
         boolean valuesProduced = false;
 
         // retainValues=false: every value is consumed within one loop iteration, before the cursor advances.

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextShardBatchMapperResolveTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextShardBatchMapperResolveTests.java
@@ -110,6 +110,15 @@ public class MatchOnlyTextShardBatchMapperResolveTests extends MapperServiceTest
         assertTrue(resolution.columnMappers()[0] instanceof MatchOnlyTextFieldMapper);
     }
 
+    public void testMatchOnlyTextNonColumnarDocValuesFallsBack() throws IOException {
+        MapperService ms = createMapperService(
+            mapping(b -> b.startObject("f").field("type", "match_only_text").field("doc_values", true).endObject())
+        );
+        var rawMapper = ms.mappingLookup().getMapper("f");
+        assertTrue(rawMapper instanceof MatchOnlyTextFieldMapper);
+        assertFalse(((MatchOnlyTextFieldMapper) rawMapper).supportsColumnarParse(ms.getIndexSettings()));
+    }
+
     public void testMatchOnlyTextDocValuesDisabledFallsBack() throws IOException {
         MapperService ms = mapper(
             mapping(b -> { b.startObject("f").field("type", "match_only_text").field("doc_values", false).endObject(); })


### PR DESCRIPTION
MatchOnlyTextFieldMapper.doSupportsColumnarParse was missing the multi-value/array-order guard that TextFieldMapper gains in #158798


Created to address https://github.com/elastic/elasticsearch/pull/158798#discussion_r3977237710