### PR TITLE
Add fail-fast for unavailable cluster in REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -98,6 +98,10 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -267,7 +271,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     /**
      * A client for the running Elasticsearch cluster
      */
-    private static RestClient client;
+    static RestClient client;
     /**
      * A client for the running Elasticsearch cluster configured to take test administrative actions like remove all indexes after the test
      * completes
@@ -277,6 +281,12 @@ public abstract class ESRestTestCase extends ESTestCase {
      * A client for the running Elasticsearch cluster configured to clean up the cluster after tests
      */
     private static RestClient cleanupClient;
+
+    /**
+     * Set once a test failure indicates the cluster is unreachable, so that remaining tests in the
+     * suite are skipped instead of producing redundant failures. Reset after each suite.
+     */
+    static boolean clusterUnavailable;
 
     private static boolean multiProjectEnabled;
     private static String activeProject;
@@ -387,6 +397,50 @@ public abstract class ESRestTestCase extends ESTestCase {
         activeProject = "active00" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
         extraProjects = randomSet(1, 3, () -> randomAlphaOfLength(12).toLowerCase(Locale.ROOT));
         multiProjectEnabled = Booleans.parseBoolean(System.getProperty("tests.multi_project.enabled", "false"));
+    }
+
+    @Before
+    public final void skipIfClusterUnavailable() {
+        assumeFalse("cluster unavailable", clusterUnavailable);
+    }
+
+    /**
+     * Wraps each test with logic that, on any (non-assumption) test failure, pings the cluster to
+     * check whether it is still usable. If the ping fails for any reason (unreachable or error
+     * response), the remaining tests in the suite are skipped and the original failure is replaced
+     * with a clearer error, avoiding a cascade of redundant, confusing failures.
+     */
+    @Rule
+    public final TestRule clusterDeadRule = (base, description) -> new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+            try {
+                base.evaluate();
+            } catch (AssumptionViolatedException e) {
+                throw e;
+            } catch (Throwable originalFailure) {
+                RestClient c = client();
+                if (c == null) {
+                    // initClient() failed before any test body ran — terminal state for the suite
+                    throw markClusterUnavailable("Test cluster was unreachable during client initialization", null, originalFailure);
+                }
+                try {
+                    c.performRequest(new Request("HEAD", "/"));
+                } catch (ResponseException e) {
+                    throw markClusterUnavailable("Test cluster is in a bad state", e, originalFailure);
+                } catch (IOException e) {
+                    throw markClusterUnavailable("Test cluster is unreachable", e, originalFailure);
+                }
+                throw originalFailure;
+            }
+        }
+    };
+
+    private static AssertionError markClusterUnavailable(String message, Throwable pingFailure, Throwable originalFailure) {
+        clusterUnavailable = true;
+        AssertionError e = new AssertionError(message, pingFailure);
+        e.addSuppressed(originalFailure);
+        return e;
     }
 
     @Before
@@ -640,6 +694,11 @@ public abstract class ESRestTestCase extends ESTestCase {
         return new HttpHost(host, port, getProtocol());
     }
 
+    @Override
+    protected boolean previousFailureSkipsRemaining() {
+        return clusterUnavailable || super.previousFailureSkipsRemaining();
+    }
+
     /**
      * Clean up after the test case.
      */
@@ -655,6 +714,11 @@ public abstract class ESRestTestCase extends ESTestCase {
                 logIfThereAreRunningTasks();
             }
         }
+    }
+
+    @AfterClass
+    public static void resetClusterUnavailable() {
+        clusterUnavailable = false;
     }
 
     @AfterClass

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/ESRestTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/ESRestTestCaseTests.java
@@ -8,15 +8,149 @@
  */
 package org.elasticsearch.test.rest;
 
+import org.apache.http.HttpHost;
+import org.apache.http.RequestLine;
+import org.apache.http.StatusLine;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
+import java.io.IOException;
 import java.util.regex.Matcher;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ESRestTestCaseTests extends ESTestCase {
+
+    // Minimal concrete subclass — ESRestTestCase declares no abstract methods
+    static class MinimalRestTestCase extends ESRestTestCase {}
+
+    private MinimalRestTestCase subject;
+
+    @Before
+    public void setUpClusterAvailabilityFields() {
+        subject = new MinimalRestTestCase();
+        ESRestTestCase.client = null;
+        ESRestTestCase.clusterUnavailable = false;
+    }
+
+    @After
+    public void tearDownClusterAvailabilityFields() {
+        ESRestTestCase.client = null;
+        ESRestTestCase.clusterUnavailable = false;
+    }
+
+    /** Runs the clusterDeadRule around a statement that always throws the given throwable. */
+    private void evaluateRule(Throwable toThrow) throws Throwable {
+        Statement failing = new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                throw toThrow;
+            }
+        };
+        Description description = Description.createTestDescription(MinimalRestTestCase.class, "testMethod");
+        subject.clusterDeadRule.apply(failing, description).evaluate();
+    }
+
+    public void testAssumptionViolationPassesThroughWithoutSettingFlag() throws Throwable {
+        AssumptionViolatedException assumption = new AssumptionViolatedException("skipped");
+        AssumptionViolatedException thrown = expectThrows(AssumptionViolatedException.class, () -> evaluateRule(assumption));
+        assertSame(assumption, thrown);
+        assertFalse(ESRestTestCase.clusterUnavailable);
+    }
+
+    public void testNullClientSetsUnavailableWithOriginalFailureSuppressed() throws Throwable {
+        RuntimeException original = new RuntimeException("test failure");
+        AssertionError thrown = expectThrows(AssertionError.class, () -> evaluateRule(original));
+        assertThat(thrown.getMessage(), containsString("initialization"));
+        assertNull(thrown.getCause());
+        assertSame(original, thrown.getSuppressed()[0]);
+        assertTrue(ESRestTestCase.clusterUnavailable);
+    }
+
+    public void testSuccessfulPingRethrownOriginalFailure() throws Throwable {
+        RestClient mockClient = mock(RestClient.class);
+        // performRequest returns normally — ping succeeds, cluster is alive
+        ESRestTestCase.client = mockClient;
+
+        RuntimeException original = new RuntimeException("test failure");
+        RuntimeException thrown = expectThrows(RuntimeException.class, () -> evaluateRule(original));
+        assertSame(original, thrown);
+        assertFalse(ESRestTestCase.clusterUnavailable);
+    }
+
+    public void testIOExceptionPingSetsUnreachable() throws Throwable {
+        RestClient mockClient = mock(RestClient.class);
+        IOException pingFailure = new IOException("connection refused");
+        when(mockClient.performRequest(any(Request.class))).thenThrow(pingFailure);
+        ESRestTestCase.client = mockClient;
+
+        RuntimeException original = new RuntimeException("test failure");
+        AssertionError thrown = expectThrows(AssertionError.class, () -> evaluateRule(original));
+        assertEquals("Test cluster is unreachable", thrown.getMessage());
+        assertSame(pingFailure, thrown.getCause());
+        assertSame(original, thrown.getSuppressed()[0]);
+        assertTrue(ESRestTestCase.clusterUnavailable);
+    }
+
+    public void testResponseExceptionPingSetsBadState() throws Throwable {
+        RestClient mockClient = mock(RestClient.class);
+        ResponseException pingFailure = mockResponseException();
+        when(mockClient.performRequest(any(Request.class))).thenThrow(pingFailure);
+        ESRestTestCase.client = mockClient;
+
+        RuntimeException original = new RuntimeException("test failure");
+        AssertionError thrown = expectThrows(AssertionError.class, () -> evaluateRule(original));
+        assertEquals("Test cluster is in a bad state", thrown.getMessage());
+        assertSame(pingFailure, thrown.getCause());
+        assertSame(original, thrown.getSuppressed()[0]);
+        assertTrue(ESRestTestCase.clusterUnavailable);
+    }
+
+    public void testSkipIfClusterUnavailableSkipsWhenFlagIsSet() throws Exception {
+        ESRestTestCase.clusterUnavailable = true;
+        expectThrows(AssumptionViolatedException.class, () -> subject.skipIfClusterUnavailable());
+    }
+
+    public void testPreviousFailureSkipsRemainingReflectsFlag() {
+        assertFalse(subject.previousFailureSkipsRemaining());
+        ESRestTestCase.clusterUnavailable = true;
+        assertTrue(subject.previousFailureSkipsRemaining());
+    }
+
+    public void testResetClusterUnavailableClearsFlag() {
+        ESRestTestCase.clusterUnavailable = true;
+        ESRestTestCase.resetClusterUnavailable();
+        assertFalse(ESRestTestCase.clusterUnavailable);
+    }
+
+    private static ResponseException mockResponseException() throws IOException {
+        Response response = mock(Response.class);
+        RequestLine requestLine = mock(RequestLine.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(response.getRequestLine()).thenReturn(requestLine);
+        when(requestLine.getMethod()).thenReturn("HEAD");
+        when(requestLine.getUri()).thenReturn("/");
+        when(response.getHost()).thenReturn(new HttpHost("localhost", 9200));
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.toString()).thenReturn("HTTP/1.1 503 Service Unavailable");
+        when(response.hasWarnings()).thenReturn(false);
+        when(response.getEntity()).thenReturn(null);
+        return new ResponseException(response);
+    }
 
     public void testIgnoreMatchMultipleTemplatesPattern() {
         String input = "index [test_index] matches multiple legacy templates [global, prevent-bwc-deprecation-template], "


### PR DESCRIPTION
When a REST test fails, the test rule now pings the cluster and skips
remaining tests in the suite if the cluster appears unavailable. This
covers three cases: the client was never initialized (initClient()
failed), the ping returns a non-2xx HTTP response (ResponseException),
or the ping throws an IOException (truly unreachable). Previously only
the IOException case triggered fail-fast, and a null client just
rethrew the original failure.

closes elastic/elasticsearch-team#4034
