### PR TITLE
[ESQL] Disable test for windows

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -687,9 +687,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.datasources.FileSplitProviderTests
   method: testMultiFileParallelProbeAccumulatesCpuNanos
   issue: https://github.com/elastic/elasticsearch/issues/158462
-- class: org.elasticsearch.xpack.esql.plugin.EsqlQueryMetricsCollectorIT
-  method: testMetricsCollectorMultiFileCsv
-  issue: https://github.com/elastic/elasticsearch/issues/158463
 - class: org.elasticsearch.xpack.slm.SLMSnapshotBlockingIntegTests
   method: testRetentionWhileSnapshotInProgress
   issue: https://github.com/elastic/elasticsearch/issues/158608

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/EsqlQueryMetricsCollectorIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/EsqlQueryMetricsCollectorIT.java
@@ -283,6 +283,7 @@ public class EsqlQueryMetricsCollectorIT extends AbstractExternalDataSourceIT {
      * Uses a glob URI so {@code FileSplitProvider} receives multiple file tasks and spawns BPG workers.
      */
     public void testMetricsCollectorMultiFileCsv() throws Exception {
+        assumeFalse("Windows has bad timer resolution, metrics are not accurate", Constants.WINDOWS);
         Path dir = createTempDir();
         for (int i = 0; i < 3; i++) {
             Files.writeString(dir.resolve("data_" + i + ".csv"), createCsv(20));


### PR DESCRIPTION
Test fails on windows due to slow CPU time capture.

Closes #158463
