### PR TITLE
[ESQL] Wait for node to leave cluster

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -726,9 +726,6 @@ tests:
 - class: org.elasticsearch.action.bulk.BulkOperationTests
   method: testTsdbTimestampErrorDuringRoutingRedirectsToFailureStoreBatchMode
   issue: https://github.com/elastic/elasticsearch/issues/159019
-- class: org.elasticsearch.action.fieldcaps.FieldCapsWithFilterIT
-  method: testSkipUnmatchedShards
-  issue: https://github.com/elastic/elasticsearch/issues/159021
 - class: org.elasticsearch.transport.ProxyConnectionStrategyTests
   method: testProxyStrategyWillOpenNewConnectionsOnDisconnect
   issue: https://github.com/elastic/elasticsearch/issues/159027

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/fieldcaps/FieldCapsWithFilterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/fieldcaps/FieldCapsWithFilterIT.java
@@ -131,7 +131,10 @@ public class FieldCapsWithFilterIT extends ESIntegTestCase {
             oldTimestamp,
             true
         );
+        int nodeCount = internalCluster().size();
         internalCluster().stopNode(redNode);
+        // Wait for the master to commit redNode's departure before creating the next index
+        ensureStableCluster(nodeCount - 1);
         createIndexAndIndexDocs(
             "index_new",
             indexSettings(between(1, 5), 0).put("index.routing.allocation.include._name", blueNode),


### PR DESCRIPTION
After the node is removed, wait for the cluster to process the node removal before creating the next index.

Closes #159021
