### PR TITLE
fix(columnar): lower minCoverage threshold to 0.25

### DIFF
--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryPolicy.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/DictionaryPolicy.java
@@ -24,7 +24,7 @@ package org.elasticsearch.columnar.string;
  * for has bought nothing, however well it covers them.
  *
  * @param maxBytes         the most term bytes a dictionary may hold
- * @param minCoverage      the share of a column's values the dictionary must account for
+ * @param minCoverage      the share of a column's raw bytes the dictionary must account for
  * @param maxShareOfColumn the largest share of the column's value bytes the dictionary may occupy
  */
 public record DictionaryPolicy(int maxBytes, double minCoverage, double maxShareOfColumn) {

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnOptions.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnOptions.java
@@ -34,8 +34,13 @@ public record StringColumnOptions(DictionaryPolicy dictionary, ChunkCodec chunkC
      * <p>Half a megabyte holds the whole vocabulary of a column like host names. Beyond it the bound starts
      * admitting the tails of larger ones, where terms seen once cover almost nothing and widen the ordinal
      * every value pays for.
+     *
+     * <p>{@code minCoverage} is set to 0.25, which is 1.25x the theoretical break-even of
+     * {@code maxShareOfColumn} (0.2): at break-even the ordinal savings on covered bytes exactly offset
+     * the dictionary overhead. The margin ensures the dictionary produces a meaningful net saving rather
+     * than barely justifying itself.
      */
-    public static final DictionaryPolicy DEFAULT_DICTIONARY = new DictionaryPolicy(512 * 1024, 0.5, 0.2);
+    public static final DictionaryPolicy DEFAULT_DICTIONARY = new DictionaryPolicy(512 * 1024, 0.25, 0.2);
 
     /**
      * How much a chunk holds before it is closed on the dictionary path, when a field names nothing of its own.

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnWriter.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnWriter.java
@@ -114,10 +114,7 @@ public final class StringColumnWriter {
         Vocabulary.Terms surveyed = null;
         if (policy.enabled()) {
             // A merge that worked out the vocabulary from what its inputs recorded does not survey again.
-            // Nulls are named by a reserved ordinal, not by a term, so they are no part of what a dictionary
-            // could cover. Counting them in the denominator would cost a column its dictionary on the
-            // strength of slots no dictionary was ever going to name.
-            surveyed = known != null ? known : Vocabulary.survey(cursors.get(), policy, numValues - numNullSlots);
+            surveyed = known != null ? known : Vocabulary.survey(cursors.get(), policy);
             // Coverage is a lower bound, so a column admitted here covers at least as much as it claims.
             if (surveyed != null && policy.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes())) {
                 return withSummary(

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/Vocabulary.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/Vocabulary.java
@@ -51,7 +51,7 @@ public final class Vocabulary {
      * @param terms          the surveyed terms, addressed by id
      * @param sortedIds      the kept ids in term order, so an ordinal comparison is a term comparison
      * @param ordinalOfId    an ordinal per surveyed id, or {@link #DROPPED} for one that was not kept
-     * @param coverage       the share of the column's values these terms account for, as a lower bound
+     * @param coverage       the share of the column's raw bytes these terms account for, as a lower bound
      * @param dictionaryBytes the term bytes the kept terms occupy
      * @param columnBytes    the value bytes the whole column occupies
      * @param counts         how often each id was seen, as a lower bound, or null when unknown
@@ -113,13 +113,8 @@ public final class Vocabulary {
     /**
      * Surveys {@code values}, returning the terms worth a dictionary entry, or null when the column holds
      * nothing worth naming.
-     *
-     * @param numNonNullValues the slots a term could account for, which is every slot but the null ones. A
-     *                         null is named by a reserved ordinal rather than by a dictionary entry, so
-     *                         counting it here would hold a column's nulls against a dictionary that covers
-     *                         every value it actually has.
      */
-    public static Terms survey(StringColumnValues values, DictionaryPolicy policy, long numNonNullValues) throws IOException {
+    public static Terms survey(StringColumnValues values, DictionaryPolicy policy) throws IOException {
         final BytesRefHash terms = new BytesRefHash(new ByteBlockPool(new ByteBlockPool.DirectTrackingAllocator(Counter.newCounter())));
         int[] counts = new int[64];
         long tableBytes = 0;
@@ -193,18 +188,18 @@ public final class Vocabulary {
         // Indexed by id, so a term the survey saw but did not keep is told apart from ordinal zero.
         final int[] ordinalOfId = new int[terms.size()];
         Arrays.fill(ordinalOfId, DROPPED);
-        long covered = 0;
+        long coveredBytes = 0;
         long keptBytes = 0;
         final BytesRef scratch = new BytesRef();
         for (int ordinal = 0; ordinal < sortedIds.length; ordinal++) {
             final int id = sortedIds[ordinal];
             ordinalOfId[id] = ordinal;
-            covered += counts[id];
             terms.get(id, scratch);
+            coveredBytes += (long) counts[id] * scratch.length;
             keptBytes += scratch.length;
         }
-        final double coverage = numNonNullValues == 0 ? 0.0 : (double) covered / numNonNullValues;
-        return new Terms(terms, sortedIds, ordinalOfId, coverage, keptBytes, columnBytes, counts);
+        // NOTE: columnBytes is 0 only when there are no values, which keepMostFrequent already gates on.
+        return new Terms(terms, sortedIds, ordinalOfId, (double) coveredBytes / columnBytes, keptBytes, columnBytes, counts);
     }
 
     /**

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
@@ -281,6 +281,46 @@ public class StringColumnTests extends ColumnarStringTestCase {
         }
     }
 
+    public void testDictionaryRejectedWhenEscapeBytesExceedCoveredBytes() throws IOException {
+        final BytesRef[] docs = new BytesRef[2000];
+        final String[] frequent = { "alpha", "bravo", "char.", "delta", "echo." };
+        for (int i = 0; i < 1000; i++) {
+            docs[i] = new BytesRef(frequent[i % frequent.length]);
+        }
+        // 1000 unique 50-byte values seen once each: all escape the dictionary after keepMostFrequent.
+        for (int i = 0; i < 1000; i++) {
+            final byte[] escape = new byte[50];
+            escape[0] = (byte) (i & 0xff);
+            escape[1] = (byte) ((i >> 8) & 0xff);
+            docs[1000 + i] = new BytesRef(escape);
+        }
+        // Covered bytes = 5000, column bytes = 55000: byte coverage ~9%.
+        // A 50% byte-coverage threshold rejects the dictionary; 91% of the column would gain nothing from it.
+        withColumn(
+            docs,
+            randomValidBlockSize(),
+            ChunkCodec.ZSTD,
+            64 * 1024,
+            new DictionaryPolicy(512 * 1024, 0.5, 0.2),
+            (metadata, reader) -> {
+                plainOf(metadata);
+                assertColumnValues(docs, reader);
+            }
+        );
+        // A 5% threshold accepts the dictionary because the covered terms are present.
+        withColumn(
+            docs,
+            randomValidBlockSize(),
+            ChunkCodec.ZSTD,
+            64 * 1024,
+            new DictionaryPolicy(512 * 1024, 0.05, 0.2),
+            (metadata, reader) -> {
+                dictionaryOf(metadata);
+                assertColumnValues(docs, reader);
+            }
+        );
+    }
+
     /** Writes {@code docSlots} as a string column, reads it back, and asserts every slot round-trips in order. */
     private void assertSlots(BytesRef[][] docSlots) throws IOException {
         withColumn(docSlots, (metadata, reader) -> assertSlots(docSlots, metadata, reader));
@@ -341,5 +381,15 @@ public class StringColumnTests extends ColumnarStringTestCase {
             }
             assertEquals("documents with a value", numDocsWithField, seenDocs);
         });
+    }
+
+    private static void assertColumnValues(BytesRef[] docValues, StringColumnReader reader) throws IOException {
+        int seenDocs = 0;
+        final ColumnIterator iterator = reader.iterator();
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+            assertEquals(docValues[doc], reader.valueAt(reader.firstValueAddress(iterator.rank())));
+            seenDocs++;
+        }
+        assertEquals(numDocsWithField(docValues), seenDocs);
     }
 }

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/VocabularyTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/VocabularyTests.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
@@ -136,16 +137,85 @@ public class VocabularyTests extends ColumnarStringTestCase {
         assertEquals("coverage is kept as given", 1.0, known.coverage(), 0.0);
     }
 
+    public void testCoverageIsByteWeighted() throws IOException {
+        final List<BytesRef> values = new ArrayList<>();
+        final String[] frequent = { "alpha", "bravo", "char.", "delta", "echo." };
+        for (int i = 0; i < 1000; i++) {
+            values.add(new BytesRef(frequent[i % frequent.length]));
+        }
+        // 1000 unique 50-byte values, each seen once: all dropped by keepMostFrequent.
+        for (int i = 0; i < 1000; i++) {
+            final byte[] escape = new byte[50];
+            escape[0] = (byte) (i & 0xff);
+            escape[1] = (byte) ((i >> 8) & 0xff);
+            values.add(new BytesRef(escape));
+        }
+        // 1000 covered values × 5 bytes = 5000 covered bytes out of 55000 total (≈9%).
+        // By value count the ratio is 50%, which would pass minCoverage=0.5 and accept the dictionary
+        // even though 91% of column bytes are in the escape stream and gain nothing from it.
+        final Vocabulary.Terms surveyed = survey(values, ROOMY);
+        assertNotNull(surveyed);
+        assertEquals(5, surveyed.size());
+        assertThat("byte coverage is ~9%, not the 50% value-count ratio", surveyed.coverage(), lessThan(0.5));
+        assertFalse(ROOMY.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes()));
+    }
+
     public void testCoverageNeverOverstates() throws IOException {
         final List<BytesRef> values = zipfish();
         final Map<String, Integer> actual = tally(values);
         final Vocabulary.Terms surveyed = survey(values, ROOMY);
         assertNotNull(surveyed);
-        long truly = 0;
-        for (String term : termsOf(surveyed)) {
-            truly += actual.get(term);
+        long totalBytes = 0;
+        for (BytesRef v : values) {
+            totalBytes += v.length;
         }
-        assertThat("coverage", surveyed.coverage(), lessThanOrEqualTo((double) truly / values.size() + 1e-9));
+        long trulyBytes = 0;
+        for (String term : termsOf(surveyed)) {
+            trulyBytes += (long) actual.get(term) * term.length();
+        }
+        assertThat("coverage", surveyed.coverage(), lessThanOrEqualTo((double) trulyBytes / totalBytes + 1e-9));
+    }
+
+    /** Long covered values, short escapes: byte coverage is high even when value-count coverage is modest. */
+    public void testCoverageWhenCoveredValuesAreLong() throws IOException {
+        final List<BytesRef> values = new ArrayList<>();
+        // Five 50-byte terms, 200 occurrences each: 1000 values, 50000 covered bytes.
+        final byte[] term = new byte[50];
+        for (int t = 0; t < 5; t++) {
+            term[0] = (byte) t;
+            final BytesRef ref = new BytesRef(term.clone());
+            for (int i = 0; i < 200; i++) {
+                values.add(ref);
+            }
+        }
+        // 1000 unique 5-byte singletons: all escape after keepMostFrequent.
+        for (int i = 0; i < 1000; i++) {
+            final byte[] escape = new byte[5];
+            escape[0] = (byte) (i & 0xff);
+            escape[1] = (byte) ((i >> 8) & 0xff);
+            values.add(new BytesRef(escape));
+        }
+        // By value count: 1000/2000 = 50% — same as the regression case.
+        // By bytes: 50000/55000 ≈ 91% — the dictionary is well worth keeping.
+        final Vocabulary.Terms surveyed = survey(values, ROOMY);
+        assertNotNull(surveyed);
+        assertEquals(5, surveyed.size());
+        assertThat("byte coverage is ~91%, well above 0.5", surveyed.coverage(), lessThanOrEqualTo(1.0));
+        assertTrue(ROOMY.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes()));
+    }
+
+    /** All values in the dictionary: coverage is 1.0 and the policy accepts trivially. */
+    public void testCoverageIsOneWhenAllValuesCovered() throws IOException {
+        final List<BytesRef> values = new ArrayList<>();
+        final String[] terms = { "alpha", "bravo", "char.", "delta", "echo." };
+        for (int i = 0; i < 2000; i++) {
+            values.add(new BytesRef(terms[i % terms.length]));
+        }
+        final Vocabulary.Terms surveyed = survey(values, ROOMY);
+        assertNotNull(surveyed);
+        assertEquals(5, surveyed.size());
+        assertEquals("every byte is covered", 1.0, surveyed.coverage(), 1e-9);
+        assertTrue(ROOMY.worthKeeping(surveyed.coverage(), surveyed.dictionaryBytes(), surveyed.columnBytes()));
     }
 
     /**
@@ -207,6 +277,6 @@ public class VocabularyTests extends ColumnarStringTestCase {
     }
 
     private static Vocabulary.Terms survey(List<BytesRef> values, DictionaryPolicy policy) throws IOException {
-        return Vocabulary.survey(cursor(values.toArray(BytesRef[]::new)), policy, values.size());
+        return Vocabulary.survey(cursor(values.toArray(BytesRef[]::new)), policy);
     }
 }


### PR DESCRIPTION
## TL;DR

The `minCoverage` default of 0.5 was calibrated under count-based coverage semantics. Now that coverage is byte-based (see #159144), the right threshold is derived from the break-even between ordinal savings and dictionary overhead, which sits at `minCoverage = maxShareOfColumn = 0.2`. A value of 0.25 (1.25x the break-even) gives a meaningful margin and correctly accepts fields in the 0.25-0.5 byte coverage range that the old threshold rejected.

## Summary

The dictionary is beneficial when the ordinal savings on covered bytes outweigh the dictionary overhead. With byte-based coverage the break-even is approximately `minCoverage = maxShareOfColumn`: at that point the covered bytes (which become bit-packed ordinals) exactly offset the dictionary term bytes. Below break-even the dictionary inflates storage; above it the dictionary reduces storage by an amount proportional to how far above the break-even the coverage sits.

The old default of 0.5 was selected when `minCoverage` was a value-count ratio. Under count-based semantics 0.5 was a legible "at least half the values must be in the dictionary" rule. Under byte-based semantics it is 2.5x the theoretical break-even and rejects fields with byte coverage in the 0.25-0.5 range that would genuinely benefit from a dictionary — for example, a field with 200 distinct 28-byte pod names recurring ~40 times each alongside occasional one-off escapes has around 80% byte coverage and is accepted by both thresholds, but a field with moderate coverage and longer values may fall in the 0.25-0.5 range and be incorrectly rejected.

Setting `minCoverage = 0.25` keeps a 25% margin above the break-even, ensuring the dictionary produces a net saving under normal conditions, while opening the threshold to the intermediate coverage range where the dictionary is beneficial.

## Changes

- `StringColumnOptions`: `DEFAULT_DICTIONARY` `minCoverage` lowered from 0.5 to 0.25; Javadoc updated to explain the break-even relationship with `maxShareOfColumn`.

## Testing

```
./gradlew :libs:columnar:test --tests "*columnar.string*"
```

Stacks on #159144.