### PR TITLE
[9.5] ESQL: read partition_detection and partition_path on the query path (#157208)

### DIFF
--- a/docs/changelog/157208.yaml
+++ b/docs/changelog/157208.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157208
+summary: Read `partition_detection` and `partition_path` on the query path
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
@@ -249,6 +249,25 @@ tasks.register('generateHivePartitionedParquet_employees', JavaExec) {
 }
 generateParquetTasks.add(tasks.named('generateHivePartitionedParquet_employees'))
 
+// Generate a Hive-partitioned fixture whose partition key COLLIDES with a real payload column: rows are
+// bucketed by `languages` into directories languages=1/, ..., languages=__HIVE_DEFAULT_PARTITION__/, and the
+// generator preserves `languages` in the parquet payload. Reading this dataset therefore hides the physical
+// column behind the path-derived one (Spark/DuckDB shadowing semantics) and emits the shadow warning. Used to
+// reproduce that `partition_detection: none` cannot opt out of that substitution.
+def hiveShadowDir = file("${parquetFixtureOutputDir}/hive-partitioned-shadow")
+tasks.register('generateHiveShadowParquet_employees', JavaExec) {
+  dependsOn serverProject.tasks.named('compileParquetFixtureGeneratorJava')
+  dependsOn testFixturesProject.tasks.named('processResources')
+  classpath = serverProject.configurations.parquetFixtureGenerator + serverProject.sourceSets.parquetFixtureGenerator.output
+  mainClass = 'org.elasticsearch.xpack.esql.datasources.ParquetFixtureGenerator'
+  args = [hivePartitionedEmployeesCsv.path, hiveShadowDir.path, '--hive-by', 'languages', 'languages']
+  inputs.file(hivePartitionedEmployeesCsv)
+  outputs.dir(hiveShadowDir)
+  systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+  systemProperty 'slf4j.internal.verbosity', 'WARN'
+}
+generateParquetTasks.add(tasks.named('generateHiveShadowParquet_employees'))
+
 // Generate compressed Parquet fixtures for each supported internal codec.
 // Each codec gets its own directory: standalone-snappy/, standalone-gzip/, etc.
 apply from: serverProject.file('compressed-parquet-fixtures.gradle')

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/parquet-partition-detection.csv-spec
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/parquet-partition-detection.csv-spec
@@ -1,0 +1,117 @@
+// Pins that the `partition_detection`, `partition_path` and `hive_partitioning` dataset settings select the
+// partition detector on the read path, end to end over a real storage backend.
+//
+// A csv-spec has no error channel, so only the promises expressible as a result table live here; the promises whose
+// fulfilment is an absence — suppressed partition metadata — or a cache-identity property are pinned in
+// PartitionDetectionSettingTests instead.
+//
+// Fixtures:
+//   {{employees_hive}}         hive-partitioned/lang=*/              partition key `lang`, payload column `languages`
+//   {{employees_hive_shadow}}  hive-partitioned-shadow/languages=*/  partition key COLLIDES with payload `languages`
+
+hiveDetectionOnByDefault
+required_capability: dataset_in_from_command
+dataset: employees_hive: "{{employees_hive}}"
+
+FROM employees_hive
+| STATS count = COUNT(*) BY lang
+| SORT lang NULLS LAST;
+
+count:long | lang:integer
+15         | 1
+19         | 2
+17         | 3
+18         | 4
+21         | 5
+10         | null
+;
+
+// ---------------------------------------------------------------------------------------------------------
+// The legacy switch. It now resolves through the same PartitionConfig as everything else (folded to
+// Strategy.NONE), so it must keep behaving exactly as it always has.
+// ---------------------------------------------------------------------------------------------------------
+
+hivePartitioningFalseTurnsDetectionOff
+required_capability: dataset_in_from_command
+dataset: employees_hive_detection_off: "{{employees_hive}}" WITH {"hive_partitioning": "false"}
+
+FROM employees_hive_detection_off
+| STATS count = COUNT(*);
+
+count:long
+100
+;
+
+// ---------------------------------------------------------------------------------------------------------
+// A `partition_path` template names the partition column. If the setting stops reaching the read path the Hive
+// detector runs instead, the template is dropped, and this fails with `Unknown column [bucket]`.
+//
+// The expected `lang=__HIVE_DEFAULT_PARTITION__` is deliberate: template detection binds the literal directory name,
+// and the Hive null sentinel is a Hive-writer convention that only the Hive detector interprets.
+// ---------------------------------------------------------------------------------------------------------
+
+templateStrategyNamesTheColumnFromTheTemplate
+required_capability: dataset_in_from_command
+dataset: employees_hive_template: "{{employees_hive}}" WITH {"partition_detection": "template", "partition_path": "{bucket}"}
+
+FROM employees_hive_template
+| STATS count = COUNT(*) BY bucket
+| SORT bucket;
+
+count:long | bucket:keyword
+15         | lang=1
+19         | lang=2
+17         | lang=3
+18         | lang=4
+21         | lang=5
+10         | lang=__HIVE_DEFAULT_PARTITION__
+;
+
+// ---------------------------------------------------------------------------------------------------------
+// Silent column substitution on a colliding layout: the directory key `languages` is also a real column inside the
+// parquet files. The path-derived value wins and the physical column is hidden (Spark/DuckDB semantics), and the
+// response warns. The warning now points at `partition_detection: none`, which is the setting that actually
+// switches it off.
+// ---------------------------------------------------------------------------------------------------------
+
+shadowedColumnSubstitutionAndWarning
+required_capability: dataset_in_from_command
+dataset: employees_hive_shadow_ds: "{{employees_hive_shadow}}"
+
+FROM employees_hive_shadow_ds
+| STATS count = COUNT(*) BY languages
+| SORT languages NULLS LAST;
+
+warningRegex:.*one or more physical columns are shadowed by same-named Hive partition keys.*Set partition_detection to none to read the physical column instead.*
+warningRegex:.*physical column \[languages\] is shadowed by a same-named Hive partition key.*
+
+count:long | languages:integer
+15         | 1
+19         | 2
+17         | 3
+18         | 4
+21         | 5
+10         | null
+;
+
+// ---------------------------------------------------------------------------------------------------------
+// The documented opt-out stops the substitution: with `partition_detection: none` nothing is path-derived, so the
+// physical column is read and no shadow warning is emitted.
+// ---------------------------------------------------------------------------------------------------------
+
+noneStopsTheColumnSubstitution
+required_capability: dataset_in_from_command
+dataset: employees_hive_shadow_none: "{{employees_hive_shadow}}" WITH {"partition_detection": "none"}
+
+FROM employees_hive_shadow_none
+| STATS count = COUNT(*) BY languages
+| SORT languages NULLS LAST;
+
+count:long | languages:integer
+15         | 1
+19         | 2
+17         | 3
+18         | 4
+21         | 5
+10         | null
+;

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourceValidatorTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourceValidatorTests.java
@@ -285,19 +285,73 @@ public class S3DataSourceValidatorTests extends AbstractDataSourceValidatorTests
     }
 
     public void testValidateDatasetPartitionDetectionInvalid() {
-        expectThrows(
+        ValidationException e = expectThrows(
             ValidationException.class,
             () -> validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", "banana"))
         );
+        // One actionable message, not that message plus Enum.valueOf's raw "No enum constant ...".
+        assertThat(e.validationErrors(), hasSize(1));
+        assertThat(e.getMessage(), not(containsString("No enum constant")));
     }
 
     public void testValidateDatasetPartitionDetectionAllValues() {
-        for (String strategy : new String[] { "auto", "hive", "template", "none", "AUTO", "HIVE", "TEMPLATE", "NONE" }) {
+        for (String strategy : new String[] { "auto", "hive", "none", "AUTO", "HIVE", "NONE" }) {
             assertEquals(
                 strategy,
                 validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", strategy)).get("partition_detection")
             );
         }
+        // template carries its path template with it; on its own it would be a strategy that detects nothing.
+        for (String strategy : new String[] { "template", "TEMPLATE" }) {
+            assertEquals(
+                strategy,
+                validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", strategy, "partition_path", "{year}"))
+                    .get("partition_detection")
+            );
+        }
+    }
+
+    /**
+     * The three combinations in which one of the partition settings would be silently ignored. Rejected at
+     * registration only — {@code PartitionConfig.fromConfig} still resolves them leniently so datasets stored
+     * before this validation existed keep reading.
+     */
+    public void testValidateDatasetRejectsSilentlyIgnoredPartitionSettings() {
+        expectThrows(
+            ValidationException.class,
+            () -> validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", "template"))
+        );
+        expectThrows(
+            ValidationException.class,
+            () -> validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", "hive", "hive_partitioning", "false"))
+        );
+        expectThrows(
+            ValidationException.class,
+            () -> validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", "none", "partition_path", "{year}"))
+        );
+        expectThrows(
+            ValidationException.class,
+            () -> validator.validateDataset(Map.of(), "s3://b/p", Map.of("hive_partitioning", "false", "partition_path", "{year}"))
+        );
+        // hive never reads a path template, so storing one would store a setting that does nothing.
+        expectThrows(
+            ValidationException.class,
+            () -> validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", "hive", "partition_path", "{year}"))
+        );
+    }
+
+    /** hive_partitioning:true asserts nothing — it is the default — so it never contradicts a strategy. */
+    public void testValidateDatasetAcceptsHivePartitioningTrueWithAnyStrategy() {
+        assertEquals(
+            "hive",
+            validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", "hive", "hive_partitioning", "true"))
+                .get("partition_detection")
+        );
+        assertEquals(
+            "none",
+            validator.validateDataset(Map.of(), "s3://b/p", Map.of("partition_detection", "none", "hive_partitioning", "true"))
+                .get("partition_detection")
+        );
     }
 
     public void testValidateDatasetSchemeCaseInsensitive() {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -394,7 +394,10 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         // directive so the suite's reader override still applies. A spec with no directive is returned as-is.
         String query = rebuildExternalFromDatasets(testCase.query);
 
-        if (query.contains(MULTIFILE_SUFFIX) || query.contains(HIVE_SUFFIX + "}}")) {
+        // The dataset path below matches on the bare suffix; this one matches on suffix + "}}" because it reads the
+        // rebuilt query text. HIVE_SHADOW_SUFFIX therefore needs naming explicitly: it contains HIVE_SUFFIX but does
+        // not end with it, so "_hive}}" does not match "{{employees_hive_shadow}}".
+        if (query.contains(MULTIFILE_SUFFIX) || query.contains(HIVE_SUFFIX + "}}") || query.contains(HIVE_SHADOW_SUFFIX + "}}")) {
             // HTTP does not support directory listing, so skip multi-file/Hive-partitioned glob tests
             assumeTrue("HTTP backend does not support multi-file glob patterns", storageBackend != StorageBackend.HTTP);
         }
@@ -746,6 +749,13 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
     private static final String HIVE_SUFFIX = "_hive";
 
     /**
+     * Hive-partitioned fixture whose partition key collides with a real payload column (see the
+     * {@code generateHiveShadowParquet_employees} fixture task). Checked before {@link #HIVE_SUFFIX}; the name still
+     * contains {@code _hive} so the HTTP glob-skip applies to it too.
+     */
+    private static final String HIVE_SHADOW_SUFFIX = "_hive_shadow";
+
+    /**
      * Resolve a template name to an actual path based on storage backend and format.
      *
      * @param templateName the template name (e.g., "employees", "employees_multifile", or "employees_multifile_ubn")
@@ -771,6 +781,9 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         } else if (templateName.endsWith(MULTIFILE_SUFFIX)) {
             // Multi-file template: employees_multifile -> multifile/*.parquet
             relativePath = "multifile/*." + format;
+        } else if (templateName.endsWith(HIVE_SHADOW_SUFFIX)) {
+            // Hive layout whose partition key shadows a same-named payload column.
+            relativePath = "hive-partitioned-shadow/**/*." + format;
         } else if (templateName.endsWith(HIVE_SUFFIX)) {
             // Hive-partitioned template: employees_hive -> hive-partitioned/**/*.parquet
             // (uses ** so the glob recurses into lang=*/ partition directories; HivePartitionDetector

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
@@ -78,10 +78,14 @@ public class ExternalCsvHivePartitionedIT extends AbstractExternalDataSourceIT {
     }
 
     /**
-     * Same fixture, queries with explicit {@code partition_path} key, asserting that
-     * {@code partition_path} is accepted by the coordinator-key validator (was also missing
-     * from COORDINATOR_KEYS before this fix). The primary assertion is that the query does
-     * not fail with "unknown option [partition_path]".
+     * Same fixture, with an explicit {@code partition_path}. This template names NO columns — the detector matches a
+     * path segment in full, so {@code year={year}} is not a placeholder. With no {@code partition_detection} the
+     * strategy is AUTO, which tries Hive first, so the dataset keeps the {@code year}/{@code month} columns it had
+     * before the setting reached the read path.
+     *
+     * <p>It previously asserted only that the query did not fail with "unknown option [partition_path]". An
+     * acceptance assertion cannot tell an applied template from an unapplied one, so it passed while the setting
+     * was unread. It now asserts the resulting columns.
      */
     public void testPartitionPathValidatesAndParses() throws Exception {
         Path root = createTempDir().resolve("template_csv");
@@ -92,9 +96,41 @@ public class ExternalCsvHivePartitionedIT extends AbstractExternalDataSourceIT {
         String dataset = registerDataset("template_csv", glob, Map.of("partition_path", "year={year}/month={month}/*.csv"));
         String query = "FROM " + dataset + " | LIMIT 1";
 
-        // Primary assertion: query does not throw "unknown option [partition_path]".
         try (var response = run(syncEsqlQueryRequest(query))) {
-            assertThat("expect at least 1 column", response.columns().size(), greaterThanOrEqualTo(1));
+            List<String> columnNames = response.columns().stream().map(c -> c.name()).collect(Collectors.toList());
+            assertThat("the data columns must still be read", columnNames, hasItem("id"));
+            // The template names no columns, so AUTO falls through to Hive detection -- the same columns this
+            // dataset produced before partition_path reached the read path.
+            assertThat("the Hive-derived year must still appear", columnNames, hasItem("year"));
+            assertThat("and the Hive-derived month", columnNames, hasItem("month"));
+        }
+    }
+
+    /**
+     * The documented opt-out against a colliding layout: with {@code partition_detection: none} nothing is derived
+     * from the path, so the PHYSICAL {@code year} (1999) is read rather than the directory's 2024, and no shadow
+     * warning is emitted. This is the end-to-end form of the defect: the setting was inert, so the substitution happened regardless of
+     * what the user asked for.
+     */
+    public void testDetectionNoneReadsThePhysicalColumnOnACollidingLayout() throws Exception {
+        Path root = createTempDir().resolve("hive_collision_none_csv");
+        writeCollisionCsvFiles(root);
+
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // checkstyle thinks this is Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.csv";
+        String dataset = registerDataset("hive_collision_none_csv", glob, Map.of("partition_detection", "none"));
+
+        String query = "FROM " + dataset + " | KEEP id, year, value | LIMIT 5";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<String> columnNames = response.columns().stream().map(c -> c.name()).collect(Collectors.toList());
+            int yearIdx = columnNames.indexOf("year");
+            assertThat("the physical year column must be readable", yearIdx, greaterThanOrEqualTo(0));
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("expect the rows from the data file", rows.size(), greaterThanOrEqualTo(2));
+            for (List<Object> row : rows) {
+                assertThat("partition_detection:none reads the file's own 1999, not the path's 2024", row.get(yearIdx), is(1999));
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -222,6 +222,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         "employees_extensionless",
         "logs_id_partition",
         "logs_partition_collide_nonstrict",
+        "logs_partition_collide_none",
         "logs_partition_collide_path",
         "employees_strict_coerce",
         "employees_strict_uncoercible",
@@ -5104,6 +5105,57 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         assertThat(e.getMessage(), containsString("region"));
         // Pin the partition branch specifically, not the sibling "no such column exists" reject (both embed [_id]+path).
         assertThat(e.getMessage(), containsString("not a data column"));
+    }
+
+    /**
+     * The declared-schema face of the partition-detection settings defect. A declared column colliding with a path-derived
+     * partition key is rejected ({@link #testNonStrictPartitionKeyCollisionRejected}), and on main
+     * {@code partition_detection: none} could not avoid that rejection because the setting never reached the read
+     * path — so a user whose data sat under {@code something=value/} could not declare a column of that name at
+     * all. With the setting honoured, {@code none} suppresses the detection that creates the collision, and the
+     * declaration resolves.
+     *
+     * <p>The fixture carries a physical {@code region} column holding {@code emea} while the directory says
+     * {@code region=east}, so the assertion distinguishes which one was read.
+     */
+    public void testPartitionKeyCollisionAcceptedWithDetectionNone() throws Exception {
+        Path root = createTempDir();
+        Path east = Files.createDirectories(root.resolve("region=east"));
+        // The file carries a real region column AND sits under region=east/. That is the shape the defect covers:
+        // on main the path-derived region shadowed the physical one and the declaration was rejected, with no
+        // opt-out. The physical values differ from the directory's so the assertion can tell which one was read.
+        Files.writeString(east.resolve("part1.csv"), "emp_no:integer,first_name:keyword,region:keyword\n1,Alice,emea\n2,Bob,emea\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
+        props.put("region", new DatasetFieldMapping("keyword", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, props));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "logs_partition_collide_none",
+                    "local_ds",
+                    root.toUri() + "**/*.csv",
+                    null,
+                    new HashMap<>(Map.of("format", "csv", "partition_detection", "none")),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM logs_partition_collide_none | KEEP region | LIMIT 5"), TIMEOUT)) {
+            List<String> columnNames = response.columns().stream().map(c -> c.name()).toList();
+            assertThat("the declared column must resolve rather than be rejected", columnNames, hasItem("region"));
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("expect the file's rows", rows.size(), greaterThanOrEqualTo(2));
+            for (List<Object> row : rows) {
+                assertEquals("with detection off the file's own region is read, not the directory's", "emea", row.get(0));
+            }
+        }
     }
 
     public void testNonStrictPartitionKeyCollisionRejected() throws Exception {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AutoPartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AutoPartitionDetector.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 
 /**
  * Auto-detecting partition detector that tries Hive-style detection first,
@@ -19,13 +19,10 @@ public final class AutoPartitionDetector implements PartitionDetector {
     private final PartitionConfig partitionConfig;
 
     AutoPartitionDetector(PartitionConfig partitionConfig) {
-        this.partitionConfig = partitionConfig;
+        this.partitionConfig = Objects.requireNonNull(partitionConfig, "partitionConfig cannot be null");
     }
 
     public static PartitionDetector fromConfig(PartitionConfig config) {
-        if (config == null) {
-            return HivePartitionDetector.INSTANCE;
-        }
         return new AutoPartitionDetector(config);
     }
 
@@ -35,18 +32,20 @@ public final class AutoPartitionDetector implements PartitionDetector {
     }
 
     @Override
-    public PartitionMetadata detect(List<StorageEntry> files, Map<String, Object> config) {
+    public PartitionMetadata detect(List<StorageEntry> files) {
         // Try Hive first
-        PartitionMetadata hiveResult = HivePartitionDetector.INSTANCE.detect(files, config);
+        PartitionMetadata hiveResult = HivePartitionDetector.INSTANCE.detect(files);
         if (hiveResult.isEmpty() == false) {
             return hiveResult;
         }
 
         // Fall back to template if configured
-        String template = partitionConfig != null ? partitionConfig.pathTemplate() : null;
-        if (template != null && template.isEmpty() == false) {
+        // Same grammar guard as GlobExpander.resolveDetector: TemplatePartitionDetector's constructor rejects a
+        // template naming no whole-segment {name} placeholders, and this fallback is reachable with any stored value.
+        String template = partitionConfig.pathTemplate();
+        if (template != null && TemplatePartitionDetector.parseTemplateColumns(template).isEmpty() == false) {
             TemplatePartitionDetector templateDetector = new TemplatePartitionDetector(template);
-            return templateDetector.detect(files, config);
+            return templateDetector.detect(files);
         }
 
         return PartitionMetadata.EMPTY;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -482,7 +482,6 @@ public class ExternalSourceResolver {
         String path = paths.get(index);
         Map<String, Object> config = pathConfigs.getOrDefault(path, Map.of());
         List<PartitionFilterHintExtractor.PartitionFilterHint> hints = filterHints != null ? filterHints.get(path) : null;
-        boolean hivePartitioning = isHivePartitioningEnabled(config);
         // null => legacy eager for every path; non-null => eager only for listed paths.
         boolean requiresStats = pathsRequiringStats == null || pathsRequiringStats.contains(path);
         DatasetMapping declaredMapping = declaredMappings != null ? declaredMappings.get(path) : null;
@@ -493,7 +492,7 @@ public class ExternalSourceResolver {
         // the data node stamp _id from that column rather than the synthetic (file+row-position) identity.
         DeclaredReadSpec declaredReadSpec = declaredReadSpecOf(declaredMapping);
 
-        resolveSource(path, config, hints, hivePartitioning, declaredMapping, requiresStats, ActionListener.wrap(resolvedSource -> {
+        resolveSource(path, config, hints, declaredMapping, requiresStats, ActionListener.wrap(resolvedSource -> {
             // Strict is built directly from the declaration inside resolveSource; non-strict infers first and then
             // overlays the declaration onto the resolved result (works the same for single- and multi-file).
             ExternalSourceResolution.ResolvedSource finalSource = declaredMapping != null && isDeclaredSchema(declaredMapping) == false
@@ -580,14 +579,13 @@ public class ExternalSourceResolver {
         String path,
         Map<String, Object> config,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning,
         @Nullable DatasetMapping declaredMapping,
         boolean requiresStats,
         ActionListener<ExternalSourceResolution.ResolvedSource> listener
     ) {
         LOGGER.debug("Resolving external source: path=[{}]", path);
         try {
-            resolveSourceInner(path, config, hints, hivePartitioning, declaredMapping, requiresStats, listener);
+            resolveSourceInner(path, config, hints, declaredMapping, requiresStats, listener);
         } catch (Exception e) {
             listener.onFailure(e);
         }
@@ -597,7 +595,6 @@ public class ExternalSourceResolver {
         String path,
         Map<String, Object> config,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning,
         @Nullable DatasetMapping declaredMapping,
         boolean requiresStats,
         ActionListener<ExternalSourceResolution.ResolvedSource> listener
@@ -607,7 +604,7 @@ public class ExternalSourceResolver {
         throwIfCancelled();
 
         if (GlobExpander.isMultiFile(path)) {
-            resolveMultiFileSource(path, config, hints, hivePartitioning, declaredMapping, requiresStats, listener);
+            resolveMultiFileSource(path, config, hints, declaredMapping, requiresStats, listener);
         } else {
             resolveSingleFileSource(path, config, declaredMapping, listener);
         }
@@ -688,7 +685,6 @@ public class ExternalSourceResolver {
         String path,
         Map<String, Object> config,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning,
         @Nullable DatasetMapping declaredMapping,
         boolean requiresStats,
         ActionListener<ExternalSourceResolution.ResolvedSource> listener
@@ -700,7 +696,7 @@ public class ExternalSourceResolver {
         // skipped entirely — only the glob listing plus, for columnar formats, one anchor footer read to validate
         // declared-type coercibility. The non-strict overlay is applied by the caller after this returns.
         if (isDeclaredSchema(declaredMapping)) {
-            listener.onResponse(resolveStrictMultiFile(path, storagePath, provider, hints, hivePartitioning, config, declaredMapping));
+            listener.onResponse(resolveStrictMultiFile(path, storagePath, provider, hints, config, declaredMapping));
             return;
         }
 
@@ -711,7 +707,7 @@ public class ExternalSourceResolver {
             int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
             int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
             long discoveryStartNanos = System.nanoTime();
-            FileList raw = GlobExpander.expand(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
+            FileList raw = GlobExpander.expand(path, provider, hints, config, maxDiscoveredFiles, maxGlobExpansion);
             recordDiscovery(raw, discoveryStartNanos, storagePath.scheme());
             if (raw.fileCount() == 0) {
                 throw new IllegalArgumentException("Glob pattern matched no files: " + path);
@@ -723,9 +719,9 @@ public class ExternalSourceResolver {
         FileList listing;
         long discoveryStartNanos = System.nanoTime();
         if (cacheable) {
-            listing = cachedListing(path, storagePath, provider, hints, hivePartitioning, config);
+            listing = cachedListing(path, storagePath, provider, hints, config);
         } else {
-            listing = expandAndCompact(path, provider, hints, hivePartitioning, storagePath);
+            listing = expandAndCompact(path, provider, hints, config, storagePath);
         }
         recordDiscovery(listing, discoveryStartNanos, storagePath.scheme());
 
@@ -974,18 +970,18 @@ public class ExternalSourceResolver {
         String path,
         StorageProvider provider,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning,
+        Map<String, Object> config,
         StoragePath storagePath
     ) throws Exception {
         int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
         int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
-        return GlobExpander.expandAndCompact(path, provider, hints, hivePartitioning, storagePath, maxDiscoveredFiles, maxGlobExpansion);
+        return GlobExpander.expandAndCompact(path, provider, hints, config, storagePath, maxDiscoveredFiles, maxGlobExpansion);
     }
 
     /**
      * Looks up, or computes and caches, the compacted listing for a cacheable provider. The cache-key build and the
      * compute lambda are kept together on purpose: the discriminator folded into the key must describe exactly the
-     * {@code (path, hints, hivePartitioning)} the lambda expands, or a filtered query's narrowed listing can be
+     * {@code (path, hints)} the lambda expands, or a filtered query's narrowed listing can be
      * served to a later unfiltered one. Every cacheable resolution rail routes through here so that pairing lives in
      * one place. See {@link ListingCacheKey}.
      */
@@ -994,7 +990,6 @@ public class ExternalSourceResolver {
         StoragePath storagePath,
         StorageProvider provider,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning,
         Map<String, Object> config
     ) throws Exception {
         ListingCacheKey listingKey = ListingCacheKey.build(
@@ -1002,9 +997,9 @@ public class ExternalSourceResolver {
             storagePath.host(),
             storagePath.path(),
             config,
-            GlobExpander.listingCacheDiscriminator(path, hints, hivePartitioning)
+            GlobExpander.listingCacheDiscriminator(path, hints, config)
         );
-        return cacheService.getOrComputeListing(listingKey, k -> expandAndCompact(path, provider, hints, hivePartitioning, storagePath));
+        return cacheService.getOrComputeListing(listingKey, k -> expandAndCompact(path, provider, hints, config, storagePath));
     }
 
     /**
@@ -1948,17 +1943,6 @@ public class ExternalSourceResolver {
         return merged;
     }
 
-    private static boolean isHivePartitioningEnabled(Map<String, Object> config) {
-        if (config == null) {
-            return true;
-        }
-        Object value = config.get(PartitionConfig.CONFIG_PARTITIONING_HIVE);
-        if (value == null) {
-            return true;
-        }
-        return "false".equalsIgnoreCase(value.toString()) == false;
-    }
-
     private SourceMetadata resolveSingleSource(String path, Map<String, Object> config) {
         // Early scheme validation: reject unsupported schemes without loading any plugin factories
         try {
@@ -2199,7 +2183,7 @@ public class ExternalSourceResolver {
                 enrichedSchema.add(attr);
             } else if (shadowedColumns.contains(attr.name()) == false) {
                 // Partition (path-derived) value wins; the physical column is hidden (Spark/DuckDB
-                // semantics). The escape hatch to read the physical column is hive_partitioning:false.
+                // semantics). The escape hatch to read the physical column is partition_detection: none.
                 shadowedColumns.add(attr.name());
             }
         }
@@ -2241,7 +2225,7 @@ public class ExternalSourceResolver {
      * Emits one client-facing response-header WARN per physical column that a same-named Hive
      * partition key shadows. Shadowing follows Spark (SPARK-27356) and DuckDB: the partition
      * (path-derived) value wins and the physical column is hidden. The warning lets clients notice
-     * silent data substitution and points at the {@code hive_partitioning: false} escape hatch.
+     * silent data substitution and points at the {@code partition_detection: none} escape hatch.
      * <p>
      * Delegates to {@link SkipWarnings}, which emits the summary once on the first detail. Every
      * caller reachable from {@link #resolve}'s async schema-resolution chain (which runs on
@@ -2260,7 +2244,8 @@ public class ExternalSourceResolver {
         }
         SkipWarnings warnings = new SkipWarnings(
             "one or more physical columns are shadowed by same-named Hive partition keys; "
-                + "the partition (path-derived) value is used. Set hive_partitioning to false to read the physical column instead.",
+                + "the partition (path-derived) value is used. Set partition_detection to none to read the physical "
+                + "column instead.",
             warningSink
         );
         for (String name : shadowedColumns) {
@@ -2530,7 +2515,6 @@ public class ExternalSourceResolver {
         StoragePath storagePath,
         StorageProvider provider,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning,
         Map<String, Object> config,
         DatasetMapping declaredMapping
     ) throws Exception {
@@ -2541,11 +2525,11 @@ public class ExternalSourceResolver {
         if (path.indexOf(',') >= 0) {
             int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
             int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
-            listing = GlobExpander.expand(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
+            listing = GlobExpander.expand(path, provider, hints, config, maxDiscoveredFiles, maxGlobExpansion);
         } else if (isCacheable(provider)) {
-            listing = cachedListing(path, storagePath, provider, hints, hivePartitioning, config);
+            listing = cachedListing(path, storagePath, provider, hints, config);
         } else {
-            listing = expandAndCompact(path, provider, hints, hivePartitioning, storagePath);
+            listing = expandAndCompact(path, provider, hints, config, storagePath);
         }
         recordDiscovery(listing, discoveryStartNanos, storagePath.scheme());
         if (listing.fileCount() == 0) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
@@ -59,11 +59,7 @@ public final class HivePartitionDetector implements PartitionDetector {
     }
 
     @Override
-    public PartitionMetadata detect(List<StorageEntry> files, Map<String, Object> config) {
-        return detect(files);
-    }
-
-    static PartitionMetadata detect(List<StorageEntry> files) {
+    public PartitionMetadata detect(List<StorageEntry> files) {
         if (files == null || files.isEmpty()) {
             return PartitionMetadata.EMPTY;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionConfig.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionConfig.java
@@ -52,13 +52,40 @@ public record PartitionConfig(Strategy strategy, @Nullable String pathTemplate) 
         }
     }
 
+    /**
+     * Resolves the three partition settings into one strategy, leniently: this runs on every query against every
+     * already-stored dataset, so it never throws on a stored value. Contradictions are rejected at registration
+     * instead — see {@link #validate}.
+     *
+     * <p>Resolution order: the strategy is parsed from {@code partition_detection}; an unparseable value, and an
+     * explicit {@code template} with nothing to templatise, fall back to {@code AUTO}; then
+     * {@code hive_partitioning: "false"} folds to {@code NONE} last and wins over everything. A
+     * {@code partition_path} does NOT promote {@code AUTO} to {@code TEMPLATE} — {@code AUTO} already means Hive
+     * first with the template as a fallback, which is what a dataset carrying only a {@code partition_path}
+     * resolved to before this setting reached the read path. The final fold is what keeps
+     * {@code {hive_partitioning: false, partition_path: ...}} resolving to "no partitions" as it always did.
+     *
+     * <p>Only the literal {@code "false"} disables detection, matching the boolean check this replaced — any other
+     * value (including {@code "yes"}, {@code 0} or a nonsense string) leaves detection enabled, because the setting
+     * is stored free-form and existing datasets rely on that reading. An explicit {@code true} carries no
+     * information: it is the default, so it is ignored rather than pinning the strategy to {@code HIVE}.
+     */
     public static PartitionConfig fromConfig(Map<String, Object> config) {
         if (config == null || config.isEmpty()) {
             return DEFAULT;
         }
 
         Object detectionValue = config.get(CONFIG_PARTITIONING_DETECTION);
-        Strategy strategy = detectionValue != null ? Strategy.parse(detectionValue.toString()) : Strategy.AUTO;
+        Strategy strategy = null;
+        if (detectionValue != null) {
+            try {
+                strategy = Strategy.parse(detectionValue.toString());
+            } catch (IllegalArgumentException e) {
+                // A value stored before the setting was validated as an enum. Reading must not fail on it; the
+                // registration path rejects it, and validate() reports it with an actionable message.
+                strategy = null;
+            }
+        }
         if (strategy == null) {
             strategy = Strategy.AUTO;
         }
@@ -66,10 +93,108 @@ public record PartitionConfig(Strategy strategy, @Nullable String pathTemplate) 
         Object templateValue = config.get(CONFIG_PARTITIONING_PATH);
         String template = templateValue != null ? templateValue.toString() : null;
 
-        if (template != null && Strategy.AUTO == strategy) {
-            strategy = Strategy.TEMPLATE;
+        // AUTO is NOT promoted to TEMPLATE when a partition_path is present. AUTO means "Hive first, template as a
+        // fallback" (see AutoPartitionDetector), and that is exactly what a dataset carrying only a partition_path
+        // resolved to before this setting reached the read path: Hive detection. Promoting here would take the Hive
+        // columns away from every such dataset stored against a key=value layout.
+
+        // An explicit TEMPLATE with nothing to templatise falls back to AUTO rather than detecting nothing, so a
+        // dataset stored before this combination was rejected at registration keeps the Hive columns it had.
+        if (Strategy.TEMPLATE == strategy && (template == null || template.isEmpty())) {
+            strategy = Strategy.AUTO;
+        }
+
+        if (hivePartitioningDisabled(config)) {
+            strategy = Strategy.NONE;
         }
 
         return new PartitionConfig(strategy, template);
+    }
+
+    /** Whether {@code hive_partitioning} is present and set to the literal {@code "false"}. */
+    private static boolean hivePartitioningDisabled(Map<String, Object> config) {
+        Object value = config.get(CONFIG_PARTITIONING_HIVE);
+        return value != null && "false".equalsIgnoreCase(value.toString());
+    }
+
+    /**
+     * Registration-time validation. Rejects the combinations in which one of the three settings would be silently
+     * ignored, so a new dataset cannot be registered with a setting that does nothing. Deliberately stricter than
+     * {@link #fromConfig}, which must keep reading datasets that were stored before these checks existed.
+     */
+    public static void validate(Map<String, Object> config) {
+        if (config == null || config.isEmpty()) {
+            return;
+        }
+
+        Object detectionValue = config.get(CONFIG_PARTITIONING_DETECTION);
+        Strategy declared;
+        try {
+            declared = detectionValue != null ? Strategy.parse(detectionValue.toString()) : null;
+        } catch (IllegalArgumentException e) {
+            // An unparseable value is already reported by the caller, which validates this key as an enum and
+            // produces an actionable message. Rethrowing here would append Enum.valueOf's raw "No enum constant"
+            // text as a second error on the same setting.
+            return;
+        }
+
+        Object templateValue = config.get(CONFIG_PARTITIONING_PATH);
+        String template = templateValue != null ? templateValue.toString() : null;
+        boolean hasTemplate = template != null && template.isEmpty() == false;
+
+        if (hivePartitioningDisabled(config) && declared != null && declared != Strategy.NONE) {
+            throw new IllegalArgumentException(
+                "["
+                    + CONFIG_PARTITIONING_HIVE
+                    + "] is false, which disables partition detection, but ["
+                    + CONFIG_PARTITIONING_DETECTION
+                    + "] is ["
+                    + declared.name().toLowerCase(Locale.ROOT)
+                    + "]; set ["
+                    + CONFIG_PARTITIONING_DETECTION
+                    + "] to [none] instead of using ["
+                    + CONFIG_PARTITIONING_HIVE
+                    + "]"
+            );
+        }
+
+        if (declared == Strategy.TEMPLATE && hasTemplate == false) {
+            throw new IllegalArgumentException(
+                "["
+                    + CONFIG_PARTITIONING_DETECTION
+                    + "] is [template] but no ["
+                    + CONFIG_PARTITIONING_PATH
+                    + "] was given; template detection needs a path template such as [{year}/{month}]"
+            );
+        }
+
+        // The hive strategy never reads a path template, so accepting one would store a setting that does nothing —
+        // and, before the rewrite was gated on the strategy, one that silently steered the glob. AUTO stays legal:
+        // AutoPartitionDetector genuinely consumes the template as its fallback detector.
+        if (declared == Strategy.HIVE && hasTemplate) {
+            throw new IllegalArgumentException(
+                "["
+                    + CONFIG_PARTITIONING_PATH
+                    + "] is set but ["
+                    + CONFIG_PARTITIONING_DETECTION
+                    + "] is [hive], which never reads a path template; set ["
+                    + CONFIG_PARTITIONING_DETECTION
+                    + "] to [template] or remove ["
+                    + CONFIG_PARTITIONING_PATH
+                    + "]"
+            );
+        }
+
+        // A template alongside anything that resolves to "no partitions" is the silent-drop this validation exists
+        // to prevent: the template would be accepted, stored, and never used.
+        if (hasTemplate && (declared == Strategy.NONE || hivePartitioningDisabled(config))) {
+            throw new IllegalArgumentException(
+                "["
+                    + CONFIG_PARTITIONING_PATH
+                    + "] is set but partition detection is disabled, so the template would be ignored; remove ["
+                    + CONFIG_PARTITIONING_PATH
+                    + "] or enable partition detection"
+            );
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionDetector.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Pluggable strategy for detecting partition columns from file paths.
@@ -17,7 +16,7 @@ import java.util.Map;
  */
 public interface PartitionDetector {
 
-    PartitionMetadata detect(List<StorageEntry> files, Map<String, Object> config);
+    PartitionMetadata detect(List<StorageEntry> files);
 
     String name();
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetector.java
@@ -65,7 +65,7 @@ public final class TemplatePartitionDetector implements PartitionDetector {
     }
 
     @Override
-    public PartitionMetadata detect(List<StorageEntry> files, Map<String, Object> config) {
+    public PartitionMetadata detect(List<StorageEntry> files) {
         if (files == null || files.isEmpty()) {
             return PartitionMetadata.EMPTY;
         }
@@ -74,6 +74,18 @@ public final class TemplatePartitionDetector implements PartitionDetector {
         ReservedPartitionNames.warnRenamed(renamedColumns);
 
         int segmentCount = columnNames.size();
+
+        // Every file must sit at the same directory depth. The template binds the LAST N segments before the
+        // filename, so files at different depths bind different physical levels to the same column: over
+        // data/2024/f1, data/2024/01/f2 and data/2024/01/15/f3 with template {year}, the three files would report
+        // year=2024, year=01 and year=15, and a STATS BY year would bucket a day value as a year. Bailing to EMPTY
+        // is the same all-or-nothing stance HivePartitionDetector takes when its key sets disagree across files.
+        // The cost is that a comma-separated list mixing prefixes of different depths loses template detection even
+        // where the templated tail lines up; no partition columns is safe, a misbound one is not.
+        if (hasMixedDepth(files)) {
+            return PartitionMetadata.EMPTY;
+        }
+
         List<Map<String, String>> allRawPartitions = new ArrayList<>();
 
         for (StorageEntry entry : files) {
@@ -110,6 +122,39 @@ public final class TemplatePartitionDetector implements PartitionDetector {
         }
 
         return new PartitionMetadata(partitionColumns, filePartitionValues);
+    }
+
+    /** Whether the files sit at differing directory depths, which makes last-N template binding inconsistent. */
+    private static boolean hasMixedDepth(List<StorageEntry> files) {
+        int depth = -1;
+        for (StorageEntry entry : files) {
+            int d = pathDepth(entry.path());
+            if (depth == -1) {
+                depth = d;
+            } else if (d != depth) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Non-empty path segments excluding the file name itself. Reads {@code path()} rather than {@code objectName()},
+     * which is only the last segment — the same full-path walk {@link #extractByTemplate} does.
+     */
+    private static int pathDepth(StoragePath storagePath) {
+        String path = storagePath.path();
+        if (path == null || path.isEmpty()) {
+            return 0;
+        }
+        int count = 0;
+        for (String segment : path.split("/")) {
+            if (segment.isEmpty() == false) {
+                count++;
+            }
+        }
+        // the last segment is the file name
+        return Math.max(count - 1, 0);
     }
 
     private Map<String, String> extractByTemplate(StoragePath storagePath, int expectedSegments) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ListingCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ListingCacheKey.java
@@ -23,8 +23,9 @@ import java.util.TreeMap;
  * contains different objects.
  *
  * <p>The {@code listingDiscriminatorH1/H2} are a 128-bit hash of everything about the query that changes which
- * files the listing contains — the filter hints that narrow it, and the hive-partitioning flag that decides
- * whether they can. Without it the key would not determine its value: a filtered query would cache a narrowed
+ * files the listing contains — the filter hints that narrow it, and the resolved partition config (strategy and
+ * path template) that decides whether they can and how partition columns are derived. Without it the key would
+ * not determine its value: a filtered query would cache a narrowed
  * listing under the key an unfiltered query then hits, silently serving it fewer files than the dataset holds.
  * The discriminator string is produced by {@code GlobExpander.listingCacheDiscriminator} (from the same code the
  * listing itself goes through) and hashed here for the same size reason as the credentials: a filter's
@@ -87,7 +88,7 @@ public record ListingCacheKey(
     /**
      * SHA-256 of the discriminator, truncated to its first 128 bits. Collision-resistant because the pre-image is
      * built from user-supplied filter literals (see the class javadoc). An empty/absent discriminator maps to zero,
-     * which no real discriminator reaches (it always begins with the hive-partitioning flag).
+     * which no real discriminator reaches (it always begins with the length-prefixed partition strategy name).
      */
     static long[] sha256Truncated(String value) {
         if (value == null || value.isEmpty()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
@@ -77,10 +77,10 @@ public final class GlobExpander {
         String path,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
+        @Nullable Map<String, Object> config,
         StoragePath storagePath
     ) throws IOException {
-        return expandAndCompact(path, provider, hints, hivePartitioning, storagePath, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        return expandAndCompact(path, provider, hints, config, storagePath, Integer.MAX_VALUE, Integer.MAX_VALUE);
     }
 
     /**
@@ -90,12 +90,12 @@ public final class GlobExpander {
         String path,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
+        @Nullable Map<String, Object> config,
         StoragePath storagePath,
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
-        FileList expanded = expand(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
+        FileList expanded = expand(path, provider, hints, config, maxDiscoveredFiles, maxGlobExpansion);
         if (expanded.isResolved() == false || expanded.fileCount() == 0) {
             return expanded;
         }
@@ -116,13 +116,14 @@ public final class GlobExpander {
         String path,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
+        @Nullable Map<String, Object> config,
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
+        PartitionConfig partitionConfig = PartitionConfig.fromConfig(config);
         return path.indexOf(',') >= 0
-            ? doExpandCommaSeparated(path, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion)
-            : expandGlobWithRewriteFallback(path, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion);
+            ? doExpandCommaSeparated(path, provider, hints, partitionConfig, maxDiscoveredFiles, maxGlobExpansion)
+            : expandGlobWithRewriteFallback(path, provider, hints, partitionConfig, maxDiscoveredFiles, maxGlobExpansion);
     }
 
     /**
@@ -142,45 +143,25 @@ public final class GlobExpander {
         String pattern,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
-        @Nullable PartitionConfig partitionConfig,
-        @Nullable Map<String, Object> config,
+        PartitionConfig partitionConfig,
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
-        if (effectivePattern(pattern, hints, hivePartitioning, partitionConfig).equals(pattern)) {
-            return doExpandGlob(pattern, provider, hints, hivePartitioning, partitionConfig, config, maxDiscoveredFiles, maxGlobExpansion);
+        if (effectivePattern(pattern, hints, partitionConfig).equals(pattern)) {
+            return doExpandGlob(pattern, provider, hints, partitionConfig, maxDiscoveredFiles, maxGlobExpansion);
         }
         // The retry drops the rewrite but keeps the exact _file.* filters, so it can only come back empty when the
         // un-rewritten glob genuinely matches nothing.
         List<PartitionFilterHint> fileHintsOnly = fileMetadataHints(hints);
         FileList expanded;
         try {
-            expanded = doExpandGlob(
-                pattern,
-                provider,
-                hints,
-                hivePartitioning,
-                partitionConfig,
-                config,
-                maxDiscoveredFiles,
-                maxGlobExpansion
-            );
+            expanded = doExpandGlob(pattern, provider, hints, partitionConfig, maxDiscoveredFiles, maxGlobExpansion);
         } catch (IOException e) {
             // The rewritten prefix may name a folder that does not exist; the local filesystem throws where object
             // stores return empty. Both mean the rewrite, not the dataset, emptied the listing — retry either way.
             logger.debug(() -> "Rewritten listing of [" + pattern + "] failed; re-listing without the glob rewrite", e);
             try {
-                return doExpandGlob(
-                    pattern,
-                    provider,
-                    fileHintsOnly,
-                    hivePartitioning,
-                    partitionConfig,
-                    config,
-                    maxDiscoveredFiles,
-                    maxGlobExpansion
-                );
+                return doExpandGlob(pattern, provider, fileHintsOnly, partitionConfig, maxDiscoveredFiles, maxGlobExpansion);
             } catch (IOException retryFailure) {
                 retryFailure.addSuppressed(e);
                 throw retryFailure;
@@ -190,31 +171,28 @@ public final class GlobExpander {
             logger.debug("Rewrite of [{}] narrowed to an empty listing; re-listing without the glob rewrite", pattern);
             // A full re-list can exceed max_discovered_files and throw, exactly as the un-filtered query would; that
             // cap error is preserved deliberately — deciding spelling-miss vs genuinely-empty needs the full listing.
-            return doExpandGlob(
-                pattern,
-                provider,
-                fileHintsOnly,
-                hivePartitioning,
-                partitionConfig,
-                config,
-                maxDiscoveredFiles,
-                maxGlobExpansion
-            );
+            return doExpandGlob(pattern, provider, fileHintsOnly, partitionConfig, maxDiscoveredFiles, maxGlobExpansion);
         }
         return expanded;
     }
 
+    /**
+     * The single place that decides which detector a resolved {@link PartitionConfig} selects. Takes a non-null
+     * config: the listing boundary always resolves one, so a null here is a programming error rather than a
+     * user-reachable state.
+     */
     public static PartitionDetector resolveDetector(PartitionConfig config) {
-        if (config == null) {
-            return HivePartitionDetector.INSTANCE;
-        }
         return switch (config.strategy()) {
             case NONE -> null;
             case HIVE -> HivePartitionDetector.INSTANCE;
             case TEMPLATE -> {
                 String template = config.pathTemplate();
-                if (template == null || template.isEmpty()) {
-                    yield null;
+                // A template that names no columns cannot build a detector: parseTemplateColumns matches a segment
+                // in full, so `year={year}` contributes none, and TemplatePartitionDetector's constructor rejects
+                // that. Falling back to Hive is what such a dataset resolved to before the setting reached the read
+                // path, so a stored one keeps its columns instead of failing every query.
+                if (template == null || TemplatePartitionDetector.parseTemplateColumns(template).isEmpty()) {
+                    yield HivePartitionDetector.INSTANCE;
                 }
                 yield new TemplatePartitionDetector(template);
             }
@@ -254,54 +232,50 @@ public final class GlobExpander {
     }
 
     public static FileList expandGlob(String pattern, StorageProvider provider) throws IOException {
-        return expandGlob(pattern, provider, null, true);
+        return expandGlob(pattern, provider, null, (Map<String, Object>) null);
     }
 
     public static FileList expandGlob(
         String pattern,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
-        @Nullable PartitionConfig partitionConfig,
+        PartitionConfig partitionConfig
+    ) throws IOException {
+        return doExpandGlob(pattern, provider, hints, partitionConfig, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
+
+    public static FileList expandGlob(
+        String pattern,
+        StorageProvider provider,
+        @Nullable List<PartitionFilterHint> hints,
         @Nullable Map<String, Object> config
     ) throws IOException {
-        return doExpandGlob(pattern, provider, hints, hivePartitioning, partitionConfig, config, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        return doExpandGlob(pattern, provider, hints, PartitionConfig.fromConfig(config), Integer.MAX_VALUE, Integer.MAX_VALUE);
     }
 
     public static FileList expandGlob(
         String pattern,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning
-    ) throws IOException {
-        return doExpandGlob(pattern, provider, hints, hivePartitioning, null, null, Integer.MAX_VALUE, Integer.MAX_VALUE);
-    }
-
-    public static FileList expandGlob(
-        String pattern,
-        StorageProvider provider,
-        @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
+        @Nullable Map<String, Object> config,
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
-        return doExpandGlob(pattern, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion);
+        return doExpandGlob(pattern, provider, hints, PartitionConfig.fromConfig(config), maxDiscoveredFiles, maxGlobExpansion);
     }
 
     static FileList doExpandGlob(
         String pattern,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
-        @Nullable PartitionConfig partitionConfig,
-        @Nullable Map<String, Object> config,
+        PartitionConfig partitionConfig,
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
         Check.notNull(pattern, "pattern cannot be null");
         Check.notNull(provider, "provider cannot be null");
 
-        String effectivePattern = effectivePattern(pattern, hints, hivePartitioning, partitionConfig);
+        String effectivePattern = effectivePattern(pattern, hints, partitionConfig);
 
         StoragePath storagePath = StoragePath.of(effectivePattern);
 
@@ -313,7 +287,7 @@ public final class GlobExpander {
             var obj = provider.newObject(storagePath);
             if (obj.exists()) {
                 StorageEntry entry = new StorageEntry(storagePath, obj.length(), obj.lastModified());
-                PartitionMetadata partitionMetadata = detectPartitions(List.of(entry), hivePartitioning, partitionConfig, config);
+                PartitionMetadata partitionMetadata = detectPartitions(List.of(entry), partitionConfig);
                 return new GenericFileList(List.of(entry), pattern, partitionMetadata);
             }
             return FileList.EMPTY;
@@ -343,7 +317,7 @@ public final class GlobExpander {
                     return FileList.EMPTY;
                 }
                 matched.sort(Comparator.comparing(e -> e.path().toString()));
-                PartitionMetadata partitionMetadata = detectPartitions(matched, hivePartitioning, partitionConfig, config);
+                PartitionMetadata partitionMetadata = detectPartitions(matched, partitionConfig);
                 return new GenericFileList(matched, pattern, partitionMetadata);
             }
             // candidates == null means expansion exceeded cap; fall through to listing
@@ -384,7 +358,7 @@ public final class GlobExpander {
 
         matched.sort(Comparator.comparing(e -> e.path().toString()));
 
-        PartitionMetadata partitionMetadata = detectPartitions(matched, hivePartitioning, partitionConfig, config);
+        PartitionMetadata partitionMetadata = detectPartitions(matched, partitionConfig);
 
         return new GenericFileList(matched, pattern, partitionMetadata);
     }
@@ -401,29 +375,19 @@ public final class GlobExpander {
         return filtered.isEmpty() && matched.isEmpty() == false ? matched : filtered;
     }
 
-    static PartitionMetadata detectPartitions(
-        List<StorageEntry> files,
-        boolean hivePartitioning,
-        @Nullable PartitionConfig partitionConfig,
-        @Nullable Map<String, Object> config
-    ) {
-        if (hivePartitioning == false && partitionConfig == null) {
+    /**
+     * The partition columns a listing carries, decided entirely by the resolved {@link PartitionConfig}. One input,
+     * one decision: no separate enable flag and no raw settings map alongside it.
+     */
+    static PartitionMetadata detectPartitions(List<StorageEntry> files, PartitionConfig partitionConfig) {
+        if (PartitionConfig.Strategy.NONE == partitionConfig.strategy()) {
             return null;
         }
-        if (partitionConfig != null && PartitionConfig.Strategy.NONE == partitionConfig.strategy()) {
-            return null;
-        }
-
         PartitionDetector detector = resolveDetector(partitionConfig);
         if (detector == null) {
-            if (hivePartitioning) {
-                detector = HivePartitionDetector.INSTANCE;
-            } else {
-                return null;
-            }
+            return null;
         }
-
-        PartitionMetadata result = detector.detect(files, config);
+        PartitionMetadata result = detector.detect(files);
         if (result == null || result.isEmpty()) {
             return null;
         }
@@ -443,36 +407,34 @@ public final class GlobExpander {
     }
 
     public static FileList expandCommaSeparated(String pathList, StorageProvider provider) throws IOException {
-        return expandCommaSeparated(pathList, provider, null, true);
+        return expandCommaSeparated(pathList, provider, null, (Map<String, Object>) null);
     }
 
     public static FileList expandCommaSeparated(
         String pathList,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning
+        @Nullable Map<String, Object> config
     ) throws IOException {
-        return doExpandCommaSeparated(pathList, provider, hints, hivePartitioning, null, null, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        return doExpandCommaSeparated(pathList, provider, hints, PartitionConfig.fromConfig(config), Integer.MAX_VALUE, Integer.MAX_VALUE);
     }
 
     public static FileList expandCommaSeparated(
         String pathList,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
+        @Nullable Map<String, Object> config,
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
-        return doExpandCommaSeparated(pathList, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion);
+        return doExpandCommaSeparated(pathList, provider, hints, PartitionConfig.fromConfig(config), maxDiscoveredFiles, maxGlobExpansion);
     }
 
     private static FileList doExpandCommaSeparated(
         String pathList,
         StorageProvider provider,
         @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
-        @Nullable PartitionConfig partitionConfig,
-        @Nullable Map<String, Object> config,
+        PartitionConfig partitionConfig,
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
@@ -491,9 +453,7 @@ public final class GlobExpander {
                     trimmed,
                     provider,
                     hints,
-                    hivePartitioning,
                     partitionConfig,
-                    config,
                     remainingBudget,
                     maxGlobExpansion
                 );
@@ -515,7 +475,7 @@ public final class GlobExpander {
 
         allEntries.sort(Comparator.comparing(e -> e.path().toString()));
 
-        PartitionMetadata partitionMetadata = detectPartitions(allEntries, hivePartitioning, partitionConfig, config);
+        PartitionMetadata partitionMetadata = detectPartitions(allEntries, partitionConfig);
 
         return new GenericFileList(allEntries, pathList, partitionMetadata);
     }
@@ -525,20 +485,16 @@ public final class GlobExpander {
      * whether a hint reaches the glob at all; {@link #doExpandGlob} and {@link #listingCacheDiscriminator} both
      * route through it so that the listing cache key cannot drift from the listing it names.
      */
-    static String effectivePattern(
-        String pattern,
-        @Nullable List<PartitionFilterHint> hints,
-        boolean hivePartitioning,
-        @Nullable PartitionConfig partitionConfig
-    ) {
-        if (hints == null || hints.isEmpty() || hivePartitioning == false) {
+    static String effectivePattern(String pattern, @Nullable List<PartitionFilterHint> hints, PartitionConfig partitionConfig) {
+        if (hints == null || hints.isEmpty() || PartitionConfig.Strategy.NONE == partitionConfig.strategy()) {
             return pattern;
         }
         return rewriteGlobWithHints(pattern, hints, partitionConfig);
     }
 
     /**
-     * Everything about a query that determines which files a {@code path} lists: the {@code hivePartitioning} flag,
+     * Everything about a query that determines which files a {@code path} lists: the resolved
+     * {@link PartitionConfig} (strategy AND path template),
      * the effective (post-rewrite) glob pattern, and the {@code _file.*} metadata filters. These are the inputs
      * {@link #doExpandGlob} consults beyond the storage contents themselves — the rewrite via {@link #effectivePattern}
      * and the file filters via {@link #applyFileMetadataFilters} — and this value shares those same helpers, so the
@@ -551,19 +507,26 @@ public final class GlobExpander {
      * different filters onto one key. Equal encodings therefore genuinely mean equal listings. A new field added to
      * this record joins {@code equals} for free but must be added to {@code encode} by hand to stay in the key.
      */
-    private record ListingIdentity(boolean hivePartitioning, String effectivePattern, List<String> encodedFileHints) {
+    private record ListingIdentity(PartitionConfig partitionConfig, String effectivePattern, List<String> encodedFileHints) {
 
-        static ListingIdentity of(String path, @Nullable List<PartitionFilterHint> hints, boolean hivePartitioning) {
+        static ListingIdentity of(String path, @Nullable List<PartitionFilterHint> hints, PartitionConfig partitionConfig) {
             return new ListingIdentity(
-                hivePartitioning,
-                effectiveWholePathPattern(path, hints, hivePartitioning),
+                partitionConfig,
+                effectiveWholePathPattern(path, hints, partitionConfig),
                 encodedFileMetadataHints(hints)
             );
         }
 
         String encode() {
             StringBuilder sb = new StringBuilder();
-            sb.append(hivePartitioning ? '1' : '0');
+            // Strategy AND template both discriminate: the cached FileList carries its PartitionMetadata, and two
+            // datasets on one glob with the same strategy but different templates produce different partition
+            // columns from an identical effective pattern. The template is user-controlled free text, so it is
+            // length-prefixed like every other variable-length field; the null marker keeps a null template and an
+            // empty one distinct so injectivity stays trivially provable.
+            appendLengthPrefixed(sb, partitionConfig.strategy().name());
+            sb.append(partitionConfig.pathTemplate() == null ? '0' : '1');
+            appendLengthPrefixed(sb, partitionConfig.pathTemplate() == null ? "" : partitionConfig.pathTemplate());
             appendLengthPrefixed(sb, effectivePattern);
             sb.append(encodedFileHints.size()).append(':');
             for (String encodedHint : encodedFileHints) {
@@ -584,19 +547,26 @@ public final class GlobExpander {
      * inputs it captures and why they are exhaustive; hints that reach none of them (an ordinary data column, say)
      * leave the discriminator untouched, so an incidentally-filtered query still shares the un-filtered entry.
      */
-    public static String listingCacheDiscriminator(String path, @Nullable List<PartitionFilterHint> hints, boolean hivePartitioning) {
-        return ListingIdentity.of(path, hints, hivePartitioning).encode();
+    public static String listingCacheDiscriminator(
+        String path,
+        @Nullable List<PartitionFilterHint> hints,
+        @Nullable Map<String, Object> config
+    ) {
+        return ListingIdentity.of(path, hints, PartitionConfig.fromConfig(config)).encode();
     }
 
     /**
      * Mirrors {@link #expand}'s glob/comma dispatch: in a comma list only the pattern segments are rewritten, over
-     * the same {@link #commaSegments} decomposition the expansion walks. {@code partitionConfig} is fixed null to
-     * match {@link #expand}'s signature — the production listing paths carry no {@link PartitionConfig} (see
-     * {@link #expandAndCompact}), so neither does the identity that names their result.
+     * the same {@link #commaSegments} decomposition the expansion walks, against the same resolved
+     * {@link PartitionConfig} the expansion uses.
      */
-    private static String effectiveWholePathPattern(String path, @Nullable List<PartitionFilterHint> hints, boolean hive) {
+    private static String effectiveWholePathPattern(
+        String path,
+        @Nullable List<PartitionFilterHint> hints,
+        PartitionConfig partitionConfig
+    ) {
         if (path.indexOf(',') < 0) {
-            return effectivePattern(path, hints, hive, null);
+            return effectivePattern(path, hints, partitionConfig);
         }
         List<String> segments = commaSegments(path);
         StringBuilder sb = new StringBuilder();
@@ -605,7 +575,7 @@ public final class GlobExpander {
                 sb.append(',');
             }
             String segment = segments.get(i);
-            sb.append(isPattern(segment) ? effectivePattern(segment, hints, hive, null) : segment);
+            sb.append(isPattern(segment) ? effectivePattern(segment, hints, partitionConfig) : segment);
         }
         return sb.toString();
     }
@@ -687,11 +657,25 @@ public final class GlobExpander {
             return pattern;
         }
 
-        if (partitionConfig != null && partitionConfig.pathTemplate() != null) {
+        // Only a TEMPLATE strategy may drive the template rewrite. It narrows the glob to the template's spelling of
+        // the value — a bare segment — which is sound only when detection is certainly template-based. Under HIVE a
+        // coincidental bare folder (data/2024/) would be listed instead of the real data/year=2024/, and because that
+        // listing is non-empty the rewrite-to-empty fallback never fires, so the query returns the wrong rows rather
+        // than a superset. Under AUTO, detection may still resolve to Hive at detect time. HIVE and AUTO keep the
+        // key=value segment rewrite below, which is what they had before the setting reached the read path.
+        if (partitionConfig != null
+            && PartitionConfig.Strategy.TEMPLATE == partitionConfig.strategy()
+            && partitionConfig.pathTemplate() != null) {
             String templateRewritten = rewriteGlobWithTemplate(pattern, rewritableHints, partitionConfig.pathTemplate());
             if (templateRewritten != null) {
                 return templateRewritten;
             }
+            // Under TEMPLATE the column value is the WHOLE directory segment, so the key=value rewrite below would
+            // narrow on the wrong axis: for a template-bound value of "part=a" it would spell the segment
+            // "part=part=a" and list a sibling directory of that literal name instead. That listing is non-empty, so
+            // the rewrite-to-empty fallback would not fire. The rewrite is never useful under TEMPLATE anyway — the
+            // template rewrite above is the only one that matches how the value was bound.
+            return pattern;
         }
 
         String[] segments = pattern.split("/");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceValidator.java
@@ -262,8 +262,10 @@ public class FileDataSourceValidator implements DataSourceValidator {
         // would produce at query time. Each parser reads the keys it owns from the settings map.
         // error_mode + max_errors + max_error_ratio (incl. mutual exclusion) via the owning policy parser.
         validate(() -> ErrorPolicy.fromConfig(settings, ErrorPolicy.STRICT), errors);
-        // partition_detection enum via its owning parser (partition_path/hive_partitioning are free-form,
-        // matching the query path which treats any non-"false" hive value as enabled).
+        // partition_detection enum, plus the combinations in which one of the three partition settings would be
+        // silently ignored, via the owning parser. Stricter than the query path deliberately: PartitionConfig
+        // resolves stored datasets leniently so an upgrade cannot turn a working dataset into a query-time error,
+        // which means a new registration is the only place a contradiction can still be caught.
         validateEnum(
             settings,
             result,
@@ -272,6 +274,7 @@ public class FileDataSourceValidator implements DataSourceValidator {
             PartitionConfig.Strategy::parse,
             errors
         );
+        validate(() -> PartitionConfig.validate(settings), errors);
         Object schemaResolution = settings.get(ExternalSourceResolver.CONFIG_SCHEMA_RESOLUTION);
         if (schemaResolution != null) {
             validate(() -> FormatReader.SchemaResolution.parse(schemaResolution.toString()), errors);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AutoPartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AutoPartitionDetectorTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 
 public class AutoPartitionDetectorTests extends ESTestCase {
 
@@ -26,7 +25,7 @@ public class AutoPartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/year=2023/file2.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.INTEGER, result.partitionColumns().get("year"));
@@ -41,7 +40,7 @@ public class AutoPartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/2023/12/file2.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.INTEGER, result.partitionColumns().get("year"));
@@ -56,7 +55,7 @@ public class AutoPartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/2023/12/file2.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
         assertTrue(result.isEmpty());
     }
 
@@ -69,7 +68,7 @@ public class AutoPartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/year=2023/file.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
         assertFalse(result.isEmpty());
         // Template detector extracts the last segment before filename positionally
         assertEquals("year=2024", result.filePartitionValues().get(StoragePath.of("s3://bucket/data/year=2024/file.parquet")).get("year"));
@@ -82,9 +81,13 @@ public class AutoPartitionDetectorTests extends ESTestCase {
         assertNull(detector);
     }
 
-    public void testNullConfigDefaultsToHive() {
-        PartitionDetector detector = AutoPartitionDetector.fromConfig(null);
-        assertEquals("hive", ((HivePartitionDetector) detector).name());
+    /**
+     * {@code fromConfig} no longer defaults a null config to the Hive detector. The listing boundary always
+     * resolves a {@link PartitionConfig}, so a null here is a programming error rather than a user-reachable
+     * state.
+     */
+    public void testNullConfigIsRejected() {
+        expectThrows(NullPointerException.class, () -> AutoPartitionDetector.fromConfig(null));
     }
 
     public void testAutoDetectorName() {
@@ -101,7 +104,7 @@ public class AutoPartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/year=2023/file2.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
         assertFalse(result.isEmpty());
         // Hive should be detected first, so the column should be "year" not "col"
         assertTrue(result.partitionColumns().containsKey("year"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobExpanderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobExpanderTests.java
@@ -22,12 +22,30 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 
 public class GlobExpanderTests extends ESTestCase {
+
+    /** No partition settings: the default, which resolves to AUTO and behaves as Hive detection did. */
+    private static final Map<String, Object> HIVE_ON = Map.of();
+
+    /** The legacy switch that turns partition detection off, now folded into Strategy.NONE. */
+    private static final Map<String, Object> HIVE_OFF = Map.of(PartitionConfig.CONFIG_PARTITIONING_HIVE, "false");
+
+    /** The settings map a PartitionConfig-shaped test intent resolves from. */
+    private static Map<String, Object> configMapOf(PartitionConfig config) {
+        Map<String, Object> settings = new HashMap<>();
+        settings.put(PartitionConfig.CONFIG_PARTITIONING_DETECTION, config.strategy().name().toLowerCase(Locale.ROOT));
+        if (config.pathTemplate() != null) {
+            settings.put(PartitionConfig.CONFIG_PARTITIONING_PATH, config.pathTemplate());
+        }
+        return settings;
+    }
 
     // -- isMultiFile --
 
@@ -208,7 +226,7 @@ public class GlobExpanderTests extends ESTestCase {
         );
 
         var hints = List.of(hint("category", PartitionFilterHintExtractor.Operator.IN, "login", "ns:click"));
-        FileList result = GlobExpander.expand("s3://bucket/data/category=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/category=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         List<String> paths = new ArrayList<>();
         for (int i = 0; i < result.fileCount(); i++) {
@@ -252,7 +270,7 @@ public class GlobExpanderTests extends ESTestCase {
         );
         StubProvider provider = new StubProvider(listing);
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/data/year=*/*.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/data/year=*/*.parquet", provider, null, HIVE_ON);
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
         assertNotNull(result.partitionMetadata());
@@ -267,7 +285,7 @@ public class GlobExpanderTests extends ESTestCase {
         );
         StubProvider provider = new StubProvider(listing);
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/data/year=*/*.parquet", provider, null, false);
+        FileList result = GlobExpander.expandGlob("s3://bucket/data/year=*/*.parquet", provider, null, HIVE_OFF);
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
         assertNull(result.partitionMetadata());
@@ -281,7 +299,7 @@ public class GlobExpanderTests extends ESTestCase {
         StubProvider provider = new StubProvider(listing);
 
         @SuppressWarnings("RegexpMultiline")
-        FileList result = GlobExpander.expandGlob("s3://bucket/data/**/*.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/data/**/*.parquet", provider, null, HIVE_ON);
         assertTrue(result.isResolved());
         assertNull(result.partitionMetadata());
     }
@@ -339,7 +357,7 @@ public class GlobExpanderTests extends ESTestCase {
         PartitionConfig config = new PartitionConfig(PartitionConfig.Strategy.TEMPLATE, "{year}/{month}");
 
         @SuppressWarnings("RegexpMultiline")
-        FileList result = GlobExpander.expandGlob("s3://bucket/data/**/*.parquet", provider, null, true, config, Map.of());
+        FileList result = GlobExpander.expandGlob("s3://bucket/data/**/*.parquet", provider, null, configMapOf(config));
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
         assertNotNull(result.partitionMetadata());
@@ -355,7 +373,7 @@ public class GlobExpanderTests extends ESTestCase {
         StubProvider provider = new StubProvider(listing);
         PartitionConfig config = new PartitionConfig(PartitionConfig.Strategy.NONE, null);
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/data/year=*/*.parquet", provider, null, true, config, Map.of());
+        FileList result = GlobExpander.expandGlob("s3://bucket/data/year=*/*.parquet", provider, null, configMapOf(config));
         assertTrue(result.isResolved());
         assertNull(result.partitionMetadata());
     }
@@ -371,7 +389,7 @@ public class GlobExpanderTests extends ESTestCase {
 
         QlIllegalArgumentException e = expectThrows(
             QlIllegalArgumentException.class,
-            () -> GlobExpander.expandGlob("s3://bucket/data/*.parquet", provider, null, true, 10, Integer.MAX_VALUE)
+            () -> GlobExpander.expandGlob("s3://bucket/data/*.parquet", provider, null, HIVE_ON, 10, Integer.MAX_VALUE)
         );
         assertThat(e.getMessage(), containsString("Glob pattern discovered too many files"));
         assertThat(e.getMessage(), containsString("limit 10"));
@@ -385,7 +403,7 @@ public class GlobExpanderTests extends ESTestCase {
         }
         StubProvider provider = new StubProvider(listing);
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/data/*.parquet", provider, null, true, 10, Integer.MAX_VALUE);
+        FileList result = GlobExpander.expandGlob("s3://bucket/data/*.parquet", provider, null, HIVE_ON, 10, Integer.MAX_VALUE);
         assertTrue(result.isResolved());
         assertEquals(10, result.fileCount());
     }
@@ -397,7 +415,7 @@ public class GlobExpanderTests extends ESTestCase {
         }
         StubProvider provider = new StubProvider(listing);
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/data/*.parquet", provider, null, true, 10, Integer.MAX_VALUE);
+        FileList result = GlobExpander.expandGlob("s3://bucket/data/*.parquet", provider, null, HIVE_ON, 10, Integer.MAX_VALUE);
         assertTrue(result.isResolved());
         assertEquals(5, result.fileCount());
     }
@@ -418,7 +436,7 @@ public class GlobExpanderTests extends ESTestCase {
                 "s3://bucket/data/*.parquet, s3://bucket/extra1.parquet, s3://bucket/extra2.parquet, s3://bucket/extra3.parquet",
                 provider,
                 null,
-                true,
+                HIVE_ON,
                 9,
                 Integer.MAX_VALUE
             )
@@ -433,7 +451,7 @@ public class GlobExpanderTests extends ESTestCase {
         provider.existingPaths.add("s3://bucket/a.parquet");
         provider.existingPaths.add("s3://bucket/b.parquet");
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b}.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b}.parquet", provider, null, HIVE_ON);
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
         assertEquals("s3://bucket/a.parquet", result.path(0).toString());
@@ -445,7 +463,7 @@ public class GlobExpanderTests extends ESTestCase {
         provider.existingPaths.add("s3://bucket/a.parquet");
         provider.existingPaths.add("s3://bucket/c.parquet");
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b,c}.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b,c}.parquet", provider, null, HIVE_ON);
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
     }
@@ -453,7 +471,7 @@ public class GlobExpanderTests extends ESTestCase {
     public void testExpandGlobBraceOnlyAllMissingReturnsEmpty() throws IOException {
         StubProvider provider = new StubProvider(List.of());
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b}.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b}.parquet", provider, null, HIVE_ON);
         assertTrue(result.isEmpty());
     }
 
@@ -461,7 +479,7 @@ public class GlobExpanderTests extends ESTestCase {
         List<StorageEntry> listing = List.of(entry("s3://bucket/a/file.parquet", 100), entry("s3://bucket/b/file.parquet", 200));
         StubProvider provider = new StubProvider(listing);
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b}/*.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/{a,b}/*.parquet", provider, null, HIVE_ON);
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
     }
@@ -477,7 +495,7 @@ public class GlobExpanderTests extends ESTestCase {
         pattern.append("}.parquet");
         StubProvider provider = new StubProvider(listing);
 
-        FileList result = GlobExpander.expandGlob(pattern.toString(), provider, null, true, 10000, 5);
+        FileList result = GlobExpander.expandGlob(pattern.toString(), provider, null, HIVE_ON, 10000, 5);
         assertTrue(result.isResolved());
         assertEquals(200, result.fileCount());
     }
@@ -487,7 +505,7 @@ public class GlobExpanderTests extends ESTestCase {
         provider.existingPaths.add("s3://bucket/year=2024/data.parquet");
         provider.existingPaths.add("s3://bucket/year=2025/data.parquet");
 
-        FileList result = GlobExpander.expandGlob("s3://bucket/year={2024,2025}/data.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/year={2024,2025}/data.parquet", provider, null, HIVE_ON);
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
     }
@@ -499,7 +517,7 @@ public class GlobExpanderTests extends ESTestCase {
         provider.existingPaths.add("s3://bucket/year=2024/data.parquet");
 
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
-        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/data.parquet", provider, hints, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/data.parquet", provider, hints, HIVE_ON);
         assertTrue(result.isResolved());
         assertEquals(1, result.fileCount());
         assertEquals("s3://bucket/year=2024/data.parquet", result.path(0).toString());
@@ -509,7 +527,7 @@ public class GlobExpanderTests extends ESTestCase {
         StubProvider provider = new StubProvider(List.of());
 
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
-        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/data.parquet", provider, hints, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/data.parquet", provider, hints, HIVE_ON);
         assertTrue(result.isEmpty());
     }
 
@@ -518,7 +536,7 @@ public class GlobExpanderTests extends ESTestCase {
         provider.existingPaths.add("s3://bucket/year=2024/data.parquet");
 
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
-        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/data.parquet", provider, hints, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/data.parquet", provider, hints, HIVE_ON);
         assertTrue(result.isResolved());
         assertNotNull(result.partitionMetadata());
         assertTrue(result.partitionMetadata().partitionColumns().containsKey("year"));
@@ -526,7 +544,7 @@ public class GlobExpanderTests extends ESTestCase {
 
     public void testExpandGlobLiteralWithoutHintsStillReturnsUnresolved() throws IOException {
         StubProvider provider = new StubProvider(List.of());
-        FileList result = GlobExpander.expandGlob("s3://bucket/year=2024/data.parquet", provider, null, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/year=2024/data.parquet", provider, null, HIVE_ON);
         assertFalse(result.isResolved());
     }
 
@@ -538,7 +556,7 @@ public class GlobExpanderTests extends ESTestCase {
         StubProvider provider = new StubProvider(listing);
 
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
-        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/*.parquet", provider, hints, true);
+        FileList result = GlobExpander.expandGlob("s3://bucket/year=*/*.parquet", provider, hints, HIVE_ON);
         assertTrue(result.isResolved());
         assertEquals(2, result.fileCount());
     }
@@ -556,7 +574,7 @@ public class GlobExpanderTests extends ESTestCase {
         );
 
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
-        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         assertEquals(1, result.fileCount());
         assertEquals("s3://bucket/data/year=2024/a.parquet", result.path(0).toString());
@@ -573,7 +591,7 @@ public class GlobExpanderTests extends ESTestCase {
         );
 
         var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6));
-        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         assertEquals("the zero-padded folder must still be listed", 1, result.fileCount());
         assertEquals("s3://bucket/data/month=06/a.parquet", result.path(0).toString());
@@ -590,7 +608,7 @@ public class GlobExpanderTests extends ESTestCase {
         provider.throwOnUnknownPrefix = true;
 
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
-        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         assertEquals(1, result.fileCount());
     }
@@ -606,7 +624,7 @@ public class GlobExpanderTests extends ESTestCase {
         );
 
         var hints = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "nope.parquet"));
-        FileList result = GlobExpander.expand("s3://bucket/data/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         assertEquals(2, result.fileCount());
         assertEquals("an exact _file.* prune is retained in one listing pass, not re-listed", 1, provider.listCallCount);
@@ -628,7 +646,14 @@ public class GlobExpanderTests extends ESTestCase {
         );
 
         var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6));
-        FileList result = GlobExpander.expand("s3://bucket/a/month=*/*.parquet,s3://bucket/b/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand(
+            "s3://bucket/a/month=*/*.parquet,s3://bucket/b/*.parquet",
+            provider,
+            hints,
+            HIVE_ON,
+            MAX,
+            MAX
+        );
 
         List<String> paths = new ArrayList<>();
         for (int i = 0; i < result.fileCount(); i++) {
@@ -654,7 +679,7 @@ public class GlobExpanderTests extends ESTestCase {
         );
 
         var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.IN, 6, 11));
-        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         List<String> paths = new ArrayList<>();
         for (int i = 0; i < result.fileCount(); i++) {
@@ -678,7 +703,14 @@ public class GlobExpanderTests extends ESTestCase {
         provider.throwOnUnknownPrefix = true;
 
         var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6));
-        FileList result = GlobExpander.expand("s3://bucket/a/month=*/*.parquet,s3://bucket/b/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand(
+            "s3://bucket/a/month=*/*.parquet,s3://bucket/b/*.parquet",
+            provider,
+            hints,
+            HIVE_ON,
+            MAX,
+            MAX
+        );
 
         assertEquals(2, result.fileCount());
     }
@@ -704,7 +736,7 @@ public class GlobExpanderTests extends ESTestCase {
             hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6),
             hint(FileMetadataColumns.SIZE, PartitionFilterHintExtractor.Operator.GREATER_THAN, 100)
         );
-        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         List<String> paths = new ArrayList<>();
         for (int i = 0; i < result.fileCount(); i++) {
@@ -729,7 +761,7 @@ public class GlobExpanderTests extends ESTestCase {
             hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6),
             hint(FileMetadataColumns.SIZE, PartitionFilterHintExtractor.Operator.GREATER_THAN, 1_000_000)
         );
-        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         assertTrue(result.isResolved());
         assertEquals(1, result.fileCount());
@@ -741,7 +773,7 @@ public class GlobExpanderTests extends ESTestCase {
         PrefixAwareStubProvider provider = new PrefixAwareStubProvider(Map.of("s3://bucket/data/", List.of()));
 
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
-        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, HIVE_ON, MAX, MAX);
 
         assertTrue(result.isResolved());
         assertEquals(0, result.fileCount());
@@ -751,7 +783,7 @@ public class GlobExpanderTests extends ESTestCase {
     public void testUnhintedEmptyListingIsNotRetried() throws IOException {
         PrefixAwareStubProvider provider = new PrefixAwareStubProvider(Map.of("s3://bucket/data/", List.of()));
 
-        FileList result = GlobExpander.expand("s3://bucket/data/*.parquet", provider, null, true, MAX, MAX);
+        FileList result = GlobExpander.expand("s3://bucket/data/*.parquet", provider, null, HIVE_ON, MAX, MAX);
 
         assertEquals(0, result.fileCount());
         assertEquals("no hints, so no fallback listing", 1, provider.listCallCount);
@@ -777,7 +809,7 @@ public class GlobExpanderTests extends ESTestCase {
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
         var e = expectThrows(
             QlIllegalArgumentException.class,
-            () -> GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, 2, MAX)
+            () -> GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, HIVE_ON, 2, MAX)
         );
         assertThat(e.getMessage(), containsString("discovered too many files"));
     }
@@ -812,7 +844,7 @@ public class GlobExpanderTests extends ESTestCase {
 
         Map<String, List<String>> listingByDiscriminator = new HashMap<>();
         for (var hints : hintSets) {
-            for (boolean hive : List.of(true, false)) {
+            for (Map<String, Object> hive : List.of(HIVE_ON, HIVE_OFF)) {
                 String discriminator = GlobExpander.listingCacheDiscriminator(pattern, hints, hive);
                 List<String> files = new ArrayList<>();
                 FileList expanded = GlobExpander.expand(pattern, new PrefixAwareStubProvider(tree), hints, hive, MAX, MAX);
@@ -834,45 +866,45 @@ public class GlobExpanderTests extends ESTestCase {
      */
     public void testDiscriminatorIgnoresHintsThatCannotNarrowTheListing() {
         String pattern = "s3://bucket/data/*.parquet";
-        String unhinted = GlobExpander.listingCacheDiscriminator(pattern, null, true);
+        String unhinted = GlobExpander.listingCacheDiscriminator(pattern, null, HIVE_ON);
 
         var dataColumnHint = List.of(hint("user_id", PartitionFilterHintExtractor.Operator.EQUALS, 42));
-        assertEquals(unhinted, GlobExpander.listingCacheDiscriminator(pattern, dataColumnHint, true));
+        assertEquals(unhinted, GlobExpander.listingCacheDiscriminator(pattern, dataColumnHint, HIVE_ON));
 
         // A `year=*` segment is absent from this pattern, so even a rewritable hint cannot narrow it.
         var absentPartitionHint = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
-        assertEquals(unhinted, GlobExpander.listingCacheDiscriminator(pattern, absentPartitionHint, true));
+        assertEquals(unhinted, GlobExpander.listingCacheDiscriminator(pattern, absentPartitionHint, HIVE_ON));
     }
 
     /** Every input that changes the listing must change the discriminator. */
     public void testDiscriminatorSeparatesHintsThatNarrowTheListing() {
         String keyed = "s3://bucket/data/year=*/*.parquet";
         String plain = "s3://bucket/data/*.parquet";
-        String unhintedKeyed = GlobExpander.listingCacheDiscriminator(keyed, null, true);
+        String unhintedKeyed = GlobExpander.listingCacheDiscriminator(keyed, null, HIVE_ON);
 
         var year2024 = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
         var year2025 = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2025));
-        assertNotEquals(unhintedKeyed, GlobExpander.listingCacheDiscriminator(keyed, year2024, true));
+        assertNotEquals(unhintedKeyed, GlobExpander.listingCacheDiscriminator(keyed, year2024, HIVE_ON));
         assertNotEquals(
-            GlobExpander.listingCacheDiscriminator(keyed, year2024, true),
-            GlobExpander.listingCacheDiscriminator(keyed, year2025, true)
+            GlobExpander.listingCacheDiscriminator(keyed, year2024, HIVE_ON),
+            GlobExpander.listingCacheDiscriminator(keyed, year2025, HIVE_ON)
         );
 
         // hive_partitioning gates the rewrite and selects the partition metadata carried by the cached listing.
-        assertNotEquals(unhintedKeyed, GlobExpander.listingCacheDiscriminator(keyed, null, false));
+        assertNotEquals(unhintedKeyed, GlobExpander.listingCacheDiscriminator(keyed, null, HIVE_OFF));
 
         var fileName = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "a.parquet"));
         assertNotEquals(
-            GlobExpander.listingCacheDiscriminator(plain, null, true),
-            GlobExpander.listingCacheDiscriminator(plain, fileName, true)
+            GlobExpander.listingCacheDiscriminator(plain, null, HIVE_ON),
+            GlobExpander.listingCacheDiscriminator(plain, fileName, HIVE_ON)
         );
 
         // A value's type is part of its identity: _file.name == "6" and _file.name == 6 do not filter alike.
         var nameSix = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "6"));
         var nameSixInt = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, 6));
         assertNotEquals(
-            GlobExpander.listingCacheDiscriminator(plain, nameSix, true),
-            GlobExpander.listingCacheDiscriminator(plain, nameSixInt, true)
+            GlobExpander.listingCacheDiscriminator(plain, nameSix, HIVE_ON),
+            GlobExpander.listingCacheDiscriminator(plain, nameSixInt, HIVE_ON)
         );
     }
 
@@ -881,8 +913,8 @@ public class GlobExpanderTests extends ESTestCase {
         String paths = "s3://bucket/a/year=*/*.parquet,s3://bucket/b/plain.parquet";
         var year2024 = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
 
-        String unhinted = GlobExpander.listingCacheDiscriminator(paths, null, true);
-        String hinted = GlobExpander.listingCacheDiscriminator(paths, year2024, true);
+        String unhinted = GlobExpander.listingCacheDiscriminator(paths, null, HIVE_ON);
+        String hinted = GlobExpander.listingCacheDiscriminator(paths, year2024, HIVE_ON);
 
         assertNotEquals(unhinted, hinted);
         assertThat(hinted, containsString("s3://bucket/a/year=2024/*.parquet"));
@@ -903,16 +935,16 @@ public class GlobExpanderTests extends ESTestCase {
         );
         var twoValues = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.IN, "a", "b"));
         assertNotEquals(
-            GlobExpander.listingCacheDiscriminator(pattern, oneSplicedValue, true),
-            GlobExpander.listingCacheDiscriminator(pattern, twoValues, true)
+            GlobExpander.listingCacheDiscriminator(pattern, oneSplicedValue, HIVE_ON),
+            GlobExpander.listingCacheDiscriminator(pattern, twoValues, HIVE_ON)
         );
 
         // A value carrying the top-level joiner must not fake the pattern/hints boundary.
         var nullByteValue = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "x\u0000y"));
         var plainValue = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "xy"));
         assertNotEquals(
-            GlobExpander.listingCacheDiscriminator(pattern, nullByteValue, true),
-            GlobExpander.listingCacheDiscriminator(pattern, plainValue, true)
+            GlobExpander.listingCacheDiscriminator(pattern, nullByteValue, HIVE_ON),
+            GlobExpander.listingCacheDiscriminator(pattern, plainValue, HIVE_ON)
         );
     }
 
@@ -926,6 +958,145 @@ public class GlobExpanderTests extends ESTestCase {
         Object... values
     ) {
         return new PartitionFilterHintExtractor.PartitionFilterHint(column, op, List.of(values));
+    }
+
+    /**
+     * A template-partitioned dataset narrows its glob from a filter hint. No such dataset could before: the
+     * production listing paths passed no {@link PartitionConfig}, and the template rewrite needs one. Separately,
+     * {@code effectivePattern} gated the rewrite on the Hive boolean, which is the wrong axis once a strategy
+     * exists; it gates on {@code Strategy.NONE} now. Driven through the public entry point so it exercises the
+     * boundary resolution, not just the rewrite helper.
+     */
+    public void testTemplateConfigNarrowsGlobWithHints() throws IOException {
+        Map<String, List<StorageEntry>> tree = new HashMap<>();
+        tree.put("s3://bucket/logs/", List.of(entry("s3://bucket/logs/2024/a.parquet", 1), entry("s3://bucket/logs/2025/b.parquet", 1)));
+        tree.put("s3://bucket/logs/2024/", List.of(entry("s3://bucket/logs/2024/a.parquet", 1)));
+        tree.put("s3://bucket/logs/2025/", List.of(entry("s3://bucket/logs/2025/b.parquet", 1)));
+
+        List<PartitionFilterHintExtractor.PartitionFilterHint> hints = List.of(
+            new PartitionFilterHintExtractor.PartitionFilterHint("year", PartitionFilterHintExtractor.Operator.EQUALS, List.of("2024"))
+        );
+        Map<String, Object> templateSettings = Map.of(
+            PartitionConfig.CONFIG_PARTITIONING_DETECTION,
+            "template",
+            PartitionConfig.CONFIG_PARTITIONING_PATH,
+            "{year}"
+        );
+
+        FileList result = GlobExpander.expand(
+            "s3://bucket/logs/*/*.parquet",
+            new PrefixAwareStubProvider(tree),
+            hints,
+            templateSettings,
+            MAX,
+            MAX
+        );
+
+        assertEquals(
+            "the template partition column must be detected",
+            Set.of("year"),
+            result.partitionMetadata().partitionColumns().keySet()
+        );
+        for (int i = 0; i < result.fileCount(); i++) {
+            assertThat("only the 2024 partition may survive the rewrite", result.path(i).toString(), containsString("/2024/"));
+        }
+    }
+
+    /**
+     * Two datasets on the same glob with the same strategy but different templates produce different partition
+     * columns from an identical effective pattern. The cached {@code FileList} carries its {@code PartitionMetadata},
+     * so if the identity bound only the strategy they would share one entry and one would be served the other's
+     * columns. Covers the non-null-template arm of {@code ListingIdentity.encode}.
+     */
+    public void testListingIdentitySeparatesTemplatesWithinOneStrategy() {
+        String glob = "s3://bucket/logs/*" + "/*.parquet";
+        Map<String, Object> byYear = Map.of(
+            PartitionConfig.CONFIG_PARTITIONING_DETECTION,
+            "template",
+            PartitionConfig.CONFIG_PARTITIONING_PATH,
+            "{year}"
+        );
+        Map<String, Object> byRegion = Map.of(
+            PartitionConfig.CONFIG_PARTITIONING_DETECTION,
+            "template",
+            PartitionConfig.CONFIG_PARTITIONING_PATH,
+            "{region}"
+        );
+
+        assertNotEquals(
+            "two templates under one strategy must not share a listing-cache entry",
+            GlobExpander.listingCacheDiscriminator(glob, null, byYear),
+            GlobExpander.listingCacheDiscriminator(glob, null, byRegion)
+        );
+        // A null template and an empty one stay distinct, which is what the null marker in encode() buys.
+        assertNotEquals(
+            "an absent template and an empty one must encode differently",
+            GlobExpander.listingCacheDiscriminator(glob, null, Map.of(PartitionConfig.CONFIG_PARTITIONING_DETECTION, "hive")),
+            GlobExpander.listingCacheDiscriminator(
+                glob,
+                null,
+                Map.of(PartitionConfig.CONFIG_PARTITIONING_DETECTION, "hive", PartitionConfig.CONFIG_PARTITIONING_PATH, "")
+            )
+        );
+    }
+
+    /**
+     * The template rewrite narrows a bare glob segment to the template's spelling of the value. That is only sound
+     * under a TEMPLATE strategy: under HIVE the same rewrite would list a coincidental {@code data/2024/} folder
+     * instead of the real {@code data/year=2024/}, and because that listing is non-empty the rewrite-to-empty
+     * fallback never fires.
+     */
+    public void testRewriteGlobHiveStrategyIgnoresTemplate() {
+        List<PartitionFilterHintExtractor.PartitionFilterHint> hints = List.of(
+            new PartitionFilterHintExtractor.PartitionFilterHint("year", PartitionFilterHintExtractor.Operator.EQUALS, List.of("2024"))
+        );
+        String pattern = "s3://bucket/data/*" + "/*.parquet";
+
+        assertEquals(
+            "a hive strategy must not apply the path template to the glob",
+            pattern,
+            GlobExpander.rewriteGlobWithHints(pattern, hints, new PartitionConfig(PartitionConfig.Strategy.HIVE, "{year}"))
+        );
+        assertEquals(
+            "auto may still resolve to hive at detect time, so it must not apply the template either",
+            pattern,
+            GlobExpander.rewriteGlobWithHints(pattern, hints, new PartitionConfig(PartitionConfig.Strategy.AUTO, "{year}"))
+        );
+    }
+
+    /** The key=value segment rewrite is untouched by that gate — hive keeps the narrowing it always had. */
+    public void testRewriteGlobHiveStrategyStillRewritesKeyValueSegments() {
+        List<PartitionFilterHintExtractor.PartitionFilterHint> hints = List.of(
+            new PartitionFilterHintExtractor.PartitionFilterHint("year", PartitionFilterHintExtractor.Operator.EQUALS, List.of("2024"))
+        );
+
+        assertEquals(
+            "s3://bucket/data/year=2024/*.parquet",
+            GlobExpander.rewriteGlobWithHints(
+                "s3://bucket/data/year=*/*.parquet",
+                hints,
+                new PartitionConfig(PartitionConfig.Strategy.HIVE, "{year}")
+            )
+        );
+    }
+
+    /**
+     * Under TEMPLATE the bound column value is the whole directory segment, so the key=value segment rewrite would
+     * narrow on the wrong axis — spelling a template-bound {@code part=a} as the segment {@code part=part=a}. The
+     * template rewrite is the only one whose spelling matches how the value was bound; when it declines, the pattern
+     * must be left alone.
+     */
+    public void testRewriteGlobTemplateStrategyDoesNotFallBackToKeyValueRewrite() {
+        List<PartitionFilterHintExtractor.PartitionFilterHint> hints = List.of(
+            new PartitionFilterHintExtractor.PartitionFilterHint("part", PartitionFilterHintExtractor.Operator.EQUALS, List.of("part=a"))
+        );
+        String pattern = "s3://bucket/data/part=*/*.parquet";
+
+        assertEquals(
+            "a template strategy must not apply the key=value segment rewrite",
+            pattern,
+            GlobExpander.rewriteGlobWithHints(pattern, hints, new PartitionConfig(PartitionConfig.Strategy.TEMPLATE, "{part}"))
+        );
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
@@ -26,7 +26,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/year=2023/month=12/file3.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(2, result.partitionColumns().size());
@@ -80,7 +80,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/flag=False/file2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.BOOLEAN, result.partitionColumns().get("flag"));
@@ -100,7 +100,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/flag=__HIVE_DEFAULT_PARTITION__/file2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.BOOLEAN, result.partitionColumns().get("flag"));
@@ -126,7 +126,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/_index=beta/year=2023/file2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(2, result.partitionColumns().size());
@@ -156,7 +156,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/_tier=cold/file2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertFalse("snapshot-gated reserved name must not surface as-is", result.partitionColumns().containsKey("_tier"));
@@ -178,7 +178,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/month=01/file2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
         assertTrue(result.isEmpty());
     }
 
@@ -188,14 +188,14 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/2024/02/file2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
         assertTrue(result.isEmpty());
     }
 
     public void testUrlEncodedValues() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/city=S%C3%A3o%20Paulo/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.KEYWORD, result.partitionColumns().get("city"));
@@ -214,7 +214,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testLiteralPlusIsNotDecodedToSpace() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a+b/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.KEYWORD, result.partitionColumns().get("tag"));
@@ -227,7 +227,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testPercentEncodedPlusDecodesToPlus() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a%2Bb/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a%2Bb/file.parquet"));
@@ -238,7 +238,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testPercentEncodedColonDecodesToColon() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=ns%3Aclick/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=ns%3Aclick/file.parquet"));
@@ -252,7 +252,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testLiteralPlusAndEscapedSpaceInOneValue() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a+b%20c/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a+b%20c/file.parquet"));
@@ -263,7 +263,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testMalformedPercentEscapeFallsBackToRawValue() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a%2/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a%2/file.parquet"));
@@ -277,7 +277,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testLiteralPlusWithMalformedEscapeFallsBackToRawValue() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a+%2/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a+%2/file.parquet"));
@@ -287,7 +287,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testSingleFile() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/year=2024/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.partitionColumns().size());
@@ -295,18 +295,18 @@ public class HivePartitionDetectorTests extends ESTestCase {
     }
 
     public void testEmptyFileList() {
-        PartitionMetadata result = HivePartitionDetector.detect(List.of());
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(List.of());
         assertTrue(result.isEmpty());
     }
 
     public void testNullFileList() {
-        PartitionMetadata result = HivePartitionDetector.detect(null);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(null);
         assertTrue(result.isEmpty());
     }
 
     public void testEmptyValues() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/file.parquet"));
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
         assertTrue(result.isEmpty());
     }
 
@@ -316,7 +316,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/country=UK/state=London/city=Westminster/file.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(3, result.partitionColumns().size());
@@ -374,7 +374,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
         // file.parquet contains '=' but is not a partition segment (has a dot)
         List<StorageEntry> files = List.of(entry("s3://bucket/data/year=2024/a=b.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.partitionColumns().size());
@@ -390,23 +390,24 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/year=2023/file2.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
         assertFalse(result.isEmpty());
         assertEquals(DataType.INTEGER, result.partitionColumns().get("year"));
     }
 
-    public void testDetectViaInterfaceIgnoresConfig() {
+    /** Renamed from testDetectViaInterfaceIgnoresConfig: detect() no longer takes a config map to ignore. */
+    public void testDetectViaInterface() {
         PartitionDetector detector = HivePartitionDetector.INSTANCE;
         List<StorageEntry> files = List.of(entry("s3://bucket/data/year=2024/file.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of("irrelevant", "value"));
+        PartitionMetadata result = detector.detect(files);
         assertFalse(result.isEmpty());
     }
 
     public void testHiveDefaultPartitionAlone() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/year=2024/month=__HIVE_DEFAULT_PARTITION__/file.parquet"));
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.INTEGER, result.partitionColumns().get("year"));
@@ -426,7 +427,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/year=2024/month=__HIVE_DEFAULT_PARTITION__/f2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.INTEGER, result.partitionColumns().get("month"));
@@ -445,7 +446,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/region=__HIVE_DEFAULT_PARTITION__/f2.parquet")
         );
 
-        PartitionMetadata result = HivePartitionDetector.detect(files);
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.KEYWORD, result.partitionColumns().get("region"));
@@ -476,6 +477,22 @@ public class HivePartitionDetectorTests extends ESTestCase {
         assertNull(HivePartitionDetector.castValue(null, DataType.DOUBLE));
         assertNull(HivePartitionDetector.castValue(null, DataType.BOOLEAN));
         assertNull(HivePartitionDetector.castValue(null, DataType.KEYWORD));
+    }
+
+    /**
+     * Mixed partition depth — older data partitioned by year only, newer by year/month/day — yields no partition
+     * columns at all, not even the common {@code year}. The detector requires an identical key set across every
+     * file. Pinned as the current contract: changing it to an intersection, to per-file nulls, or to a loud error
+     * would change results for stored datasets and needs its own design pass.
+     */
+    public void testMixedPartitionDepthReturnsEmpty() {
+        List<StorageEntry> files = List.of(
+            entry("s3://bucket/data/year=2024/f1.parquet"),
+            entry("s3://bucket/data/year=2024/month=01/f2.parquet"),
+            entry("s3://bucket/data/year=2024/month=01/day=15/f3.parquet")
+        );
+
+        assertTrue("inconsistent key sets across files yield no partition columns", HivePartitionDetector.INSTANCE.detect(files).isEmpty());
     }
 
     private static StorageEntry entry(String path) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionConfigTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionConfigTests.java
@@ -9,10 +9,12 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.datasources.PartitionConfig.CONFIG_PARTITIONING_DETECTION;
 import static org.elasticsearch.xpack.esql.datasources.PartitionConfig.CONFIG_PARTITIONING_PATH;
+import static org.hamcrest.Matchers.containsString;
 
 public class PartitionConfigTests extends ESTestCase {
 
@@ -52,9 +54,14 @@ public class PartitionConfigTests extends ESTestCase {
         assertEquals(PartitionConfig.Strategy.NONE, config.strategy());
     }
 
-    public void testFromConfigAutoWithTemplatePromotesToTemplate() {
+    /**
+     * A partition_path with no partition_detection stays AUTO. AUTO is "Hive first, template as a fallback", which
+     * is what such a dataset resolved to before the setting reached the read path; promoting to TEMPLATE here would
+     * take the Hive columns away from every one stored against a key=value layout.
+     */
+    public void testFromConfigAutoWithTemplateStaysAuto() {
         PartitionConfig config = PartitionConfig.fromConfig(Map.of(CONFIG_PARTITIONING_PATH, "{year}/{month}"));
-        assertEquals(PartitionConfig.Strategy.TEMPLATE, config.strategy());
+        assertEquals(PartitionConfig.Strategy.AUTO, config.strategy());
         assertEquals("{year}/{month}", config.pathTemplate());
     }
 
@@ -73,5 +80,137 @@ public class PartitionConfigTests extends ESTestCase {
 
     public void testEmptyStrategyReturnsNull() {
         assertNull(PartitionConfig.Strategy.parse(""));
+    }
+
+    // -- hive_partitioning folding (lenient: runs on every query against every stored dataset) --
+
+    public void testHivePartitioningFalseFoldsToNone() {
+        PartitionConfig config = PartitionConfig.fromConfig(Map.of(PartitionConfig.CONFIG_PARTITIONING_HIVE, "false"));
+        assertEquals(PartitionConfig.Strategy.NONE, config.strategy());
+    }
+
+    public void testHivePartitioningFalseAsBooleanFoldsToNone() {
+        PartitionConfig config = PartitionConfig.fromConfig(Map.of(PartitionConfig.CONFIG_PARTITIONING_HIVE, false));
+        assertEquals(PartitionConfig.Strategy.NONE, config.strategy());
+    }
+
+    /**
+     * Only the literal "false" disables detection. The setting is stored free-form and the boolean check this
+     * replaced treated every other value as enabled, so stored datasets carrying junk must keep reading as they do.
+     */
+    public void testHivePartitioningNonFalseValuesLeaveDetectionEnabled() {
+        for (Object value : List.of("true", true, "yes", "no", 0, 1, "banana")) {
+            PartitionConfig config = PartitionConfig.fromConfig(Map.of(PartitionConfig.CONFIG_PARTITIONING_HIVE, value));
+            assertNotEquals("value [" + value + "] must not disable detection", PartitionConfig.Strategy.NONE, config.strategy());
+        }
+    }
+
+    /** Explicit true carries no information — it is the default — so it must not change the resolved strategy. */
+    public void testHivePartitioningTrueDoesNotChangeTheStrategy() {
+        PartitionConfig config = PartitionConfig.fromConfig(
+            Map.of(PartitionConfig.CONFIG_PARTITIONING_HIVE, true, CONFIG_PARTITIONING_PATH, "{year}")
+        );
+        assertEquals(PartitionConfig.Strategy.AUTO, config.strategy());
+        assertEquals("{year}", config.pathTemplate());
+    }
+
+    /** hive_partitioning:false folds last and wins over a path template, so this reads as no-partitions. */
+    public void testHivePartitioningFalseBeatsPathTemplate() {
+        PartitionConfig config = PartitionConfig.fromConfig(
+            Map.of(PartitionConfig.CONFIG_PARTITIONING_HIVE, "false", CONFIG_PARTITIONING_PATH, "{year}")
+        );
+        assertEquals(PartitionConfig.Strategy.NONE, config.strategy());
+    }
+
+    /** An explicit template with nothing to templatise falls back to AUTO, keeping a stored dataset's columns. */
+    public void testTemplateWithoutPathFallsBackToAuto() {
+        PartitionConfig config = PartitionConfig.fromConfig(Map.of(CONFIG_PARTITIONING_DETECTION, "template"));
+        assertEquals(PartitionConfig.Strategy.AUTO, config.strategy());
+    }
+
+    /** hive never reads a path template, so storing one would store a setting that does nothing. */
+    public void testValidateRejectsHiveWithPartitionPath() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_DETECTION, "hive", CONFIG_PARTITIONING_PATH, "{year}"))
+        );
+        assertThat(e.getMessage(), containsString(CONFIG_PARTITIONING_PATH));
+        assertThat(e.getMessage(), containsString(CONFIG_PARTITIONING_DETECTION));
+
+        // Reading stays lenient: a dataset stored before this check keeps resolving, it simply never uses the template.
+        PartitionConfig stored = PartitionConfig.fromConfig(
+            Map.of(CONFIG_PARTITIONING_DETECTION, "hive", CONFIG_PARTITIONING_PATH, "{year}")
+        );
+        assertEquals(PartitionConfig.Strategy.HIVE, stored.strategy());
+        assertEquals("{year}", stored.pathTemplate());
+    }
+
+    /** auto genuinely consumes the template as its fallback detector, so it stays legal. */
+    public void testValidateAllowsAutoWithPartitionPath() {
+        PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_DETECTION, "auto", CONFIG_PARTITIONING_PATH, "{year}"));
+        PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_PATH, "{year}"));
+    }
+
+    /** A value stored before the setting was validated as an enum must not fail the read. */
+    public void testUnparseableStoredStrategyFallsBackToAuto() {
+        PartitionConfig config = PartitionConfig.fromConfig(Map.of(CONFIG_PARTITIONING_DETECTION, "banana"));
+        assertEquals(PartitionConfig.Strategy.AUTO, config.strategy());
+    }
+
+    // -- validate(): registration-time strictness --
+
+    public void testValidateRejectsHiveFalseWithExplicitStrategy() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_DETECTION, "hive", PartitionConfig.CONFIG_PARTITIONING_HIVE, "false"))
+        );
+        assertThat(e.getMessage(), containsString("disables partition detection"));
+    }
+
+    public void testValidateAllowsHiveFalseWithExplicitNone() {
+        PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_DETECTION, "none", PartitionConfig.CONFIG_PARTITIONING_HIVE, "false"));
+    }
+
+    public void testValidateRejectsTemplateWithoutPath() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_DETECTION, "template"))
+        );
+        assertThat(e.getMessage(), containsString("needs a path template"));
+    }
+
+    public void testValidateRejectsPathAlongsideNone() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_DETECTION, "none", CONFIG_PARTITIONING_PATH, "{year}"))
+        );
+        assertThat(e.getMessage(), containsString("would be ignored"));
+    }
+
+    public void testValidateRejectsPathAlongsideHiveFalse() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> PartitionConfig.validate(Map.of(PartitionConfig.CONFIG_PARTITIONING_HIVE, "false", CONFIG_PARTITIONING_PATH, "{year}"))
+        );
+        assertThat(e.getMessage(), containsString("would be ignored"));
+    }
+
+    public void testValidateAcceptsHivePartitioningTrueWithAnyStrategy() {
+        PartitionConfig.validate(Map.of(CONFIG_PARTITIONING_DETECTION, "hive", PartitionConfig.CONFIG_PARTITIONING_HIVE, true));
+        PartitionConfig.validate(
+            Map.of(
+                CONFIG_PARTITIONING_DETECTION,
+                "template",
+                CONFIG_PARTITIONING_PATH,
+                "{year}",
+                PartitionConfig.CONFIG_PARTITIONING_HIVE,
+                true
+            )
+        );
+    }
+
+    public void testValidateAcceptsEmptyAndNullSettings() {
+        PartitionConfig.validate(Map.of());
+        PartitionConfig.validate(null);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionDetectionSettingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionDetectionSettingTests.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Pins that the {@code partition_detection}, {@code partition_path} and {@code hive_partitioning} dataset settings
+ * select the partition detector on the read path.
+ *
+ * <p>Each test drives {@link GlobExpander#expand} with a settings map, the way {@code ExternalSourceResolver} does,
+ * and asserts the partition columns that fall out. A failure here means a setting has stopped reaching the detector.
+ *
+ * <p>The {@code testMachineryHonours*} pair states the narrowest form of the same contract — what each strategy
+ * does once its config reaches the expander — and is kept as the isolation point between the wiring and the
+ * detectors themselves.
+ */
+public class PartitionDetectionSettingTests extends ESTestCase {
+
+    private static final int MAX = Integer.MAX_VALUE;
+
+    /** A Hive-shaped tree: the partition key is spelled in the directory name. */
+    private static final String HIVE_PATTERN = "s3://bucket/data/**" + "/*.parquet";
+    private static final List<StorageEntry> HIVE_TREE = List.of(
+        entry("s3://bucket/data/year=2024/a.parquet"),
+        entry("s3://bucket/data/year=2025/b.parquet")
+    );
+
+    /** A NON-Hive tree: bare directory segments, exactly what {@code partition_path} exists to describe. */
+    private static final String FLAT_PATTERN = "s3://bucket/logs/**" + "/*.parquet";
+    private static final List<StorageEntry> FLAT_TREE = List.of(
+        entry("s3://bucket/logs/2024/a.parquet"),
+        entry("s3://bucket/logs/2025/b.parquet")
+    );
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Controls: the detection machinery works when a PartitionConfig is handed to it.
+    // ---------------------------------------------------------------------------------------------------------
+
+    public void testMachineryHonoursNoneWhenGivenAPartitionConfig() throws IOException {
+        FileList listing = GlobExpander.expandGlob(HIVE_PATTERN, provider(HIVE_TREE), null, partitionSettings("none", null));
+        assertNull("the NONE strategy suppresses detection when the config reaches the expander", listing.partitionMetadata());
+    }
+
+    public void testMachineryHonoursTemplateWhenGivenAPartitionConfig() throws IOException {
+        FileList listing = GlobExpander.expandGlob(FLAT_PATTERN, provider(FLAT_TREE), null, partitionSettings("template", "{year}"));
+        assertEquals("the TEMPLATE strategy names the column after the template placeholder", Set.of("year"), columnsOf(listing));
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Reproductions: the same settings, driven through the entry point the resolver uses.
+    // ---------------------------------------------------------------------------------------------------------
+
+    /**
+     * {@code partition_detection: none} is documented as the way to turn partition detection off. Against
+     * {@code main} it did not: the Hive detector ran anyway and injected a {@code year} column present in none of
+     * the user's files.
+     */
+    public void testNoneDisablesDetection() throws IOException {
+        FileList listing = expandAsResolverDoes(HIVE_PATTERN, HIVE_TREE, Map.of("partition_detection", "none"));
+        assertNull("partition_detection:none must suppress partition detection", listing.partitionMetadata());
+    }
+
+    /**
+     * {@code partition_detection: none} and {@code hive_partitioning: false} both mean "do not derive columns from
+     * the path". They must agree. Against {@code main} only the second worked, so the documented setting and the undocumented one produced
+     * different schemas.
+     */
+    public void testNoneAgreesWithHivePartitioningFalse() throws IOException {
+        FileList viaDocumentedSetting = expandAsResolverDoes(HIVE_PATTERN, HIVE_TREE, Map.of("partition_detection", "none"));
+        FileList viaUndocumentedSetting = expandAsResolverDoes(HIVE_PATTERN, HIVE_TREE, Map.of("hive_partitioning", "false"));
+        assertEquals(
+            "partition_detection:none and hive_partitioning:false must produce the same schema",
+            columnsOf(viaUndocumentedSetting),
+            columnsOf(viaDocumentedSetting)
+        );
+    }
+
+    /**
+     * A hive strategy must never let a {@code partition_path} steer the glob rewrite. With both a real
+     * {@code year=2024/} partition and a coincidental bare {@code 2024/} folder present, the template rewrite would
+     * narrow the listing to the bare folder; that listing is non-empty, so the rewrite-to-empty fallback never fires
+     * and the query silently returns the wrong rows rather than a superset.
+     */
+    public void testHiveStrategyWithTemplateListsTheHiveTree() throws IOException {
+        List<StorageEntry> tree = List.of(entry("s3://bucket/data/year=2024/hive.parquet"), entry("s3://bucket/data/2024/flat.parquet"));
+        List<PartitionFilterHintExtractor.PartitionFilterHint> hints = List.of(
+            new PartitionFilterHintExtractor.PartitionFilterHint("year", PartitionFilterHintExtractor.Operator.EQUALS, List.of("2024"))
+        );
+
+        FileList listing = GlobExpander.expand(
+            "s3://bucket/data/*" + "/*.parquet",
+            provider(tree),
+            hints,
+            Map.of("partition_detection", "hive", "partition_path", "{year}"),
+            MAX,
+            MAX
+        );
+
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < listing.fileCount(); i++) {
+            paths.add(listing.path(i).toString());
+        }
+        assertTrue("the real hive partition must be listed, got " + paths, paths.stream().anyMatch(p -> p.contains("year=2024")));
+    }
+
+    /**
+     * The load-bearing BWC shape. {@code {partition_detection: hive, hive_partitioning: "false"}} was registerable
+     * before this validation existed, and read with detection OFF because the boolean short-circuited first. It
+     * must keep reading that way now that the two settings resolve through one strategy — verified here at the
+     * read-path grain, not just at {@code fromConfig}.
+     */
+    public void testGrandfatheredHiveFalseWithExplicitStrategyStillDisablesDetection() throws IOException {
+        FileList listing = expandAsResolverDoes(
+            HIVE_PATTERN,
+            HIVE_TREE,
+            Map.of("partition_detection", "hive", PartitionConfig.CONFIG_PARTITIONING_HIVE, "false")
+        );
+        assertNull("hive_partitioning:false must still win over an explicit strategy", listing.partitionMetadata());
+    }
+
+    /**
+     * A stored template that names no columns — {@code year={year}} is not a whole-segment placeholder — must keep
+     * reading as it did before the setting reached the read path, which for this layout means Hive detection.
+     * {@code TemplatePartitionDetector}'s constructor rejects such a template, so the guard in
+     * {@code resolveDetector} is what stops this shape from throwing on every query.
+     */
+    public void testStoredPlaceholderlessTemplateFallsBackToHive() throws IOException {
+        FileList listing = expandAsResolverDoes(
+            HIVE_PATTERN,
+            HIVE_TREE,
+            Map.of("partition_detection", "template", "partition_path", "year={year}/month={month}")
+        );
+        assertEquals("a placeholderless template must not throw, and must keep the Hive columns", Set.of("year"), columnsOf(listing));
+    }
+
+    /**
+     * A {@code partition_path} template is the only way to describe a non-Hive layout. Against {@code main} it was
+     * dropped: the Hive detector found no {@code key=value} segment, so the dataset had no partition columns to
+     * filter or prune on.
+     */
+    public void testTemplateExtractsColumnsFromANonHiveLayout() throws IOException {
+        FileList listing = expandAsResolverDoes(
+            FLAT_PATTERN,
+            FLAT_TREE,
+            Map.of("partition_detection", "template", "partition_path", "{year}")
+        );
+        assertEquals("partition_path must name the partition column on a non-Hive layout", Set.of("year"), columnsOf(listing));
+    }
+
+    /**
+     * Setting {@code partition_path} alone leaves the strategy at AUTO — it is deliberately NOT promoted to
+     * TEMPLATE. On a layout Hive cannot read, {@code AutoPartitionDetector} falls through to its template fallback,
+     * which is what surfaces the column here.
+     */
+    public void testPartitionPathAloneEnablesTemplateFallbackUnderAuto() throws IOException {
+        FileList listing = expandAsResolverDoes(FLAT_PATTERN, FLAT_TREE, Map.of("partition_path", "{year}"));
+        assertEquals("partition_path alone must reach the template fallback under AUTO", Set.of("year"), columnsOf(listing));
+    }
+
+    /**
+     * An explicit {@code template} strategy must beat Hive-shaped directory names — that is the whole point of
+     * naming a strategy rather than letting AUTO guess. Against {@code main} the Hive detector ran regardless, so a
+     * Hive-shaped layout could not be reinterpreted.
+     */
+    public void testTemplateStrategyOverridesAHiveShapedLayout() throws IOException {
+        FileList listing = expandAsResolverDoes(
+            HIVE_PATTERN,
+            HIVE_TREE,
+            Map.of("partition_detection", "template", "partition_path", "{bucket}")
+        );
+        assertEquals("an explicit template strategy must not fall back to Hive detection", Set.of("bucket"), columnsOf(listing));
+    }
+
+    /**
+     * The four strategies are four behaviours. Against {@code main} they collapsed onto one: every value produced
+     * identical partition columns.
+     */
+    public void testStrategiesAreDistinguishable() throws IOException {
+        Set<Set<String>> distinctResults = new LinkedHashSet<>();
+        for (String strategy : List.of("auto", "hive", "template", "none")) {
+            distinctResults.add(columnsOf(expandAsResolverDoes(HIVE_PATTERN, HIVE_TREE, settingsFor(strategy))));
+        }
+        assertNotEquals(
+            "all four partition_detection values produced the same schema, so the setting has no effect",
+            1,
+            distinctResults.size()
+        );
+    }
+
+    /**
+     * The listing cache is keyed on {@code GlobExpander.listingCacheDiscriminator}, which binds the path pattern, the
+     * filter hints and the {@code hivePartitioning} flag — but not the partition strategy. The cached {@link FileList} carries its
+     * {@code PartitionMetadata}, so once the strategy affects detection, two datasets differing only in
+     * {@code partition_detection} collide on one cache entry and one of them is served the other's partition
+     * columns. This was latent while the setting was unread; wiring it makes the collision a wrong answer, so the key binds the
+     * strategy in the same change.
+     */
+    public void testListingCacheIdentityBindsThePartitionStrategy() throws IOException {
+        FileList none = GlobExpander.expandGlob(HIVE_PATTERN, provider(HIVE_TREE), null, partitionSettings("none", null));
+        FileList hive = GlobExpander.expandGlob(HIVE_PATTERN, provider(HIVE_TREE), null, partitionSettings("hive", null));
+        assertNotEquals("the two strategies must produce different listings for this to matter", columnsOf(none), columnsOf(hive));
+
+        String discriminator = GlobExpander.listingCacheDiscriminator(HIVE_PATTERN, null, partitionSettings("none", null));
+        assertTrue(
+            "the listing cache identity ["
+                + discriminator
+                + "] does not mention the partition strategy, so two datasets differing only in partition_detection "
+                + "share one cache entry",
+            discriminator.contains("none") || discriminator.contains("NONE")
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------------------------------
+
+    /**
+     * Expands the way {@code ExternalSourceResolver} does: it hands the dataset's settings map to
+     * {@link GlobExpander#expand}, which resolves the {@link PartitionConfig} once at the boundary.
+     */
+    private static FileList expandAsResolverDoes(String pattern, List<StorageEntry> tree, Map<String, Object> settings) throws IOException {
+        return GlobExpander.expand(pattern, provider(tree), null, settings, MAX, MAX);
+    }
+
+    private static Map<String, Object> settingsFor(String strategy) {
+        return "template".equals(strategy)
+            ? Map.of("partition_detection", strategy, "partition_path", "{bucket}")
+            : Map.of("partition_detection", strategy);
+    }
+
+    /** The dataset settings a user would register for a given strategy. */
+    private static Map<String, Object> partitionSettings(String strategy, String template) {
+        return template == null
+            ? Map.of("partition_detection", strategy)
+            : Map.of("partition_detection", strategy, "partition_path", template);
+    }
+
+    private static Set<String> columnsOf(FileList listing) {
+        PartitionMetadata metadata = listing.partitionMetadata();
+        return metadata == null ? Set.of() : metadata.partitionColumns().keySet();
+    }
+
+    private static StorageEntry entry(String path) {
+        return new StorageEntry(StoragePath.of(path), 1L, Instant.EPOCH);
+    }
+
+    private static StorageProvider provider(List<StorageEntry> listing) {
+        return new StubProvider(listing);
+    }
+
+    private static class StubProvider implements StorageProvider {
+        private final List<StorageEntry> listing;
+
+        StubProvider(List<StorageEntry> listing) {
+            this.listing = listing;
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return new StubStorageObject(path, 0);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return new StubStorageObject(path, length);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return new StubStorageObject(path, length);
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+            List<StorageEntry> matched = new ArrayList<>();
+            for (StorageEntry e : listing) {
+                if (e.path().toString().startsWith(prefix.toString())) {
+                    matched.add(e);
+                }
+            }
+            return new StorageIterator() {
+                private final Iterator<StorageEntry> it = matched.iterator();
+
+                @Override
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                @Override
+                public StorageEntry next() {
+                    if (it.hasNext() == false) {
+                        throw new NoSuchElementException();
+                    }
+                    return it.next();
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return false;
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of("s3");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class StubStorageObject implements StorageObject {
+        private final StoragePath path;
+        private final long length;
+
+        StubStorageObject(StoragePath path, long length) {
+            this.path = path;
+            this.length = length;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public long length() {
+            return length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return false;
+        }
+
+        @Override
+        public StoragePath path() {
+            return path;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionMetadataTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionMetadataTests.java
@@ -129,7 +129,7 @@ public class PartitionMetadataTests extends ESTestCase {
             new StorageEntry(StoragePath.of("s3://b/year=2024/month=__HIVE_DEFAULT_PARTITION__/f2.parquet"), 100, Instant.EPOCH)
         );
 
-        PartitionMetadata pm = HivePartitionDetector.detect(files);
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(files);
         assertFalse(pm.isEmpty());
         assertEquals(Set.of("month"), pm.nullablePartitionColumns());
     }
@@ -140,7 +140,7 @@ public class PartitionMetadataTests extends ESTestCase {
             new StorageEntry(StoragePath.of("s3://b/year=2024/month=02/f2.parquet"), 100, Instant.EPOCH)
         );
 
-        PartitionMetadata pm = HivePartitionDetector.detect(files);
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(files);
         assertFalse(pm.isEmpty());
         assertEquals(Set.of(), pm.nullablePartitionColumns());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetectorTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TemplatePartitionDetectorTests extends ESTestCase {
 
@@ -26,7 +27,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/2023/12/31/file3.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(3, result.partitionColumns().size());
@@ -55,7 +56,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/beta/2023/file2.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertFalse("reserved name must not surface as-is", result.partitionColumns().containsKey("_index"));
@@ -83,7 +84,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/k1/v1/file1.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.KEYWORD, result.partitionColumns().get("_partition._id"));
@@ -106,7 +107,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/europe/london/file.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.KEYWORD, result.partitionColumns().get("region"));
@@ -125,7 +126,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/file2.parquet")  // not enough segments
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
         assertTrue(result.isEmpty());
     }
 
@@ -137,7 +138,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/2024-02-20/file.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.partitionColumns().size());
@@ -152,7 +153,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/2024/01/15/13/file.json")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(4, result.partitionColumns().size());
@@ -165,7 +166,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/americas/sao_paulo/file.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(
@@ -183,7 +184,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/S%C3%A3o%20Paulo/file.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/S%C3%A3o%20Paulo/file.parquet"));
@@ -200,7 +201,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/a+b/file.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a+b/file.parquet"));
@@ -213,7 +214,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/a%2Bns%3Ab/file.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a%2Bns%3Ab/file.parquet"));
@@ -229,7 +230,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/a+b%20c/file.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a+b%20c/file.parquet"));
@@ -242,7 +243,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/a%2/file.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a%2/file.parquet"));
@@ -251,13 +252,13 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
     public void testEmptyFilesReturnsEmpty() {
         TemplatePartitionDetector detector = new TemplatePartitionDetector("{year}");
-        PartitionMetadata result = detector.detect(List.of(), Map.of());
+        PartitionMetadata result = detector.detect(List.of());
         assertTrue(result.isEmpty());
     }
 
     public void testNullFilesReturnsEmpty() {
         TemplatePartitionDetector detector = new TemplatePartitionDetector("{year}");
-        PartitionMetadata result = detector.detect(null, Map.of());
+        PartitionMetadata result = detector.detect(null);
         assertTrue(result.isEmpty());
     }
 
@@ -294,7 +295,7 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
 
         List<StorageEntry> files = List.of(entry("s3://bucket/data/True/file1.parquet"), entry("s3://bucket/data/False/file2.parquet"));
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.BOOLEAN, result.partitionColumns().get("flag"));
@@ -310,11 +311,40 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
             entry("s3://bucket/data/2023/eu-west/file.parquet")
         );
 
-        PartitionMetadata result = detector.detect(files, Map.of());
+        PartitionMetadata result = detector.detect(files);
 
         assertFalse(result.isEmpty());
         assertEquals(DataType.INTEGER, result.partitionColumns().get("year"));
         assertEquals(DataType.KEYWORD, result.partitionColumns().get("region"));
+    }
+
+    /**
+     * The template binds the last N segments before the filename, so files at differing depths would bind different
+     * physical levels to the same column — over these three files with {@code {year}} the values would be 2024, 01
+     * and 15, and a STATS BY year would bucket a day as a year. Mixed depth therefore yields no partition columns,
+     * the same all-or-nothing stance {@code HivePartitionDetector} takes when its key sets disagree.
+     */
+    public void testMixedDepthReturnsEmpty() {
+        List<StorageEntry> files = List.of(
+            entry("s3://bucket/data/2024/f1.parquet"),
+            entry("s3://bucket/data/2024/01/f2.parquet"),
+            entry("s3://bucket/data/2024/01/15/f3.parquet")
+        );
+
+        assertTrue("mixed depth must not bind a template column", new TemplatePartitionDetector("{year}").detect(files).isEmpty());
+        assertTrue(
+            "mixed depth must not bind a multi-column template either",
+            new TemplatePartitionDetector("{year}/{month}").detect(files).isEmpty()
+        );
+    }
+
+    /** The uniform-depth case still binds, so the gate above is not simply switching template detection off. */
+    public void testUniformDepthStillBinds() {
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/2024/01/f1.parquet"), entry("s3://bucket/data/2025/02/f2.parquet"));
+
+        PartitionMetadata result = new TemplatePartitionDetector("{year}/{month}").detect(files);
+        assertFalse(result.isEmpty());
+        assertEquals(Set.of("year", "month"), result.partitionColumns().keySet());
     }
 
     private static StorageEntry entry(String path) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -42,6 +42,9 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 public class ExternalSourceCacheServiceTests extends ESTestCase {
+    private static final Map<String, Object> HIVE_ON = Map.of();
+
+    private static final Map<String, Object> HIVE_OFF = Map.of("hive_partitioning", "false");
 
     private static Settings defaultSettings() {
         return Settings.builder()
@@ -185,14 +188,14 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
                 "bucket",
                 "/data/year=*/*.parquet",
                 Map.of(),
-                GlobExpander.listingCacheDiscriminator(glob, List.of(hint), true)
+                GlobExpander.listingCacheDiscriminator(glob, List.of(hint), HIVE_ON)
             );
             ListingCacheKey unfiltered = ListingCacheKey.build(
                 "s3",
                 "bucket",
                 "/data/year=*/*.parquet",
                 Map.of(),
-                GlobExpander.listingCacheDiscriminator(glob, null, true)
+                GlobExpander.listingCacheDiscriminator(glob, null, HIVE_ON)
             );
             assertNotEquals(filtered, unfiltered);
 
@@ -212,7 +215,7 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
             AtomicInteger loaderCalls = new AtomicInteger();
 
-            String discriminator = GlobExpander.listingCacheDiscriminator("s3://bucket/data/*.parquet", null, true);
+            String discriminator = GlobExpander.listingCacheDiscriminator("s3://bucket/data/*.parquet", null, HIVE_ON);
             ListingCacheKey key1 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), discriminator);
             ListingCacheKey key2 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), discriminator);
             assertEquals(key1, key2);
@@ -2222,7 +2225,7 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
 
         // Detect partitions the way production does, so the fixture exercises the real typing and
         // percent-decoding rather than the on-disk spelling a hand-built PartitionMetadata would carry.
-        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries, Map.of());
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries);
         return GlobExpander.fileListOf(entries, "s3://bucket/data/*" + "*/*.parquet", pm);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -48,7 +47,7 @@ public class FileListCompactorTests extends ESTestCase {
         for (int i = 0; i < keys.length; i++) {
             entries.add(new StorageEntry(StoragePath.of(keys[i]), 100L * (i + 1), mtime));
         }
-        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries, Map.of());
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries);
         return new GenericFileList(entries, pattern, pm == null || pm.isEmpty() ? null : pm);
     }
 
@@ -404,7 +403,7 @@ public class FileListCompactorTests extends ESTestCase {
         for (int i = 0; i < keys.length; i++) {
             entries.add(new StorageEntry(StoragePath.of(keys[i]), 100L * (i + 1), Instant.ofEpochMilli(mtimesMillis[i])));
         }
-        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries, Map.of());
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries);
         return new GenericFileList(entries, pattern, pm == null || pm.isEmpty() ? null : pm);
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL: read partition_detection and partition_path on the query path (#157208)