### PR TITLE
Harden partitioned test cases

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PartitionedGroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PartitionedGroupingAggregatorFunctionTestCase.java
@@ -32,6 +32,7 @@ import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 
@@ -114,11 +115,13 @@ public abstract class PartitionedGroupingAggregatorFunctionTestCase extends Grou
         return pages;
     }
 
-    record Key(long longKey, int intKey) implements Comparable<Key> {
+    record Key(Long longKey, Integer intKey) implements Comparable<Key> {
+        private static final Comparator<Key> COMPARATOR = Comparator.comparing(Key::longKey, Comparator.nullsFirst(Long::compare))
+            .thenComparing(Key::intKey, Comparator.nullsFirst(Integer::compare));
+
         @Override
         public int compareTo(Key other) {
-            int compareLong = Long.compare(longKey, other.longKey);
-            return compareLong != 0 ? compareLong : Integer.compare(intKey, other.intKey);
+            return COMPARATOR.compare(this, other);
         }
     }
 
@@ -182,7 +185,8 @@ public abstract class PartitionedGroupingAggregatorFunctionTestCase extends Grou
                 IntBlock intKeys = page.getBlock(1);
                 Block valueBlock = page.getBlock(2);
                 for (int p = 0; p < page.getPositionCount(); p++) {
-                    rows.add(new AggResult(new Key(longKeys.getLong(p), intKeys.getInt(p)), BlockUtils.toJavaObject(valueBlock, p)));
+                    Key key = new Key(longKeys.isNull(p) ? null : longKeys.getLong(p), intKeys.isNull(p) ? null : intKeys.getInt(p));
+                    rows.add(new AggResult(key, BlockUtils.toJavaObject(valueBlock, p)));
                 }
             }
             return rows.stream().sorted().toList();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/PartitionedBlockHashTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/PartitionedBlockHashTestCase.java
@@ -104,36 +104,19 @@ public abstract class PartitionedBlockHashTestCase extends ComputeTestCase {
             Block[] blocks = new Block[groups.size() + 1];
             int positionCount = between(1, 1_000);
             for (int g = 0; g < groups.size(); g++) {
-                BlockHash.GroupSpec group = groups.get(g);
+                boolean vector = randomBoolean();
                 blocks[g] = RandomBlock.randomBlock(
                     blockFactory,
-                    group.elementType(),
+                    groups.get(g).elementType(),
                     positionCount,
-                    randomBoolean(),
+                    vector == false && randomBoolean(),
                     1,
-                    between(1, 3),
-                    1,
-                    between(1, 3)
+                    vector ? 1 : between(1, 3),
+                    0,
+                    vector ? 0 : between(0, 3)
                 ).block();
-
             }
-            try (var sums = blockFactory.newIntBlockBuilder(positionCount)) {
-                for (int p = 0; p < positionCount; p++) {
-                    int valueCount = between(0, 2);
-                    if (valueCount == 0) {
-                        sums.appendNull();
-                    } else if (valueCount == 1) {
-                        sums.appendInt(randomInt());
-                    } else {
-                        sums.beginPositionEntry();
-                        for (int v = 0; v < valueCount; v++) {
-                            sums.appendInt(randomInt());
-                        }
-                        sums.endPositionEntry();
-                    }
-                }
-                blocks[groups.size()] = sums.build();
-            }
+            blocks[groups.size()] = RandomBlock.randomBlock(blockFactory, ElementType.INT, positionCount, false, 0, 2, 0, 0).block();
             pages.add(new Page(blocks));
         }
         return pages;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ParallelHashAggregationOperatorTests.java
@@ -154,7 +154,7 @@ public class ParallelHashAggregationOperatorTests extends ComputeTestCase {
         assertThat(partitioningStatus.partitionedBlocksReceived(), greaterThan(0));
     }
 
-    record Key(long longValue, int intValue) {}
+    record Key(Long longValue, Integer intValue) {}
 
     record Row(Key key, int[] sums) {}
 
@@ -167,13 +167,17 @@ public class ParallelHashAggregationOperatorTests extends ComputeTestCase {
         HashAggregationOperator.ParallelConfig parallelConfig
     ) {
         int aggregations = between(0, 4);
+        boolean nullKeys = randomBoolean();
         List<Row> inputRows = new ArrayList<>(numValues);
         for (int i = 0; i < numValues; i++) {
             int[] sums = new int[aggregations];
             for (int v = 0; v < aggregations; v++) {
                 sums[v] = randomIntBetween(0, Integer.MAX_VALUE);
             }
-            Key key = new Key(randomLongBetween(0, numValues * 2L), randomIntBetween(0, numValues * 2));
+            Key key = new Key(
+                nullKeys && randomInt(100) < 20 ? null : randomLongBetween(0, numValues * 2L),
+                nullKeys && randomInt(100) < 20 ? null : randomIntBetween(0, numValues * 2)
+            );
             inputRows.add(new Row(key, sums));
         }
         Map<Key, long[]> expected = expected(inputRows, aggregations);
@@ -218,7 +222,8 @@ public class ParallelHashAggregationOperatorTests extends ComputeTestCase {
                     for (int a = 0; a < aggregations; a++) {
                         counts[a] = ((LongBlock) page.getBlock(2 + a)).getLong(i);
                     }
-                    assertNull(actual.put(new Key(longBlock.getLong(i), intBlock.getInt(i)), counts));
+                    Key key = new Key(longBlock.isNull(i) ? null : longBlock.getLong(i), intBlock.isNull(i) ? null : intBlock.getInt(i));
+                    assertNull(actual.put(key, counts));
                 }
             }
             assertThat(actual.keySet(), equalTo(expected.keySet()));
@@ -390,8 +395,16 @@ public class ParallelHashAggregationOperatorTests extends ComputeTestCase {
                 sumBuilders.add(blockFactory.newIntBlockBuilder(rows.size()));
             }
             for (Row row : rows) {
-                longKeys.appendLong(row.key.longValue);
-                intKeys.appendInt(row.key.intValue);
+                if (row.key.longValue == null) {
+                    longKeys.appendNull();
+                } else {
+                    longKeys.appendLong(row.key.longValue);
+                }
+                if (row.key.intValue == null) {
+                    intKeys.appendNull();
+                } else {
+                    intKeys.appendInt(row.key.intValue);
+                }
                 for (int a = 0; a < sumAggregations; a++) {
                     sumBuilders.get(a).appendInt(row.sums[a]);
                 }


### PR DESCRIPTION
PartitionedBlockHashTestCase accidentally never emitted vector keys and ParallelHashAggregationOperatorTests never emitted null keys, so we are missing some coverage.

This change randomly generates both kinds of input in these tests.