### PR TITLE
[ESQL] Add null-safety to TRange exception

### DIFF
--- a/docs/changelog/159125.yaml
+++ b/docs/changelog/159125.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 159125
+summary: Add null-safety to TRange exception
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/TRange.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/TRange.java
@@ -290,7 +290,7 @@ public class TRange extends EsqlConfigurationFunction
             var zonedDateTime = ZonedDateTime.ofInstant(base, QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()));
             return zonedDateTime.minus(amount).toInstant();
         }
-        throw new InvalidArgumentException("Unsupported offset type [{}]", offset.getClass().getSimpleName());
+        throw new InvalidArgumentException("Unsupported offset type [{}]", offset != null ? offset.getClass().getSimpleName() : "null");
     }
 
     private Instant parseToInstant(Object value, String paramName, boolean nanos) {
@@ -316,7 +316,7 @@ public class TRange extends EsqlConfigurationFunction
 
         throw new InvalidArgumentException(
             "Unsupported time value type [{}] for parameter [{}]",
-            value.getClass().getSimpleName(),
+            value != null ? value.getClass().getSimpleName() : "null",
             paramName
         );
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/TRangeErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/TRangeErrorTests.java
@@ -132,6 +132,34 @@ public class TRangeErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
             );
             trange.surrogate();
         });
+
+        // Start time folds to null in two parameter mode (typed non-null, so it passes resolveType's isNotNull)
+        expectThrows(
+            InvalidArgumentException.class,
+            equalTo("invalid time range for []: Unsupported time value type [null] for parameter [start_time_or_offset]"),
+            () -> {
+                TRange trange = new TRange(
+                    Source.EMPTY,
+                    new Literal(Source.EMPTY, null, DataType.DATETIME),
+                    Literal.keyword(Source.EMPTY, "2024-01-01T12:00:00Z"),
+                    Literal.dateTime(Source.EMPTY, Instant.now()),
+                    EsqlTestUtils.configuration(StringUtils.EMPTY)
+                );
+                trange.surrogate();
+            }
+        );
+
+        // Offset folds to null in single parameter mode
+        expectThrows(InvalidArgumentException.class, equalTo("invalid time range for []: Unsupported offset type [null]"), () -> {
+            TRange trange = new TRange(
+                Source.EMPTY,
+                new Literal(Source.EMPTY, null, DataType.TIME_DURATION),
+                null,
+                Literal.dateTime(Source.EMPTY, Instant.now()),
+                EsqlTestUtils.configuration(StringUtils.EMPTY)
+            );
+            trange.surrogate();
+        });
     }
 
     @Override


### PR DESCRIPTION
TRange will throw an invalidation exception when start or offset are null.
