### PR TITLE
fix(columnar): replace count-based dictionary coverage with byte coverage

### DIFF
--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryPolicy.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryPolicy.java
@@ -24,7 +24,7 @@ package org.elasticsearch.columnar.string;
  * for has bought nothing, however well it covers them.
  *
  * @param maxBytes         the most term bytes a dictionary may hold
- * @param minCoverage      the share of a column's values the dictionary must account for
+ * @param minCoverage      the share of a column's raw bytes the dictionary must account for
  * @param maxShareOfColumn the largest share of the column's value bytes the dictionary may occupy
  */
 public record DictionaryPolicy(int maxBytes, double minCoverage, double maxShareOfColumn) {

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnWriter.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnWriter.java
@@ -114,10 +114,7 @@ public final class StringColumnWriter {
         Vocabulary.Terms surveyed = null;
         if (policy.enabled()) {
             // A merge that worked out the vocabulary from what its inputs recorded does not survey again.
-            // Nulls are named by a reserved ordinal, not by a term, so they are no part of what a dictionary
-            // could cover. Counting them in the denominator would cost a column its dictionary on the
-            // strength of slots no dictionary was ever going to name.
-            surveyed = known != null ? known : Vocabulary.survey(cursors.get(), policy, numValues - numNullSlots);
+            surveyed = known != null ? known : Vocabulary.survey(cursors.get(), policy);
             // Coverage is a lower bound, so a column admitted here covers at least as much as it claims.
             if (surveyed != null && policy.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes())) {
                 return withSummary(

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/Vocabulary.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/Vocabulary.java
@@ -51,7 +51,7 @@ public final class Vocabulary {
      * @param terms          the surveyed terms, addressed by id
      * @param sortedIds      the kept ids in term order, so an ordinal comparison is a term comparison
      * @param ordinalOfId    an ordinal per surveyed id, or {@link #DROPPED} for one that was not kept
-     * @param coverage       the share of the column's values these terms account for, as a lower bound
+     * @param coverage       the share of the column's raw bytes these terms account for, as a lower bound
      * @param dictionaryBytes the term bytes the kept terms occupy
      * @param columnBytes    the value bytes the whole column occupies
      * @param counts         how often each id was seen, as a lower bound, or null when unknown
@@ -113,13 +113,8 @@ public final class Vocabulary {
     /**
      * Surveys {@code values}, returning the terms worth a dictionary entry, or null when the column holds
      * nothing worth naming.
-     *
-     * @param numNonNullValues the slots a term could account for, which is every slot but the null ones. A
-     *                         null is named by a reserved ordinal rather than by a dictionary entry, so
-     *                         counting it here would hold a column's nulls against a dictionary that covers
-     *                         every value it actually has.
      */
-    public static Terms survey(StringColumnValues values, DictionaryPolicy policy, long numNonNullValues) throws IOException {
+    public static Terms survey(StringColumnValues values, DictionaryPolicy policy) throws IOException {
         final BytesRefHash terms = new BytesRefHash(new ByteBlockPool(new ByteBlockPool.DirectTrackingAllocator(Counter.newCounter())));
         int[] counts = new int[64];
         long tableBytes = 0;
@@ -193,18 +188,18 @@ public final class Vocabulary {
         // Indexed by id, so a term the survey saw but did not keep is told apart from ordinal zero.
         final int[] ordinalOfId = new int[terms.size()];
         Arrays.fill(ordinalOfId, DROPPED);
-        long covered = 0;
+        long coveredBytes = 0;
         long keptBytes = 0;
         final BytesRef scratch = new BytesRef();
         for (int ordinal = 0; ordinal < sortedIds.length; ordinal++) {
             final int id = sortedIds[ordinal];
             ordinalOfId[id] = ordinal;
-            covered += counts[id];
             terms.get(id, scratch);
+            coveredBytes += (long) counts[id] * scratch.length;
             keptBytes += scratch.length;
         }
-        final double coverage = numNonNullValues == 0 ? 0.0 : (double) covered / numNonNullValues;
-        return new Terms(terms, sortedIds, ordinalOfId, coverage, keptBytes, columnBytes, counts);
+        // NOTE: columnBytes is 0 only when there are no values, which keepMostFrequent already gates on.
+        return new Terms(terms, sortedIds, ordinalOfId, (double) coveredBytes / columnBytes, keptBytes, columnBytes, counts);
     }
 
     /**

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
@@ -281,6 +281,46 @@ public class StringColumnTests extends ColumnarStringTestCase {
         }
     }
 
+    public void testDictionaryRejectedWhenEscapeBytesExceedCoveredBytes() throws IOException {
+        final BytesRef[] docs = new BytesRef[2000];
+        final String[] frequent = { "alpha", "bravo", "char.", "delta", "echo." };
+        for (int i = 0; i < 1000; i++) {
+            docs[i] = new BytesRef(frequent[i % frequent.length]);
+        }
+        // 1000 unique 50-byte values seen once each: all escape the dictionary after keepMostFrequent.
+        for (int i = 0; i < 1000; i++) {
+            final byte[] escape = new byte[50];
+            escape[0] = (byte) (i & 0xff);
+            escape[1] = (byte) ((i >> 8) & 0xff);
+            docs[1000 + i] = new BytesRef(escape);
+        }
+        // Covered bytes = 5000, column bytes = 55000: byte coverage ~9%.
+        // A 50% byte-coverage threshold rejects the dictionary; 91% of the column would gain nothing from it.
+        withColumn(
+            docs,
+            randomValidBlockSize(),
+            ChunkCodec.ZSTD,
+            64 * 1024,
+            new DictionaryPolicy(512 * 1024, 0.5, 0.2),
+            (metadata, reader) -> {
+                plainOf(metadata);
+                assertColumnValues(docs, reader);
+            }
+        );
+        // A 5% threshold accepts the dictionary because the covered terms are present.
+        withColumn(
+            docs,
+            randomValidBlockSize(),
+            ChunkCodec.ZSTD,
+            64 * 1024,
+            new DictionaryPolicy(512 * 1024, 0.05, 0.2),
+            (metadata, reader) -> {
+                dictionaryOf(metadata);
+                assertColumnValues(docs, reader);
+            }
+        );
+    }
+
     /** Writes {@code docSlots} as a string column, reads it back, and asserts every slot round-trips in order. */
     private void assertSlots(BytesRef[][] docSlots) throws IOException {
         withColumn(docSlots, (metadata, reader) -> assertSlots(docSlots, metadata, reader));
@@ -341,5 +381,15 @@ public class StringColumnTests extends ColumnarStringTestCase {
             }
             assertEquals("documents with a value", numDocsWithField, seenDocs);
         });
+    }
+
+    private static void assertColumnValues(BytesRef[] docValues, StringColumnReader reader) throws IOException {
+        int seenDocs = 0;
+        final ColumnIterator iterator = reader.iterator();
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+            assertEquals(docValues[doc], reader.valueAt(reader.firstValueAddress(iterator.rank())));
+            seenDocs++;
+        }
+        assertEquals(numDocsWithField(docValues), seenDocs);
     }
 }

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/VocabularyTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/VocabularyTests.java
@@ -150,7 +150,7 @@ public class VocabularyTests extends ColumnarStringTestCase {
             escape[1] = (byte) ((i >> 8) & 0xff);
             values.add(new BytesRef(escape));
         }
-        // 1000 covered values × 5 bytes = 5000 covered bytes out of 55000 total (≈9%).
+        // 1000 covered values x 5 bytes = 5000 covered bytes out of 55000 total (~9%).
         // By value count the ratio is 50%, which would pass minCoverage=0.5 and accept the dictionary
         // even though 91% of column bytes are in the escape stream and gain nothing from it.
         final Vocabulary.Terms surveyed = survey(values, ROOMY);
@@ -195,8 +195,8 @@ public class VocabularyTests extends ColumnarStringTestCase {
             escape[1] = (byte) ((i >> 8) & 0xff);
             values.add(new BytesRef(escape));
         }
-        // By value count: 1000/2000 = 50% — same as the regression case.
-        // By bytes: 50000/55000 ≈ 91% — the dictionary is well worth keeping.
+        // By value count: 1000/2000 = 50%, same as the regression case.
+        // By bytes: 50000/55000 ~= 91%; the dictionary is well worth keeping.
         final Vocabulary.Terms surveyed = survey(values, ROOMY);
         assertNotNull(surveyed);
         assertEquals(5, surveyed.size());

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/VocabularyTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/VocabularyTests.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
@@ -136,16 +137,85 @@ public class VocabularyTests extends ColumnarStringTestCase {
         assertEquals("coverage is kept as given", 1.0, known.coverage(), 0.0);
     }
 
+    public void testCoverageIsByteWeighted() throws IOException {
+        final List<BytesRef> values = new ArrayList<>();
+        final String[] frequent = { "alpha", "bravo", "char.", "delta", "echo." };
+        for (int i = 0; i < 1000; i++) {
+            values.add(new BytesRef(frequent[i % frequent.length]));
+        }
+        // 1000 unique 50-byte values, each seen once: all dropped by keepMostFrequent.
+        for (int i = 0; i < 1000; i++) {
+            final byte[] escape = new byte[50];
+            escape[0] = (byte) (i & 0xff);
+            escape[1] = (byte) ((i >> 8) & 0xff);
+            values.add(new BytesRef(escape));
+        }
+        // 1000 covered values × 5 bytes = 5000 covered bytes out of 55000 total (≈9%).
+        // By value count the ratio is 50%, which would pass minCoverage=0.5 and accept the dictionary
+        // even though 91% of column bytes are in the escape stream and gain nothing from it.
+        final Vocabulary.Terms surveyed = survey(values, ROOMY);
+        assertNotNull(surveyed);
+        assertEquals(5, surveyed.size());
+        assertThat("byte coverage is ~9%, not the 50% value-count ratio", surveyed.coverage(), lessThan(0.5));
+        assertFalse(ROOMY.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes()));
+    }
+
     public void testCoverageNeverOverstates() throws IOException {
         final List<BytesRef> values = zipfish();
         final Map<String, Integer> actual = tally(values);
         final Vocabulary.Terms surveyed = survey(values, ROOMY);
         assertNotNull(surveyed);
-        long truly = 0;
-        for (String term : termsOf(surveyed)) {
-            truly += actual.get(term);
+        long totalBytes = 0;
+        for (BytesRef v : values) {
+            totalBytes += v.length;
         }
-        assertThat("coverage", surveyed.coverage(), lessThanOrEqualTo((double) truly / values.size() + 1e-9));
+        long trulyBytes = 0;
+        for (String term : termsOf(surveyed)) {
+            trulyBytes += (long) actual.get(term) * term.length();
+        }
+        assertThat("coverage", surveyed.coverage(), lessThanOrEqualTo((double) trulyBytes / totalBytes + 1e-9));
+    }
+
+    /** Long covered values, short escapes: byte coverage is high even when value-count coverage is modest. */
+    public void testCoverageWhenCoveredValuesAreLong() throws IOException {
+        final List<BytesRef> values = new ArrayList<>();
+        // Five 50-byte terms, 200 occurrences each: 1000 values, 50000 covered bytes.
+        final byte[] term = new byte[50];
+        for (int t = 0; t < 5; t++) {
+            term[0] = (byte) t;
+            final BytesRef ref = new BytesRef(term.clone());
+            for (int i = 0; i < 200; i++) {
+                values.add(ref);
+            }
+        }
+        // 1000 unique 5-byte singletons: all escape after keepMostFrequent.
+        for (int i = 0; i < 1000; i++) {
+            final byte[] escape = new byte[5];
+            escape[0] = (byte) (i & 0xff);
+            escape[1] = (byte) ((i >> 8) & 0xff);
+            values.add(new BytesRef(escape));
+        }
+        // By value count: 1000/2000 = 50% — same as the regression case.
+        // By bytes: 50000/55000 ≈ 91% — the dictionary is well worth keeping.
+        final Vocabulary.Terms surveyed = survey(values, ROOMY);
+        assertNotNull(surveyed);
+        assertEquals(5, surveyed.size());
+        assertThat("byte coverage is ~91%, well above 0.5", surveyed.coverage(), lessThanOrEqualTo(1.0));
+        assertTrue(ROOMY.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes()));
+    }
+
+    /** All values in the dictionary: coverage is 1.0 and the policy accepts trivially. */
+    public void testCoverageIsOneWhenAllValuesCovered() throws IOException {
+        final List<BytesRef> values = new ArrayList<>();
+        final String[] terms = { "alpha", "bravo", "char.", "delta", "echo." };
+        for (int i = 0; i < 2000; i++) {
+            values.add(new BytesRef(terms[i % terms.length]));
+        }
+        final Vocabulary.Terms surveyed = survey(values, ROOMY);
+        assertNotNull(surveyed);
+        assertEquals(5, surveyed.size());
+        assertEquals("every byte is covered", 1.0, surveyed.coverage(), 1e-9);
+        assertTrue(ROOMY.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes()));
     }
 
     /**
@@ -207,6 +277,6 @@ public class VocabularyTests extends ColumnarStringTestCase {
     }
 
     private static Vocabulary.Terms survey(List<BytesRef> values, DictionaryPolicy policy) throws IOException {
-        return Vocabulary.survey(cursor(values.toArray(BytesRef[]::new)), policy, values.size());
+        return Vocabulary.survey(cursor(values.toArray(BytesRef[]::new)), policy);
     }
 }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -720,3 +720,8 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
   method: testMixedOperationsDuringSplitWithDisruption
   issue: https://github.com/elastic/elasticsearch/issues/159143
+- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT
+  issue: https://github.com/elastic/elasticsearch/issues/159149
+- class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=esql/40_tsdb/PromQL missing field outside the command fails under nullify}
+  issue: https://github.com/elastic/elasticsearch/issues/159152


### PR DESCRIPTION
## TL;DR

The dictionary layout is only beneficial when it covers enough of the column's bytes that the ordinal savings outweigh the overhead. Before this change, coverage was measured in value count rather than bytes, so the threshold did not fire for fields where escape values are longer than covered values. Those fields were written with a dictionary that inflated storage instead of reducing it.

## Summary

The dictionary layout stores covered values as bit-packed ordinals; uncovered values (escapes) write their raw bytes to a ZSTD escape stream plus a sentinel ordinal. The saving comes from covered bytes only: each covered byte is replaced by ordinal bits, while escape bytes flow through ZSTD in both layouts.

Before this change, `DictionaryPolicy.worthKeeping` computed coverage as `covered_count / total_count`. A column with 1,000 short repeated terms and 1,000 long unique values reports 50% count coverage but only 9% byte coverage. The dictionary was accepted, adding sentinel ordinal overhead to every escape value while those escape bytes went to ZSTD regardless.

The fix changes coverage to `covered_bytes / column_bytes`. The same distribution reports 9%, which a 50% threshold correctly rejects.

This is also the right metric for query correctness, and the stronger justification. The dictionary's primary purpose is query acceleration: an equality filter resolves the term to an ordinal and scans the bit-packed stream as integers, bypassing ZSTD entirely. Escaped values always decompress regardless of whether a dictionary exists. Both the cost of accepting a dictionary and the fraction of read I/O it actually accelerates scale with bytes, not value count. Count-based coverage can report 50% while 95% of read I/O still goes through decompression, because it measures the denominator in the wrong unit. Byte coverage is a strict generalization: when all values have equal length the two metrics are identical, so the fix is correct in every case count-based coverage handled and correct in the cases it did not.

## Example

Consider a column with 1,000 values drawn from {"alpha", "bravo", "char.", "delta", "echo."} (5 bytes each) and 1,000 unique 50-byte values each seen once. The singletons escape the dictionary after `keepMostFrequent`.

Before the fix:

```
covered values = 1,000
total values   = 2,000
coverage       = 1,000 / 2,000 = 0.50  (passes minCoverage=0.5)

storage = ordinal stream (1,000 real ordinals + 1,000 escape sentinels)
        + ZSTD escape stream (50,000 bytes of raw escape content)
        + dictionary (25 bytes)
```

The dictionary is accepted. Each of the 1,000 long escape values pays a sentinel ordinal in addition to its 50 raw bytes in the escape stream. A query on "alpha" takes the ordinal fast path; a query on any of the 1,000 unique values still decompresses the escape stream.

After the fix:

```
covered bytes = 1,000 x 5 = 5,000
column bytes  = 1,000 x 5 + 1,000 x 50 = 55,000
coverage      = 5,000 / 55,000 ~= 0.091  (fails minCoverage=0.5)

storage = ZSTD chunks (55,000 bytes, no ordinal stream, no sentinel overhead)
```

The dictionary is rejected. The column uses the plain path.

## Changes

- `Vocabulary`: replaced `numNonNullValues` parameter in `survey` with byte-accumulated `coveredBytes` and `columnBytes`; coverage is now `coveredBytes / columnBytes`. Null slots are excluded automatically because they contribute no bytes to `columnBytes`.
- `StringColumnWriter`: removed the now-redundant `numNonNullValues` argument from the `Vocabulary.survey` call.
- `Vocabulary` (follow-up): empty strings have zero bytes, so `0 / 0 = NaN` caused `worthKeeping` to silently reject any all-empty or empty-dominant column. Fixed with `Math.max(1, length)` at both accumulation sites, keeping the metric a pure byte fraction and only affecting zero-length values.
- `DictionaryPolicy`: updated `minCoverage` param Javadoc to describe a byte share rather than a value-count share.
- `VocabularyTests`: added `testCoverageIsByteWeighted` (fails before the fix, passes after), `testCoverageNeverOverstates` (updated to a byte-based upper bound), `testCoverageWhenCoveredValuesAreLong` (opposite case: long covered values, short escapes), `testCoverageIsOneWhenAllValuesCovered`, `testEmptyStringColumnAcceptsDictionary`, and `testEmptyStringCoverageWithLongEscapes`.
- `StringColumnTests`: added `testDictionaryRejectedWhenEscapeBytesExceedCoveredBytes`, an end-to-end test that writes the regression-case distribution through `StringColumnWriter` and asserts the layout path the policy selects.

## Testing

```
./gradlew :libs:columnar:test --tests "*columnar.string*"
```
