### PR TITLE
Use confined arena for columnar temp-file reads

### DIFF
--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnWriter.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnWriter.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.ReadOnceHint;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -460,7 +461,7 @@ public final class StringColumnWriter {
 
             final String staged = ordinalTempName;
             final NumericColumnMetadata ordinals = NumericColumnWriter.write(numDocsWithField, numDocsWithField, numValues, () -> {
-                final IndexInput in = directory.openInput(staged, context);
+                final IndexInput in = directory.openInput(staged, context.withHints(ReadOnceHint.INSTANCE));
                 replays.add(in);
                 return stagedOrdinals(cursors.get(), in);
             },
@@ -513,7 +514,7 @@ public final class StringColumnWriter {
             return ValueStream.Metadata.empty();
         }
         try (
-            IndexInput staged = directory.openInput(name, context);
+            IndexInput staged = directory.openInput(name, context.withHints(ReadOnceHint.INSTANCE));
             ValueStream.Writer writer = new ValueStream.Writer(
                 chunkCodec,
                 targetChunkBytes,

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/substrate/ChunkedBytesWriter.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/substrate/ChunkedBytesWriter.java
@@ -13,6 +13,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.ReadOnceHint;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.IOUtils;
 
@@ -133,7 +134,7 @@ public final class ChunkedBytesWriter implements Closeable {
         final MonotonicWriter.Table startsTable;
         final MonotonicWriter.Table offsetsTable;
         try (
-            IndexInput staged = directory.openInput(chunkTempName, context);
+            IndexInput staged = directory.openInput(chunkTempName, context.withHints(ReadOnceHint.INSTANCE));
             MonotonicWriter startsOut = new MonotonicWriter(directory, context, prefix, numChunks + 1L);
             MonotonicWriter offsetsOut = new MonotonicWriter(directory, context, prefix, numChunks + 1L)
         ) {

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/substrate/MonotonicWriter.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/substrate/MonotonicWriter.java
@@ -15,6 +15,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.ReadOnceHint;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 
@@ -69,7 +70,7 @@ public final class MonotonicWriter implements Closeable {
         dataTemp.close();
         dataClosed = true;
         long dataOffset = data.getFilePointer();
-        try (IndexInput in = directory.openInput(tempName, context)) {
+        try (IndexInput in = directory.openInput(tempName, context.withHints(ReadOnceHint.INSTANCE))) {
             data.copyBytes(in, in.length());
         }
         return new Table(dataOffset, data.getFilePointer() - dataOffset, metaBuffer.toArrayCopy());


### PR DESCRIPTION
When the columnar codec flushes a string column, it reads back several temporary files (in `MonotonicWriter.finish()`, `ChunkedBytesWriter.finish()`, and two spots in `StringColumnWriter`) to copy their data into the segment file. These `openInput` calls were passing the ambient `context`, which causes `MMapDirectory` to map the file with a *shared* `Arena`. Closing a shared arena triggers a JVM thread handshake (`ScopedMemoryAccess.closeScope`), which blocks the flushing thread until every other JVM thread acknowledges — a significant bottleneck under concurrent indexing.

Passing `IOContext.READONCE` instead tells `MMapDirectory` to use a *confined* `Arena`, which has zero handshake cost on close. 

Identified via JFR wall-clock profiling of a benchmark comparing the columnar docvalues codec against the es819 default codec on the `elastic/logs` track (`logging-querying` challenge). The blocked-in-futex samples within the docvalues flush path accounted for roughly half the wall-clock time of that path in the columnar run. We expect this change to significantly reduce the `refresh_time` regression observed in the nightly benchmarks between the two codecs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)