### PR TITLE
Fix translog delete task race during shutdown

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -111,9 +111,6 @@ tests:
 #  - class: "org.elasticsearch.xpack.esql.**"
 #    method: "test {union_types.MultiIndexIpStringStatsInline *}"
 #    issue: "https://github.com/elastic/elasticsearch/..."
-- class: org.elasticsearch.xpack.stateless.engine.translog.StatelessTranslogIT
-  method: testTranslogMasterFailureOnlyStressRecoveryTest
-  issue: https://github.com/elastic/elasticsearch/issues/147835
 - class: org.elasticsearch.xpack.stateless.autoscaling.search.AutoscalingReplicaIT
   method: testSearchSizeAffectsReplicasSPBetween100And250
   issue: https://github.com/elastic/elasticsearch-serverless/issues/5731
@@ -180,9 +177,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlOldCoordinatorSpecK8sTimeseriesCountDistinctOverTimeIT
   method: test {csv-spec:k8s-timeseries-count-distinct-over-time.valuesNull}
   issue: https://github.com/elastic/elasticsearch/issues/150188
-- class: org.elasticsearch.xpack.stateless.engine.translog.StatelessTranslogIT
-  method: testTranslogStressRecoveryTest
-  issue: https://github.com/elastic/elasticsearch/issues/150297
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/150356

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/engine/translog/StatelessTranslogIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/engine/translog/StatelessTranslogIT.java
@@ -621,7 +621,7 @@ public class StatelessTranslogIT extends AbstractStatelessPluginIntegTestCase {
                 induceFailures(settings, indexName, failureTypes);
             }
 
-            safeAwait(allReqLatch);
+            safeAwait(allReqLatch, TimeValue.timeValueSeconds(60));
 
             refresh(indexName);
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreService.java
@@ -1835,19 +1835,27 @@ public class ObjectStoreService extends AbstractLifecycleComponent implements Cl
         @Override
         public void onFailure(Exception e) {
             // Might be 100 files only log when debug enabled
+            final var level = lifecycle.started() ? Level.WARN : Level.DEBUG;
             if (logger.isDebugEnabled()) {
-                logger.warn(() -> format("exception while attempting to delete blob files [%s]", toDeleteInThisTask), e);
+                logger.log(level, () -> format("exception while attempting to delete blob files [%s]", toDeleteInThisTask), e);
             } else {
-                logger.warn("exception while attempting to delete blob files", e);
+                logger.log(level, () -> "exception while attempting to delete blob files", e);
             }
         }
 
         @Override
         public void onAfter() {
             translogDeleteSchedulePermit.release();
-            if (translogBlobsToDelete.isEmpty() == false && translogDeleteSchedulePermit.tryAcquire()) {
+            if (isRunning() && translogBlobsToDelete.isEmpty() == false && translogDeleteSchedulePermit.tryAcquire()) {
                 threadPool.executor(StatelessPlugin.TRANSLOG_THREAD_POOL).execute(new FileDeleteTask(blobContainer));
             }
+        }
+
+        @Override
+        public void onRejection(Exception e) {
+            assert e instanceof EsRejectedExecutionException esre && esre.isExecutorShutdown() : e;
+            assert lifecycle.closed() : lifecycle;
+            // no need to retry or even log, we're shutting down
         }
 
         @Override


### PR DESCRIPTION
FileDeleteTask lacked the shutdown-aware handling that
ShardFilesDeleteTask already had. When ObjectStoreService.doClose()
timed out waiting for the translogDeleteSchedulePermit and set
objectStore = null, any FileDeleteTask still in flight would call
getTranslogBlobContainer() and receive IllegalStateException: Blob store
is null.

Three changes to FileDeleteTask bring it in line with
ShardFilesDeleteTask:
- onFailure() now logs at DEBUG instead of WARN during shutdown, so
expected errors during close don't surface as unexpected test noise.
- onAfter() guards the follow-on task scheduling behind isRunning(), so
no new tasks are submitted after the service stops.
- onRejection() is added to handle executor rejection during shutdown
cleanly, consistent with ShardFilesDeleteTask.

Also increases the allReqLatch timeout in runStressTest() from 10s to
60s. The ISOLATED_INDEXING_NODE failure scenario leaves bulk requests
waiting for translog sync listeners. In tests locally I occasionally
this 10s timeout. Increasing to 30s to prevent spurious failures