### PR TITLE
Use local exchange for node-level reduction driver

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/LocalExchange.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/LocalExchange.java
@@ -13,23 +13,26 @@ import org.elasticsearch.compute.operator.IsBlockedResult;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class DirectExchange {
+/**
+ * An exchange whose sinks and sources run on the same node and share a single buffer.
+ */
+public final class LocalExchange {
     private final ExchangeBuffer buffer;
     private final AtomicInteger pendingSinks = new AtomicInteger(0);
     private final AtomicInteger pendingSources = new AtomicInteger(0);
 
-    public DirectExchange(int bufferSize) {
+    public LocalExchange(int bufferSize) {
         this.buffer = new ExchangeBuffer(bufferSize);
     }
 
     public ExchangeSource exchangeSource() {
-        return new DirectExchangeSource();
+        return new LocalExchangeSource();
     }
 
-    final class DirectExchangeSource implements ExchangeSource {
+    final class LocalExchangeSource implements ExchangeSource {
         private boolean finished = false;
 
-        DirectExchangeSource() {
+        LocalExchangeSource() {
             pendingSources.incrementAndGet();
         }
 
@@ -40,9 +43,11 @@ public final class DirectExchange {
 
         @Override
         public void finish() {
-            finished = true;
-            if (pendingSources.decrementAndGet() == 0) {
-                buffer.finish(true);
+            if (finished == false) {
+                finished = true;
+                if (pendingSources.decrementAndGet() == 0) {
+                    buffer.finish(true);
+                }
             }
         }
 
@@ -62,27 +67,32 @@ public final class DirectExchange {
         }
     }
 
-    public ExchangeSink exchangeSink() {
-        return new DirectExchangeSink();
+    public ExchangeSink exchangeSink(Runnable onPageAdded) {
+        return new LocalExchangeSink(onPageAdded);
     }
 
-    final class DirectExchangeSink implements ExchangeSink {
+    final class LocalExchangeSink implements ExchangeSink {
+        private final Runnable onPageAdded;
         private boolean finished = false;
 
-        DirectExchangeSink() {
+        LocalExchangeSink(Runnable onPageAdded) {
+            this.onPageAdded = onPageAdded;
             pendingSinks.incrementAndGet();
         }
 
         @Override
         public void addPage(Page page) {
+            onPageAdded.run();
             buffer.addPage(page);
         }
 
         @Override
         public void finish() {
-            finished = true;
-            if (pendingSinks.decrementAndGet() == 0) {
-                buffer.finish(false);
+            if (finished == false) {
+                finished = true;
+                if (pendingSinks.decrementAndGet() == 0) {
+                    buffer.finish(false);
+                }
             }
         }
 
@@ -100,5 +110,27 @@ public final class DirectExchange {
         public IsBlockedResult waitForWriting() {
             return buffer.waitForWriting();
         }
+    }
+
+    /**
+     * Stops accepting pages, optionally discarding queued pages.
+     * @param drainingPages whether to discard queued pages
+     */
+    public void finish(boolean drainingPages) {
+        buffer.finish(drainingPages);
+    }
+
+    /**
+     * Adds a listener that is notified when the exchange finishes.
+     */
+    public void addCompletionListener(ActionListener<Void> listener) {
+        buffer.addCompletionListener(listener);
+    }
+
+    /**
+     * Returns whether the exchange is finished.
+     */
+    public boolean isFinished() {
+        return buffer.isFinished();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -29,8 +29,8 @@ import org.elasticsearch.compute.operator.DriverCompletionInfo;
 import org.elasticsearch.compute.operator.PlanTimeProfile;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.compute.operator.exchange.ExchangeSink;
-import org.elasticsearch.compute.operator.exchange.ExchangeSinkHandler;
 import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
+import org.elasticsearch.compute.operator.exchange.LocalExchange;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
@@ -534,7 +534,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         private final EsqlFlags flags;
         private final DataNodeRequest request;
         private final CancellableTask parentTask;
-        private final ExchangeSinkHandler exchangeSink;
+        private final LocalExchange exchange;
         private final ComputeListener computeListener;
         private final int maxConcurrentShards;
         private final ExchangeSink blockingSink; // block until we have completed on all shards or the coordinator has enough data
@@ -548,7 +548,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             EsqlFlags flags,
             DataNodeRequest request,
             CancellableTask parentTask,
-            ExchangeSinkHandler exchangeSink,
+            LocalExchange exchange,
             int maxConcurrentShards,
             boolean failFastOnShardFailure,
             boolean singleNodeOptimizations,
@@ -559,13 +559,13 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             this.flags = flags;
             this.request = request;
             this.parentTask = parentTask;
-            this.exchangeSink = exchangeSink;
+            this.exchange = exchange;
             this.computeListener = computeListener;
             this.maxConcurrentShards = maxConcurrentShards;
             this.failFastOnShardFailure = failFastOnShardFailure;
             this.singleNodeOptimizations = singleNodeOptimizations;
             this.shardLevelFailures = shardLevelFailures;
-            this.blockingSink = exchangeSink.createExchangeSink(() -> {});
+            this.blockingSink = exchange.exchangeSink(() -> {});
             this.searchContexts = searchContexts;
             this.planTimeProfile = new PlanTimeProfile();
         }
@@ -603,7 +603,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     } else {
                         // TODO: add these to fatal failures so we can continue processing other shards.
                         try {
-                            exchangeService.finishSinkHandler(request.sessionId(), e);
+                            exchange.finish(true);
                         } finally {
                             ref.onFailure(e);
                         }
@@ -630,7 +630,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         configuration,
                         configuration.newFoldContext(),
                         null,
-                        () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet),
+                        () -> exchange.exchangeSink(pagesProduced::incrementAndGet),
                         request.retainSearchContexts(),
                         singleNodeOptimizations
                     );
@@ -719,14 +719,11 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         }
 
         private void onBatchCompleted(int lastBatchIndex) {
-            if (lastBatchIndex < request.shards().size() && exchangeSink.isFinished() == false) {
+            if (lastBatchIndex < request.shards().size() && exchange.isFinished() == false) {
                 runBatch(lastBatchIndex);
             } else {
-                // don't return until all pages are fetched
-                var completionListener = computeListener.acquireAvoid();
-                exchangeSink.addCompletionListener(
-                    ActionListener.runAfter(completionListener, () -> exchangeService.finishSinkHandler(request.sessionId(), null))
-                );
+                // don't return until the reduce driver has consumed all pages
+                exchange.addCompletionListener(computeListener.acquireAvoid());
                 blockingSink.finish();
             }
         }
@@ -760,16 +757,16 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             )
         ) {
             var parentListener = computeListener.acquireAvoid();
+            final LocalExchange internalExchange = new LocalExchange(request.pragmas().exchangeBufferSize());
             try {
                 assert request.singleNodeOptimizations() == false
                     || task.getParentTaskId().getNodeId().equals(transportService.getLocalNode().getId())
                     : "single node optimizations enabled but wrong parent task: " + task + " vs " + transportService.getLocalNode().getId();
                 // run compute with target shards
                 var externalSink = exchangeService.getSinkHandler(externalId);
-                var internalSink = exchangeService.createSinkHandler(request.sessionId(), request.pragmas().exchangeBufferSize());
                 task.addListener(() -> {
                     exchangeService.finishSinkHandler(externalId, new TaskCancelledException(task.getReasonCancelled()));
-                    exchangeService.finishSinkHandler(request.sessionId(), new TaskCancelledException(task.getReasonCancelled()));
+                    internalExchange.finish(true);
                 });
                 EsqlFlags flags = computeService.createFlags();
                 int maxConcurrentShards = request.pragmas().maxConcurrentShardsPerNode();
@@ -777,7 +774,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     flags,
                     request,
                     task,
-                    internalSink,
+                    internalExchange,
                     maxConcurrentShards,
                     failFastOnShardFailure,
                     request.singleNodeOptimizations(),
@@ -787,8 +784,6 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 );
                 dataNodeRequestExecutor.start();
                 // run the node-level reduction
-                var exchangeSource = new ExchangeSourceHandler(1, searchExecutor);
-                exchangeSource.addRemoteSink(internalSink::fetchPageAsync, true, () -> {}, 1, ActionListener.noop());
                 var reductionListener = computeListener.acquireCompute();
                 computeService.runCompute(
                     task,
@@ -800,7 +795,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         searchContexts.globalView(),
                         request.configuration(),
                         new FoldContext(request.pragmas().foldLimit().getBytes()),
-                        exchangeSource::createExchangeSource,
+                        internalExchange::exchangeSource,
                         () -> externalSink.createExchangeSink(() -> {}),
                         request.retainSearchContexts(),
                         request.singleNodeOptimizations()
@@ -826,7 +821,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 parentListener.onResponse(null);
             } catch (Exception e) {
                 exchangeService.finishSinkHandler(externalId, e);
-                exchangeService.finishSinkHandler(request.sessionId(), e);
+                internalExchange.finish(true);
                 parentListener.onFailure(e);
             }
         }


### PR DESCRIPTION
The node-level reduction driver and the data-node drivers run on the same node, but they were wired together through ExchangeSinkHandler and ExchangeSourceHandler as if they were remote. The local transport connection already avoids the network, but two overheads remain:

1. Two buffers: the sink handler and the source handler each own an ExchangeBuffer, so every page is queued twice.

2. fetchPageAsync round trips: the source handler polls the sink via fetchPageAsync, which schedules a runnable on the fetch executor and goes through listener callbacks for every page.

Replace this with LocalExchange, where sinks and sources share a single buffer and sources read pages directly. LocalExchange does not carry failures. It does not need to here: both ends share one task and one ComputeListener, so any failure are notified to the same listener.

Both overheads are small, but so is this change.